### PR TITLE
Close Ok Http bodies

### DIFF
--- a/okhttp-client-handler/monix/src/main/scala/com/softwaremill/sttp/okhttp/monix/OkHttpMonixClientHandler.scala
+++ b/okhttp-client-handler/monix/src/main/scala/com/softwaremill/sttp/okhttp/monix/OkHttpMonixClientHandler.scala
@@ -32,7 +32,10 @@ class OkHttpMonixClientHandler private (client: OkHttpClient)(
   override def responseBodyToStream(
       res: okhttp3.Response): Try[Observable[ByteBuffer]] =
     Success(
-      Observable.fromInputStream(res.body().byteStream()).map(ByteBuffer.wrap))
+      Observable
+        .fromInputStream(res.body().byteStream())
+        .map(ByteBuffer.wrap)
+        .doAfterTerminate(_ => res.close()))
 
   private def toIterable[T](observable: Observable[T])(
       implicit s: Scheduler): Iterable[T] =

--- a/okhttp-client-handler/src/main/scala/com/softwaremill/sttp/okhttp/OkHttpClientHandler.scala
+++ b/okhttp-client-handler/src/main/scala/com/softwaremill/sttp/okhttp/OkHttpClientHandler.scala
@@ -167,7 +167,7 @@ abstract class OkHttpAsyncClientHandler[R[_], S](client: OkHttpClient,
 
           override def onResponse(call: Call, response: OkHttpResponse): Unit =
             try success(readResponse(response, r.responseAs))
-            catch { case e: Exception => error(e) } finally response.close()
+            catch { case e: Exception => error(e) }
         })
     })
   }


### PR DESCRIPTION
It seems Ok Http bodies were not closed in all cases, which emitted a warning some time after running tests.

I don't know how Ok Http works, so this is a best effor at closing the bodies in all cases.

I'm not sure about the `ResponseAsStream` case.