### PR TITLE
Make request timeout configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ val query = "http language:scala"
 // `sort` is removed, as the value is not defined
 val request = sttp.get(uri"https://api.github.com/search/repositories?q=$query&sort=$sort")
   
-implicit val handler = HttpURLConnectionHandler
+implicit val handler = HttpURLConnectionHandler()
 val response = request.send()
 
 // response.header(...): Option[String]
@@ -61,7 +61,7 @@ experimenting with sttp by copy-pasting the following:
 ```scala
 import $ivy.`com.softwaremill.sttp::core:0.0.11`
 import com.softwaremill.sttp._
-implicit val handler = HttpURLConnectionHandler
+implicit val handler = HttpURLConnectionHandler()
 sttp.get(uri"http://httpbin.org/ip").send()
 ```
 
@@ -113,7 +113,7 @@ value of type `SttpHandler` needs to be in scope to invoke the `send()` on the
 request: 
 
 ```scala
-implicit val handler = HttpURLConnectionHandler
+implicit val handler = HttpURLConnectionHandler()
 
 val response: Response[String] = request.send()
 ```
@@ -214,7 +214,7 @@ in the identity type constructor, which is equivalent to no wrapper at all.
 To use, add an implicit value:
 
 ```scala
-implicit val sttpHandler = HttpURLConnectionHandler
+implicit val sttpHandler = HttpURLConnectionHandler()
 ```
 
 ### `AkkaHttpHandler`
@@ -409,7 +409,7 @@ a request to decode the response to a specific object.
 import com.softwaremill.sttp._
 import com.softwaremill.sttp.circe._
 
-implicit val handler = HttpURLConnectionHandler
+implicit val handler = HttpURLConnectionHandler()
 
 // Assume that there is an implicit circe encoder in scope
 // for the request Payload, and a decoder for the Response
@@ -454,6 +454,26 @@ There are two type aliases for the request template that are used:
 * `type Request[T, S] = RequestT[Id, T, S]`. A sendable request.
 * `type PartialRequest[T, S] = RequestT[Empty, T, S]`
 
+## Timeouts
+
+Sttp supports read and connection timeouts: 
+ * Connection timeout - can be set globally (30 seconds by default)
+ * Read timeout - can be set per request (1 minute by default)
+
+How to use:
+```scala
+import com.softwaremill.sttp._
+import scala.concurrent.duration._
+
+// all backends provide a constructor that allows users to specify connection timeout
+implicit val handler = HttpURLConnectionHandler(connectionTimeout = 1.minute)
+
+sttp
+  .get(uri"...")
+  .readTimeout(5.minutes) // or Duration.Inf to turn read timeout off
+  .send()
+```
+
 ## Notes
 
 * the encoding for `String`s defaults to `utf-8`.
@@ -486,3 +506,4 @@ and pick a task you'd like to work on!
 * [Omar Alejandro Mainegra Sarduy](https://github.com/omainegra)
 * [Bjørn Madsen](https://github.com/aeons)
 * [Piotr Buda](https://github.com/pbuda)
+* [Piotr Gabara](https://github.com/bhop)

--- a/akka-http-handler/src/main/scala/com/softwaremill/sttp/akkahttp/AkkaHttpHandler.scala
+++ b/akka-http-handler/src/main/scala/com/softwaremill/sttp/akkahttp/AkkaHttpHandler.scala
@@ -13,18 +13,22 @@ import akka.http.scaladsl.model.headers.{
   `Content-Type`
 }
 import akka.http.scaladsl.model.{Multipart => AkkaMultipart, _}
+import akka.http.scaladsl.settings.ClientConnectionSettings
+import akka.http.scaladsl.settings.ConnectionPoolSettings
 import akka.stream.ActorMaterializer
 import akka.stream.scaladsl.{FileIO, Source, StreamConverters}
 import akka.util.ByteString
 import com.softwaremill.sttp._
 
 import scala.collection.immutable.Seq
+import scala.concurrent.duration.FiniteDuration
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Success, Try}
 
 class AkkaHttpHandler private (actorSystem: ActorSystem,
                                ec: ExecutionContext,
-                               terminateActorSystemOnClose: Boolean)
+                               terminateActorSystemOnClose: Boolean,
+                               connectionTimeout: FiniteDuration)
     extends SttpHandler[Future, Source[ByteString, Any]] {
 
   // the supported stream type
@@ -35,10 +39,19 @@ class AkkaHttpHandler private (actorSystem: ActorSystem,
 
   override def send[T](r: Request[T, S]): Future[Response[T]] = {
     implicit val ec: ExecutionContext = this.ec
+
+    val connectionSettings = ClientConnectionSettings(actorSystem)
+      .withIdleTimeout(r.readTimeout)
+      .withConnectingTimeout(connectionTimeout)
+
+    val connectionPoolSettings = ConnectionPoolSettings(actorSystem)
+      .withConnectionSettings(connectionSettings)
+
     requestToAkka(r)
       .flatMap(setBodyOnAkka(r, r.body, _))
       .toFuture
-      .flatMap(Http().singleRequest(_))
+      .flatMap(req =>
+        Http().singleRequest(req, settings = connectionPoolSettings))
       .flatMap { hr =>
         val code = hr.status.intValue()
 
@@ -271,19 +284,26 @@ object AkkaHttpHandler {
 
   private def apply(actorSystem: ActorSystem,
                     ec: ExecutionContext,
-                    terminateActorSystemOnClose: Boolean)
-    : SttpHandler[Future, Source[ByteString, Any]] =
+                    terminateActorSystemOnClose: Boolean,
+                    connectionTimeout: FiniteDuration): SttpHandler[Future, Source[ByteString, Any]] =
     new FollowRedirectsHandler(
-      new AkkaHttpHandler(actorSystem, ec, terminateActorSystemOnClose))
+      new AkkaHttpHandler(actorSystem,
+                          ec,
+                          terminateActorSystemOnClose,
+                          connectionTimeout))
 
   /**
     * @param ec The execution context for running non-network related operations,
     *           e.g. mapping responses. Defaults to the global execution
     *           context.
     */
-  def apply()(implicit ec: ExecutionContext = ExecutionContext.Implicits.global)
+  def apply(connectionTimeout: FiniteDuration = SttpHandler.DefaultConnectionTimeout)(
+      implicit ec: ExecutionContext = ExecutionContext.Implicits.global)
     : SttpHandler[Future, Source[ByteString, Any]] =
-    AkkaHttpHandler(ActorSystem("sttp"), ec, terminateActorSystemOnClose = true)
+    AkkaHttpHandler(ActorSystem("sttp"),
+                    ec,
+                    terminateActorSystemOnClose = true,
+                    connectionTimeout)
 
   /**
     * @param actorSystem The actor system which will be used for the http-client
@@ -292,8 +312,12 @@ object AkkaHttpHandler {
     *           e.g. mapping responses. Defaults to the global execution
     *           context.
     */
-  def usingActorSystem(actorSystem: ActorSystem)(
+  def usingActorSystem(actorSystem: ActorSystem,
+                       connectionTimeout: FiniteDuration = SttpHandler.DefaultConnectionTimeout)(
       implicit ec: ExecutionContext = ExecutionContext.Implicits.global)
     : SttpHandler[Future, Source[ByteString, Any]] =
-    AkkaHttpHandler(actorSystem, ec, terminateActorSystemOnClose = false)
+    AkkaHttpHandler(actorSystem,
+                    ec,
+                    terminateActorSystemOnClose = false,
+                    connectionTimeout)
 }

--- a/async-http-client-handler/cats/src/main/scala/com/softwaremill/sttp/asynchttpclient/cats/AsyncHttpClientCatsHandler.scala
+++ b/async-http-client-handler/cats/src/main/scala/com/softwaremill/sttp/asynchttpclient/cats/AsyncHttpClientCatsHandler.scala
@@ -50,8 +50,7 @@ object AsyncHttpClientCatsHandler {
   def apply[F[_]: Async](connectionTimeout: FiniteDuration = SttpHandler.DefaultConnectionTimeout)
     : SttpHandler[F, Nothing] =
     AsyncHttpClientCatsHandler(
-      new DefaultAsyncHttpClient(
-        AsyncHttpClientHandler.withConnectionTimeout(connectionTimeout)),
+      AsyncHttpClientHandler.defaultClient(connectionTimeout.toMillis.toInt),
       closeClient = true)
 
   def usingConfig[F[_]: Async](

--- a/async-http-client-handler/cats/src/main/scala/com/softwaremill/sttp/asynchttpclient/cats/AsyncHttpClientCatsHandler.scala
+++ b/async-http-client-handler/cats/src/main/scala/com/softwaremill/sttp/asynchttpclient/cats/AsyncHttpClientCatsHandler.scala
@@ -16,6 +16,7 @@ import org.asynchttpclient.{
 }
 import org.reactivestreams.Publisher
 
+import scala.concurrent.duration.FiniteDuration
 import scala.language.higherKinds
 
 class AsyncHttpClientCatsHandler[F[_]: Async] private (
@@ -46,8 +47,12 @@ object AsyncHttpClientCatsHandler {
     new FollowRedirectsHandler[F, Nothing](
       new AsyncHttpClientCatsHandler(asyncHttpClient, closeClient))
 
-  def apply[F[_]: Async](): SttpHandler[F, Nothing] =
-    AsyncHttpClientCatsHandler(new DefaultAsyncHttpClient(), closeClient = true)
+  def apply[F[_]: Async](connectionTimeout: FiniteDuration = SttpHandler.DefaultConnectionTimeout)
+    : SttpHandler[F, Nothing] =
+    AsyncHttpClientCatsHandler(
+      new DefaultAsyncHttpClient(
+        AsyncHttpClientHandler.withConnectionTimeout(connectionTimeout)),
+      closeClient = true)
 
   def usingConfig[F[_]: Async](
       cfg: AsyncHttpClientConfig): SttpHandler[F, Nothing] =

--- a/async-http-client-handler/fs2/src/main/scala/com/softwaremill/sttp/asynchttpclient/fs2/AsyncHttpClientFs2Handler.scala
+++ b/async-http-client-handler/fs2/src/main/scala/com/softwaremill/sttp/asynchttpclient/fs2/AsyncHttpClientFs2Handler.scala
@@ -68,8 +68,7 @@ object AsyncHttpClientFs2Handler {
       implicit ec: ExecutionContext = ExecutionContext.Implicits.global)
     : SttpHandler[F, Stream[F, ByteBuffer]] =
     AsyncHttpClientFs2Handler[F](
-      new DefaultAsyncHttpClient(
-        AsyncHttpClientHandler.withConnectionTimeout(connectionTimeout)),
+      AsyncHttpClientHandler.defaultClient(connectionTimeout.toMillis.toInt),
       closeClient = true)
 
   /**

--- a/async-http-client-handler/fs2/src/main/scala/com/softwaremill/sttp/asynchttpclient/fs2/AsyncHttpClientFs2Handler.scala
+++ b/async-http-client-handler/fs2/src/main/scala/com/softwaremill/sttp/asynchttpclient/fs2/AsyncHttpClientFs2Handler.scala
@@ -21,6 +21,7 @@ import org.asynchttpclient.{
 import org.reactivestreams.Publisher
 
 import scala.concurrent.ExecutionContext
+import scala.concurrent.duration.FiniteDuration
 import scala.language.higherKinds
 
 class AsyncHttpClientFs2Handler[F[_]: Effect] private (
@@ -63,11 +64,13 @@ object AsyncHttpClientFs2Handler {
     *           e.g. mapping responses. Defaults to the global execution
     *           context.
     */
-  def apply[F[_]: Effect]()(
+  def apply[F[_]: Effect](connectionTimeout: FiniteDuration = SttpHandler.DefaultConnectionTimeout)(
       implicit ec: ExecutionContext = ExecutionContext.Implicits.global)
     : SttpHandler[F, Stream[F, ByteBuffer]] =
-    AsyncHttpClientFs2Handler[F](new DefaultAsyncHttpClient(),
-                                 closeClient = true)
+    AsyncHttpClientFs2Handler[F](
+      new DefaultAsyncHttpClient(
+        AsyncHttpClientHandler.withConnectionTimeout(connectionTimeout)),
+      closeClient = true)
 
   /**
     * @param ec The execution context for running non-network related operations,

--- a/async-http-client-handler/future/src/main/scala/com/softwaremill/sttp/asynchttpclient/future/AsyncHttpClientFutureHandler.scala
+++ b/async-http-client-handler/future/src/main/scala/com/softwaremill/sttp/asynchttpclient/future/AsyncHttpClientFutureHandler.scala
@@ -49,8 +49,7 @@ object AsyncHttpClientFutureHandler {
       implicit ec: ExecutionContext = ExecutionContext.Implicits.global)
     : SttpHandler[Future, Nothing] =
     AsyncHttpClientFutureHandler(
-      new DefaultAsyncHttpClient(
-        AsyncHttpClientHandler.withConnectionTimeout(connectionTimeout)),
+      AsyncHttpClientHandler.defaultClient(connectionTimeout.toMillis.toInt),
       closeClient = true)
 
   /**

--- a/async-http-client-handler/future/src/main/scala/com/softwaremill/sttp/asynchttpclient/future/AsyncHttpClientFutureHandler.scala
+++ b/async-http-client-handler/future/src/main/scala/com/softwaremill/sttp/asynchttpclient/future/AsyncHttpClientFutureHandler.scala
@@ -11,6 +11,7 @@ import org.asynchttpclient.{
 }
 import org.reactivestreams.Publisher
 
+import scala.concurrent.duration.FiniteDuration
 import scala.concurrent.{ExecutionContext, Future}
 
 class AsyncHttpClientFutureHandler private (
@@ -44,10 +45,13 @@ object AsyncHttpClientFutureHandler {
     *           e.g. mapping responses. Defaults to the global execution
     *           context.
     */
-  def apply()(implicit ec: ExecutionContext = ExecutionContext.Implicits.global)
+  def apply(connectionTimeout: FiniteDuration = SttpHandler.DefaultConnectionTimeout)(
+      implicit ec: ExecutionContext = ExecutionContext.Implicits.global)
     : SttpHandler[Future, Nothing] =
-    AsyncHttpClientFutureHandler(new DefaultAsyncHttpClient(),
-                                 closeClient = true)
+    AsyncHttpClientFutureHandler(
+      new DefaultAsyncHttpClient(
+        AsyncHttpClientHandler.withConnectionTimeout(connectionTimeout)),
+      closeClient = true)
 
   /**
     * @param ec The execution context for running non-network related operations,

--- a/async-http-client-handler/monix/src/main/scala/com/softwaremill/sttp/asynchttpclient/monix/AsyncHttpClientMonixHandler.scala
+++ b/async-http-client-handler/monix/src/main/scala/com/softwaremill/sttp/asynchttpclient/monix/AsyncHttpClientMonixHandler.scala
@@ -66,8 +66,7 @@ object AsyncHttpClientMonixHandler {
       implicit s: Scheduler = Scheduler.Implicits.global)
     : SttpHandler[Task, Observable[ByteBuffer]] =
     AsyncHttpClientMonixHandler(
-      new DefaultAsyncHttpClient(
-        AsyncHttpClientHandler.withConnectionTimeout(connectionTimeout)),
+      AsyncHttpClientHandler.defaultClient(connectionTimeout.toMillis.toInt),
       closeClient = true)
 
   /**

--- a/async-http-client-handler/monix/src/main/scala/com/softwaremill/sttp/asynchttpclient/monix/AsyncHttpClientMonixHandler.scala
+++ b/async-http-client-handler/monix/src/main/scala/com/softwaremill/sttp/asynchttpclient/monix/AsyncHttpClientMonixHandler.scala
@@ -20,6 +20,7 @@ import org.asynchttpclient.{
 }
 import org.reactivestreams.Publisher
 
+import scala.concurrent.duration.FiniteDuration
 import scala.util.{Failure, Success}
 
 class AsyncHttpClientMonixHandler private (
@@ -61,10 +62,13 @@ object AsyncHttpClientMonixHandler {
     * @param s The scheduler used for streaming request bodies. Defaults to the
     *          global scheduler.
     */
-  def apply()(implicit s: Scheduler = Scheduler.Implicits.global)
+  def apply(connectionTimeout: FiniteDuration = SttpHandler.DefaultConnectionTimeout)(
+      implicit s: Scheduler = Scheduler.Implicits.global)
     : SttpHandler[Task, Observable[ByteBuffer]] =
-    AsyncHttpClientMonixHandler(new DefaultAsyncHttpClient(),
-                                closeClient = true)
+    AsyncHttpClientMonixHandler(
+      new DefaultAsyncHttpClient(
+        AsyncHttpClientHandler.withConnectionTimeout(connectionTimeout)),
+      closeClient = true)
 
   /**
     * @param s The scheduler used for streaming request bodies. Defaults to the

--- a/async-http-client-handler/scalaz/src/main/scala/com/softwaremill/sttp/asynchttpclient/scalaz/AsyncHttpClientScalazHandler.scala
+++ b/async-http-client-handler/scalaz/src/main/scala/com/softwaremill/sttp/asynchttpclient/scalaz/AsyncHttpClientScalazHandler.scala
@@ -15,6 +15,7 @@ import org.asynchttpclient.{
 }
 import org.reactivestreams.Publisher
 
+import scala.concurrent.duration.FiniteDuration
 import scalaz.{-\/, \/-}
 import scalaz.concurrent.Task
 
@@ -42,12 +43,17 @@ object AsyncHttpClientScalazHandler {
     new FollowRedirectsHandler[Task, Nothing](
       new AsyncHttpClientScalazHandler(asyncHttpClient, closeClient))
 
-  def apply(): SttpHandler[Task, Nothing] =
-    AsyncHttpClientScalazHandler(new DefaultAsyncHttpClient(),
-                                 closeClient = true)
+  def apply(connectionTimeout: FiniteDuration = SttpHandler.DefaultConnectionTimeout)
+    : SttpHandler[Task, Nothing] =
+    AsyncHttpClientScalazHandler(
+      new DefaultAsyncHttpClient(
+        AsyncHttpClientHandler.withConnectionTimeout(connectionTimeout)),
+      closeClient = true)
+
   def usingConfig(cfg: AsyncHttpClientConfig): SttpHandler[Task, Nothing] =
     AsyncHttpClientScalazHandler(new DefaultAsyncHttpClient(cfg),
                                  closeClient = true)
+
   def usingClient(client: AsyncHttpClient): SttpHandler[Task, Nothing] =
     AsyncHttpClientScalazHandler(client, closeClient = false)
 }

--- a/async-http-client-handler/scalaz/src/main/scala/com/softwaremill/sttp/asynchttpclient/scalaz/AsyncHttpClientScalazHandler.scala
+++ b/async-http-client-handler/scalaz/src/main/scala/com/softwaremill/sttp/asynchttpclient/scalaz/AsyncHttpClientScalazHandler.scala
@@ -46,8 +46,7 @@ object AsyncHttpClientScalazHandler {
   def apply(connectionTimeout: FiniteDuration = SttpHandler.DefaultConnectionTimeout)
     : SttpHandler[Task, Nothing] =
     AsyncHttpClientScalazHandler(
-      new DefaultAsyncHttpClient(
-        AsyncHttpClientHandler.withConnectionTimeout(connectionTimeout)),
+      AsyncHttpClientHandler.defaultClient(connectionTimeout.toMillis.toInt),
       closeClient = true)
 
   def usingConfig(cfg: AsyncHttpClientConfig): SttpHandler[Task, Nothing] =

--- a/core/src/main/scala/com/softwaremill/sttp/HttpURLConnectionHandler.scala
+++ b/core/src/main/scala/com/softwaremill/sttp/HttpURLConnectionHandler.scala
@@ -21,7 +21,7 @@ class HttpURLConnectionHandler private (connectionTimeout: FiniteDuration)
     c.setRequestMethod(r.method.m)
     r.headers.foreach { case (k, v) => c.setRequestProperty(k, v) }
     c.setDoInput(true)
-    c.setReadTimeout(timeout(r.readTimeout))
+    c.setReadTimeout(timeout(r.options.readTimeout))
     c.setConnectTimeout(timeout(connectionTimeout))
 
     // redirects are handled in SttpHandler

--- a/core/src/main/scala/com/softwaremill/sttp/HttpURLConnectionHandler.scala
+++ b/core/src/main/scala/com/softwaremill/sttp/HttpURLConnectionHandler.scala
@@ -11,14 +11,18 @@ import java.util.zip.{GZIPInputStream, InflaterInputStream}
 import scala.annotation.tailrec
 import scala.io.Source
 import scala.collection.JavaConverters._
+import scala.concurrent.duration.{Duration, FiniteDuration}
 
-class HttpURLConnectionHandler extends SttpHandler[Id, Nothing] {
+class HttpURLConnectionHandler private (connectionTimeout: FiniteDuration)
+    extends SttpHandler[Id, Nothing] {
   override def send[T](r: Request[T, Nothing]): Response[T] = {
     val c =
       new URL(r.uri.toString).openConnection().asInstanceOf[HttpURLConnection]
     c.setRequestMethod(r.method.m)
     r.headers.foreach { case (k, v) => c.setRequestProperty(k, v) }
     c.setDoInput(true)
+    c.setReadTimeout(timeout(r.readTimeout))
+    c.setConnectTimeout(timeout(connectionTimeout))
 
     // redirects are handled in SttpHandler
     c.setInstanceFollowRedirects(false)
@@ -67,6 +71,10 @@ class HttpURLConnectionHandler extends SttpHandler[Id, Nothing] {
         setMultipartBody(mp, c)
     }
   }
+
+  private def timeout(t: Duration): Int =
+    if (t.isFinite()) t.toMillis.toInt
+    else 0
 
   private def writeBasicBody(body: BasicRequestBody, os: OutputStream): Unit = {
     body match {
@@ -246,4 +254,12 @@ class HttpURLConnectionHandler extends SttpHandler[Id, Nothing] {
     }
 
   override def close(): Unit = {}
+}
+
+object HttpURLConnectionHandler {
+
+  def apply(connectionTimeout: FiniteDuration = SttpHandler.DefaultConnectionTimeout)
+    : SttpHandler[Id, Nothing] =
+    new FollowRedirectsHandler[Id, Nothing](
+      new HttpURLConnectionHandler(connectionTimeout))
 }

--- a/core/src/main/scala/com/softwaremill/sttp/RequestT.scala
+++ b/core/src/main/scala/com/softwaremill/sttp/RequestT.scala
@@ -6,7 +6,7 @@ import java.nio.file.Path
 import java.util.Base64
 
 import scala.collection.immutable.Seq
-
+import scala.concurrent.duration.Duration
 import scala.language.higherKinds
 
 /**
@@ -34,6 +34,7 @@ case class RequestT[U[_], T, +S](
     body: RequestBody[S],
     headers: Seq[(String, String)],
     response: ResponseAs[T, S],
+    readTimeout: Duration,
     options: RequestOptions,
     tags: Map[String, Any]
 ) {
@@ -215,6 +216,9 @@ case class RequestT[U[_], T, +S](
 
   def streamBody[S2 >: S](b: S2): RequestT[U, T, S2] =
     copy[U, T, S2](body = StreamBody(b))
+
+  def readTimeout(t: Duration): RequestT[U, T, S] =
+    copy(readTimeout = t)
 
   def response[T2, S2 >: S](ra: ResponseAs[T2, S2]): RequestT[U, T2, S2] =
     this.copy(response = ra)

--- a/core/src/main/scala/com/softwaremill/sttp/RequestT.scala
+++ b/core/src/main/scala/com/softwaremill/sttp/RequestT.scala
@@ -34,7 +34,6 @@ case class RequestT[U[_], T, +S](
     body: RequestBody[S],
     headers: Seq[(String, String)],
     response: ResponseAs[T, S],
-    readTimeout: Duration,
     options: RequestOptions,
     tags: Map[String, Any]
 ) {
@@ -218,7 +217,7 @@ case class RequestT[U[_], T, +S](
     copy[U, T, S2](body = StreamBody(b))
 
   def readTimeout(t: Duration): RequestT[U, T, S] =
-    copy(readTimeout = t)
+    this.copy(options = options.copy(readTimeout = t))
 
   def response[T2, S2 >: S](ra: ResponseAs[T2, S2]): RequestT[U, T2, S2] =
     this.copy(response = ra)
@@ -280,4 +279,4 @@ class SpecifyAuthScheme[U[_], T, +S](hn: String, rt: RequestT[U, T, S]) {
     rt.header(hn, s"Bearer $token")
 }
 
-case class RequestOptions(followRedirects: Boolean)
+case class RequestOptions(followRedirects: Boolean, readTimeout: Duration)

--- a/core/src/main/scala/com/softwaremill/sttp/SttpHandler.scala
+++ b/core/src/main/scala/com/softwaremill/sttp/SttpHandler.scala
@@ -1,6 +1,7 @@
 package com.softwaremill.sttp
 
 import scala.language.higherKinds
+import scala.concurrent.duration._
 
 /**
   * @tparam R The type constructor in which responses are wrapped. E.g. `Id`
@@ -18,4 +19,8 @@ trait SttpHandler[R[_], -S] {
     * handlers, which map/flatMap over the return value of [[send]].
     */
   def responseMonad: MonadError[R]
+}
+
+object SttpHandler {
+  private[sttp] val DefaultConnectionTimeout = 30.seconds
 }

--- a/core/src/main/scala/com/softwaremill/sttp/package.scala
+++ b/core/src/main/scala/com/softwaremill/sttp/package.scala
@@ -58,14 +58,14 @@ package object sttp {
     * An empty request with no headers.
     */
   val emptyRequest: RequestT[Empty, String, Nothing] =
-    RequestT[Empty, String, Nothing](None,
-                                     None,
-                                     NoBody,
-                                     Vector(),
-                                     asString,
-                                     DefaultReadTimeout,
-                                     RequestOptions(followRedirects = true),
-                                     Map())
+    RequestT[Empty, String, Nothing](
+      None,
+      None,
+      NoBody,
+      Vector(),
+      asString,
+      RequestOptions(followRedirects = true, readTimeout = DefaultReadTimeout),
+      Map())
 
   /**
     * A starting request, with the following modifications comparing to

--- a/core/src/main/scala/com/softwaremill/sttp/package.scala
+++ b/core/src/main/scala/com/softwaremill/sttp/package.scala
@@ -7,6 +7,7 @@ import java.nio.file.Path
 import scala.annotation.{implicitNotFound, tailrec}
 import scala.language.higherKinds
 import scala.collection.immutable.Seq
+import scala.concurrent.duration._
 
 package object sttp {
   type Id[X] = X
@@ -25,6 +26,8 @@ package object sttp {
     * Handlers might also provide special logic for serializer instances which they define (e.g. to handle streaming).
     */
   type BodySerializer[B] = B => BasicRequestBody
+
+  val DefaultReadTimeout: Duration = 1.minute
 
   // constants
 
@@ -60,6 +63,7 @@ package object sttp {
                                      NoBody,
                                      Vector(),
                                      asString,
+                                     DefaultReadTimeout,
                                      RequestOptions(followRedirects = true),
                                      Map())
 
@@ -266,9 +270,4 @@ package object sttp {
   implicit class UriContext(val sc: StringContext) extends AnyVal {
     def uri(args: Any*): Uri = UriInterpolator.interpolate(sc, args: _*)
   }
-
-  // default handler
-
-  val HttpURLConnectionHandler: SttpHandler[Id, Nothing] =
-    new FollowRedirectsHandler[Id, Nothing](new HttpURLConnectionHandler())
 }

--- a/core/src/test/scala/com/softwaremill/sttp/RequestTests.scala
+++ b/core/src/test/scala/com/softwaremill/sttp/RequestTests.scala
@@ -66,4 +66,8 @@ class RequestTests extends FlatSpec with Matchers {
       .find(_._1.equalsIgnoreCase(ContentLengthHeader))
       .map(_._2) should be(Some("10"))
   }
+
+  "request timeout" should "use default if not overridden" in {
+    sttp.readTimeout should be(DefaultReadTimeout)
+  }
 }

--- a/core/src/test/scala/com/softwaremill/sttp/RequestTests.scala
+++ b/core/src/test/scala/com/softwaremill/sttp/RequestTests.scala
@@ -68,6 +68,6 @@ class RequestTests extends FlatSpec with Matchers {
   }
 
   "request timeout" should "use default if not overridden" in {
-    sttp.readTimeout should be(DefaultReadTimeout)
+    sttp.options.readTimeout should be(DefaultReadTimeout)
   }
 }

--- a/okhttp-handler/monix/src/main/scala/com/softwaremill/sttp/okhttp/monix/OkHttpMonixHandler.scala
+++ b/okhttp-handler/monix/src/main/scala/com/softwaremill/sttp/okhttp/monix/OkHttpMonixHandler.scala
@@ -1,7 +1,7 @@
 package com.softwaremill.sttp.okhttp.monix
 
 import java.nio.ByteBuffer
-import java.util.concurrent.{ArrayBlockingQueue, TimeUnit}
+import java.util.concurrent.ArrayBlockingQueue
 
 import com.softwaremill.sttp.{SttpHandler, _}
 import com.softwaremill.sttp.okhttp.{OkHttpAsyncHandler, OkHttpHandler}
@@ -89,13 +89,8 @@ object OkHttpMonixHandler {
       implicit s: Scheduler = Scheduler.Implicits.global)
     : SttpHandler[Task, Observable[ByteBuffer]] =
     OkHttpMonixHandler(
-      OkHttpHandler
-        .defaultBuilder()
-        .connectTimeout(connectionTimeout.toMillis, TimeUnit.MILLISECONDS)
-        .readTimeout(SttpHandler.DefaultConnectionTimeout.toMillis, TimeUnit.MILLISECONDS)
-        .build(),
-      closeClient = true
-    )(s)
+      OkHttpHandler.defaultClient(DefaultReadTimeout.toMillis, connectionTimeout.toMillis),
+      closeClient = true)(s)
 
   def usingClient(client: OkHttpClient)(implicit s: Scheduler =
                                           Scheduler.Implicits.global)

--- a/okhttp-handler/src/main/scala/com/softwaremill/sttp/okhttp/OkHttpClientHandler.scala
+++ b/okhttp-handler/src/main/scala/com/softwaremill/sttp/okhttp/OkHttpClientHandler.scala
@@ -2,6 +2,7 @@ package com.softwaremill.sttp.okhttp
 
 import java.io.IOException
 import java.nio.charset.Charset
+import java.util.concurrent.TimeUnit
 
 import com.softwaremill.sttp._
 import ResponseAs.EagerResponseHandler
@@ -20,6 +21,7 @@ import okhttp3.{
 import okio.{BufferedSink, Okio}
 
 import scala.collection.JavaConverters._
+import scala.concurrent.duration.FiniteDuration
 import scala.concurrent.{ExecutionContext, Future}
 import scala.language.higherKinds
 import scala.util.{Failure, Try}
@@ -142,18 +144,34 @@ abstract class OkHttpHandler[R[_], S](client: OkHttpClient,
 }
 
 object OkHttpHandler {
-  def buildClientNoRedirects(): OkHttpClient =
+  def defaultBuilder(): OkHttpClient.Builder =
     new OkHttpClient.Builder()
       .followRedirects(false)
       .followSslRedirects(false)
-      .build()
+
+  def updateClientIfCustomReadTimeout[T, S](
+      r: Request[T, S],
+      client: OkHttpClient): OkHttpClient = {
+    if (r.readTimeout == SttpHandler.DefaultConnectionTimeout) client
+    else
+      client
+        .newBuilder()
+        .readTimeout(if (r.readTimeout.isFinite()) r.readTimeout.toMillis
+                     else 0,
+                     TimeUnit.MILLISECONDS)
+        .build()
+
+  }
 }
 
 class OkHttpSyncHandler private (client: OkHttpClient, closeClient: Boolean)
     extends OkHttpHandler[Id, Nothing](client, closeClient) {
   override def send[T](r: Request[T, Nothing]): Response[T] = {
     val request = convertRequest(r)
-    val response = client.newCall(request).execute()
+    val response = OkHttpHandler
+      .updateClientIfCustomReadTimeout(r, client)
+      .newCall(request)
+      .execute()
     readResponse(response, r.response)
   }
 
@@ -166,9 +184,15 @@ object OkHttpSyncHandler {
     new FollowRedirectsHandler[Id, Nothing](
       new OkHttpSyncHandler(client, closeClient))
 
-  def apply(): SttpHandler[Id, Nothing] =
-    OkHttpSyncHandler(OkHttpHandler.buildClientNoRedirects(),
-                      closeClient = true)
+  def apply(
+      connectionTimeout: FiniteDuration = SttpHandler.DefaultConnectionTimeout)
+    : SttpHandler[Id, Nothing] =
+    OkHttpSyncHandler(
+      OkHttpHandler
+        .defaultBuilder()
+        .connectTimeout(connectionTimeout.toMillis, TimeUnit.MILLISECONDS)
+        .build(),
+      closeClient = true)
 
   def usingClient(client: OkHttpClient): SttpHandler[Id, Nothing] =
     OkHttpSyncHandler(client, closeClient = false)
@@ -185,7 +209,8 @@ abstract class OkHttpAsyncHandler[R[_], S](client: OkHttpClient,
       def success(r: R[Response[T]]) = cb(Right(r))
       def error(t: Throwable) = cb(Left(t))
 
-      client
+      OkHttpHandler
+        .updateClientIfCustomReadTimeout(r, client)
         .newCall(request)
         .enqueue(new Callback {
           override def onFailure(call: Call, e: IOException): Unit =
@@ -213,10 +238,17 @@ object OkHttpFutureHandler {
     new FollowRedirectsHandler[Future, Nothing](
       new OkHttpFutureHandler(client, closeClient))
 
-  def apply()(implicit ec: ExecutionContext = ExecutionContext.Implicits.global)
+  def apply(connectionTimeout: FiniteDuration = SttpHandler.DefaultConnectionTimeout)(
+      implicit ec: ExecutionContext = ExecutionContext.Implicits.global)
     : SttpHandler[Future, Nothing] =
-    OkHttpFutureHandler(OkHttpHandler.buildClientNoRedirects(),
-                        closeClient = true)
+    OkHttpFutureHandler(
+      OkHttpHandler
+        .defaultBuilder()
+        .connectTimeout(connectionTimeout.toMillis, TimeUnit.MILLISECONDS)
+        .readTimeout(SttpHandler.DefaultConnectionTimeout.toMillis, TimeUnit.MILLISECONDS)
+        .build(),
+      closeClient = true
+    )
 
   def usingClient(client: OkHttpClient)(implicit ec: ExecutionContext =
                                           ExecutionContext.Implicits.global)

--- a/tests/src/test/scala/com/softwaremill/sttp/IllTypedTests.scala
+++ b/tests/src/test/scala/com/softwaremill/sttp/IllTypedTests.scala
@@ -25,7 +25,7 @@ class IllTypedTests extends FlatSpec with Matchers {
     val thrown = intercept[ToolBoxError] {
       EvalScala("""
         import com.softwaremill.sttp._
-        implicit val sttpHandler = HttpURLConnectionHandler
+        implicit val sttpHandler = HttpURLConnectionHandler()
         sttp.send()
         """)
     }

--- a/tests/src/test/scala/com/softwaremill/sttp/testHelpers.scala
+++ b/tests/src/test/scala/com/softwaremill/sttp/testHelpers.scala
@@ -17,7 +17,10 @@ import scala.concurrent.duration._
 import scala.language.higherKinds
 import scalaz._
 
-trait TestHttpServer extends BeforeAndAfterAll with ScalaFutures with TestingPatience {
+trait TestHttpServer
+    extends BeforeAndAfterAll
+    with ScalaFutures
+    with TestingPatience {
   this: Suite =>
   protected implicit val actorSystem: ActorSystem = ActorSystem("sttp-test")
   import actorSystem.dispatcher


### PR DESCRIPTION
Hi Guys,

I think it might be useful to make requests timeout configurable. Async Http Client sets one minute by default. It might be too small for some cases e.g. streaming data from twitter API where timeout should not be set at all.

Let me know what you think

Cheers