### PR TITLE
Rename handler subprojects to be consistent

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ val query = "http language:scala"
 // `sort` is removed, as the value is not defined
 val request = sttp.get(uri"https://api.github.com/search/repositories?q=$query&sort=$sort")
   
-implicit val handler = HttpURLConnectionSttpHandler
+implicit val handler = HttpURLConnectionHandler
 val response = request.send()
 
 // response.header(...): Option[String]
@@ -61,7 +61,7 @@ experimenting with sttp by copy-pasting the following:
 ```scala
 import $ivy.`com.softwaremill.sttp::core:0.0.7`
 import com.softwaremill.sttp._
-implicit val handler = HttpURLConnectionSttpHandler
+implicit val handler = HttpURLConnectionHandler
 sttp.get(uri"http://httpbin.org/ip").send()
 ```
 
@@ -113,7 +113,7 @@ value of type `SttpHandler` needs to be in scope to invoke the `send()` on the
 request: 
 
 ```scala
-implicit val handler = HttpURLConnectionSttpHandler
+implicit val handler = HttpURLConnectionHandler
 
 val response: Response[String] = request.send()
 ```
@@ -183,18 +183,18 @@ uri"$scheme://$subdomains.example.com?x=$vx&$params#$jumpTo"
 
 | Class | Result wrapper | Supported stream type |
 | --- | --- | --- |
-| `HttpURLConnectionSttpHandler` | None (`Id`) | - |
-| `AkkaHttpSttpHandler` | `scala.concurrent.Future` | `akka.stream.scaladsl.Source[ByteString, Any]` |
-| `FutureAsyncHttpClientHandler` | `scala.concurrent.Future` | - |
-| `ScalazAsyncHttpClientHandler` | `scalaz.concurrent.Task` | - |
-| `MonixAsyncHttpClientHandler` | `monix.eval.Task` | `monix.reactive.Observable[ByteBuffer]` | 
-| `CatsAsyncHttpClientHandler` | `F[_]: cats.effect.Async` | - | 
-| `Fs2AsyncHttpClientHandler` | `F[_]: cats.effect.Async` | `fs2.Stream[F, ByteBuffer]` | 
-| `OkHttpSyncClientHandler` | None (`Id`) | - | 
-| `OkHttpFutureClientHandler` | `scala.concurrent.Future` | - |
-| `OkHttpMonixClientHandler` | `monix.eval.Task` | `monix.reactive.Observable[ByteBuffer]` |
+| `HttpURLConnectionHandler` | None (`Id`) | - |
+| `AkkaHttpHandler` | `scala.concurrent.Future` | `akka.stream.scaladsl.Source[ByteString, Any]` |
+| `AsyncHttpClientFutureHandler` | `scala.concurrent.Future` | - |
+| `AsyncHttpClientScalazHandler` | `scalaz.concurrent.Task` | - |
+| `AsyncHttpClientMonixHandler` | `monix.eval.Task` | `monix.reactive.Observable[ByteBuffer]` | 
+| `AsyncHttpClientCatsHandler` | `F[_]: cats.effect.Async` | - | 
+| `AsyncHttpClientFs2Handler` | `F[_]: cats.effect.Async` | `fs2.Stream[F, ByteBuffer]` | 
+| `OkHttpSyncHandler` | None (`Id`) | - | 
+| `OkHttpFutureHandler` | `scala.concurrent.Future` | - |
+| `OkHttpMonixHandler` | `monix.eval.Task` | `monix.reactive.Observable[ByteBuffer]` |
 
-### `HttpURLConnectionSttpHandler`
+### `HttpURLConnectionHandler`
 
 The default **synchronous** handler. Sending a request returns a response wrapped 
 in the identity type constructor, which is equivalent to no wrapper at all.
@@ -202,10 +202,10 @@ in the identity type constructor, which is equivalent to no wrapper at all.
 To use, add an implicit value:
 
 ```scala
-implicit val sttpHandler = HttpURLConnectionSttpHandler
+implicit val sttpHandler = HttpURLConnectionHandler
 ```
 
-### `AkkaHttpSttpHandler`
+### `AkkaHttpHandler`
 
 To use, add the following dependency to your project:
 
@@ -220,10 +220,10 @@ in a `Future`.
 Next you'll need to add an implicit value:
 
 ```scala
-implicit val sttpHandler = AkkaHttpSttpHandler()
+implicit val sttpHandler = AkkaHttpHandler()
 
 // or, if you'd like to use an existing actor system:
-implicit val sttpHandler = AkkaHttpSttpHandler.usingActorSystem(actorSystem)
+implicit val sttpHandler = AkkaHttpHandler.usingActorSystem(actorSystem)
 ```
 
 This backend supports sending and receiving 
@@ -255,7 +255,7 @@ import com.softwaremill.sttp.akkahttp._
 import akka.stream.scaladsl.Source
 import akka.util.ByteString
 
-implicit val sttpHandler = AkkaHttpSttpHandler()
+implicit val sttpHandler = AkkaHttpHandler()
 
 val response: Future[Response[Source[ByteString, Any]]] = 
   sttp
@@ -295,22 +295,22 @@ typeclass, such as `cats.effect.IO`. There's a transitive dependency on `cats-ef
 Next you'll need to add an implicit value:
 
 ```scala
-implicit val sttpHandler = FutureAsyncHttpClientHandler()
+implicit val sttpHandler = AsyncHttpClientFutureHandler()
 
 // or, if you're using the scalaz version:
-implicit val sttpHandler = ScalazAsyncHttpClientHandler()
+implicit val sttpHandler = AsyncHttpClientScalazHandler()
 
 // or, if you're using the monix version:
-implicit val sttpHandler = MonixAsyncHttpClientHandler()
+implicit val sttpHandler = AsyncHttpClientMonixHandler()
 
 // or, if you're using the cats effect version:
-implicit val sttpHandler = CatsAsyncHttpClientHandler[cats.effect.IO]()
+implicit val sttpHandler = AsyncHttpClientCatsHandler[cats.effect.IO]()
 
 // or, if you'd like to use custom configuration:
-implicit val sttpHandler = FutureAsyncHttpClientHandler.usingConfig(asyncHttpClientConfig)
+implicit val sttpHandler = AsyncHttpClientFutureHandler.usingConfig(asyncHttpClientConfig)
 
 // or, if you'd like to instantiate the AsyncHttpClient yourself:
-implicit val sttpHandler = FutureAsyncHttpClientHandler.usingClient(asyncHttpClient)
+implicit val sttpHandler = AsyncHttpClientFutureHandler.usingClient(asyncHttpClient)
 ```
 
 #### Streaming using Monix
@@ -343,7 +343,7 @@ import java.nio.ByteBuffer
 import monix.eval.Task
 import monix.reactive.Observable
 
-implicit val sttpHandler = MonixAsyncHttpClientHandler()
+implicit val sttpHandler = AsyncHttpClientMonixHandler()
 
 val response: Task[Response[Observable[ByteBuffer]]] = 
   sttp
@@ -361,8 +361,8 @@ To use, add the following dependency to your project:
 ```
 
 This handler depends on [OkHttp](http://square.github.io/okhttp/), and offers 
-both a **synchronous** (`OkHttpSyncClientHandler`) and **asynchronous**
-(`OkHttpFutureClientHandler`), `Future`-based handlers.
+both a **synchronous** (`OkHttpSyncHandler`) and **asynchronous**
+(`OkHttpFutureHandler`), `Future`-based handlers.
 
 OkHttp fully supports HTTP/2.
 
@@ -393,7 +393,7 @@ a request to decode the response to a specific object.
 import com.softwaremill.sttp._
 import com.softwaremill.sttp.circe._
 
-implicit val handler = HttpURLConnectionSttpHandler
+implicit val handler = HttpURLConnectionHandler
 
 // Assume that there is an implicit circe encoder in scope
 // for the request Payload, and a decoder for the Response

--- a/akka-http-handler/src/main/scala/com/softwaremill/sttp/akkahttp/AkkaHttpHandler.scala
+++ b/akka-http-handler/src/main/scala/com/softwaremill/sttp/akkahttp/AkkaHttpHandler.scala
@@ -5,26 +5,26 @@ import java.io.{File, IOException, UnsupportedEncodingException}
 import akka.actor.ActorSystem
 import akka.http.scaladsl.Http
 import akka.http.scaladsl.coding.{Deflate, Gzip, NoCoding}
+import akka.http.scaladsl.model.ContentTypes.`application/octet-stream`
 import akka.http.scaladsl.model.HttpHeader.ParsingResult
-import akka.http.scaladsl.model.{Multipart => AkkaMultipart, _}
 import akka.http.scaladsl.model.headers.{
   HttpEncodings,
-  `Content-Type`,
-  `Content-Length`
+  `Content-Length`,
+  `Content-Type`
 }
-import akka.http.scaladsl.model.ContentTypes.`application/octet-stream`
+import akka.http.scaladsl.model.{Multipart => AkkaMultipart, _}
 import akka.stream.ActorMaterializer
 import akka.stream.scaladsl.{FileIO, Source, StreamConverters}
 import akka.util.ByteString
 import com.softwaremill.sttp._
 
+import scala.collection.immutable.Seq
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Success, Try}
-import scala.collection.immutable.Seq
 
-class AkkaHttpSttpHandler private (actorSystem: ActorSystem,
-                                   ec: ExecutionContext,
-                                   terminateActorSystemOnClose: Boolean)
+class AkkaHttpHandler private (actorSystem: ActorSystem,
+                               ec: ExecutionContext,
+                               terminateActorSystemOnClose: Boolean)
     extends SttpHandler[Future, Source[ByteString, Any]] {
 
   // the supported stream type
@@ -261,7 +261,7 @@ class AkkaHttpSttpHandler private (actorSystem: ActorSystem,
   }
 }
 
-object AkkaHttpSttpHandler {
+object AkkaHttpHandler {
 
   /**
     * @param ec The execution context for running non-network related operations,
@@ -270,7 +270,7 @@ object AkkaHttpSttpHandler {
     */
   def apply()(implicit ec: ExecutionContext = ExecutionContext.Implicits.global)
     : SttpHandler[Future, Source[ByteString, Any]] =
-    new AkkaHttpSttpHandler(ActorSystem("sttp"), ec, true)
+    new AkkaHttpHandler(ActorSystem("sttp"), ec, true)
 
   /**
     * @param actorSystem The actor system which will be used for the http-client
@@ -282,5 +282,5 @@ object AkkaHttpSttpHandler {
   def usingActorSystem(actorSystem: ActorSystem)(
       implicit ec: ExecutionContext = ExecutionContext.Implicits.global)
     : SttpHandler[Future, Source[ByteString, Any]] =
-    new AkkaHttpSttpHandler(actorSystem, ec, false)
+    new AkkaHttpHandler(actorSystem, ec, false)
 }

--- a/async-http-client-handler/cats/src/main/scala/com/softwaremill/sttp/asynchttpclient/cats/AsyncHttpClientCatsHandler.scala
+++ b/async-http-client-handler/cats/src/main/scala/com/softwaremill/sttp/asynchttpclient/cats/AsyncHttpClientCatsHandler.scala
@@ -14,7 +14,7 @@ import org.reactivestreams.Publisher
 
 import scala.language.higherKinds
 
-class CatsAsyncHttpClientHandler[F[_]: Async] private (
+class AsyncHttpClientCatsHandler[F[_]: Async] private (
     asyncHttpClient: AsyncHttpClient,
     closeClient: Boolean
 ) extends AsyncHttpClientHandler[F, Nothing](
@@ -30,20 +30,20 @@ class CatsAsyncHttpClientHandler[F[_]: Async] private (
     throw new IllegalStateException("This handler does not support streaming")
 }
 
-object CatsAsyncHttpClientHandler {
+object AsyncHttpClientCatsHandler {
 
   def apply[F[_]: Async](): SttpHandler[F, Nothing] =
-    new CatsAsyncHttpClientHandler(new DefaultAsyncHttpClient(),
+    new AsyncHttpClientCatsHandler(new DefaultAsyncHttpClient(),
                                    closeClient = true)
 
   def usingConfig[F[_]: Async](
       cfg: AsyncHttpClientConfig): SttpHandler[F, Nothing] =
-    new CatsAsyncHttpClientHandler(new DefaultAsyncHttpClient(cfg),
+    new AsyncHttpClientCatsHandler(new DefaultAsyncHttpClient(cfg),
                                    closeClient = true)
 
   def usingClient[F[_]: Async](
       client: AsyncHttpClient): SttpHandler[F, Nothing] =
-    new CatsAsyncHttpClientHandler(client, closeClient = false)
+    new AsyncHttpClientCatsHandler(client, closeClient = false)
 }
 
 private[cats] class AsyncMonad[F[_]](implicit F: Async[F])

--- a/async-http-client-handler/fs2/src/main/scala/com/softwaremill/sttp/asynchttpclient/fs2/AsyncHttpClientFs2Handler.scala
+++ b/async-http-client-handler/fs2/src/main/scala/com/softwaremill/sttp/asynchttpclient/fs2/AsyncHttpClientFs2Handler.scala
@@ -17,7 +17,7 @@ import org.reactivestreams.Publisher
 import scala.concurrent.ExecutionContext
 import scala.language.higherKinds
 
-class Fs2AsyncHttpClientHandler[F[_]: Effect] private (
+class AsyncHttpClientFs2Handler[F[_]: Effect] private (
     asyncHttpClient: AsyncHttpClient,
     closeClient: Boolean)(implicit ec: ExecutionContext)
     extends AsyncHttpClientHandler[F, Stream[F, ByteBuffer]](
@@ -35,7 +35,7 @@ class Fs2AsyncHttpClientHandler[F[_]: Effect] private (
     p.toStream[F]
 }
 
-object Fs2AsyncHttpClientHandler {
+object AsyncHttpClientFs2Handler {
 
   /**
     * @param ec The execution context for running non-network related operations,
@@ -45,7 +45,7 @@ object Fs2AsyncHttpClientHandler {
   def apply[F[_]: Effect]()(
       implicit ec: ExecutionContext = ExecutionContext.Implicits.global)
     : SttpHandler[F, Stream[F, ByteBuffer]] =
-    new Fs2AsyncHttpClientHandler[F](new DefaultAsyncHttpClient(),
+    new AsyncHttpClientFs2Handler[F](new DefaultAsyncHttpClient(),
                                      closeClient = true)
 
   /**
@@ -56,7 +56,7 @@ object Fs2AsyncHttpClientHandler {
   def usingConfig[F[_]: Effect](cfg: AsyncHttpClientConfig)(
       implicit ec: ExecutionContext = ExecutionContext.Implicits.global)
     : SttpHandler[F, Stream[F, ByteBuffer]] =
-    new Fs2AsyncHttpClientHandler[F](new DefaultAsyncHttpClient(cfg),
+    new AsyncHttpClientFs2Handler[F](new DefaultAsyncHttpClient(cfg),
                                      closeClient = true)
 
   /**
@@ -67,7 +67,7 @@ object Fs2AsyncHttpClientHandler {
   def usingClient[F[_]: Effect](client: AsyncHttpClient)(
       implicit ec: ExecutionContext = ExecutionContext.Implicits.global)
     : SttpHandler[F, Stream[F, ByteBuffer]] =
-    new Fs2AsyncHttpClientHandler[F](client, closeClient = false)
+    new AsyncHttpClientFs2Handler[F](client, closeClient = false)
 }
 
 private[fs2] class EffectMonad[F[_]](implicit F: Effect[F])

--- a/async-http-client-handler/future/src/main/scala/com/softwaremill/sttp/asynchttpclient/future/AsyncHttpClientFutureHandler.scala
+++ b/async-http-client-handler/future/src/main/scala/com/softwaremill/sttp/asynchttpclient/future/AsyncHttpClientFutureHandler.scala
@@ -13,7 +13,7 @@ import org.reactivestreams.Publisher
 
 import scala.concurrent.{ExecutionContext, Future}
 
-class FutureAsyncHttpClientHandler private (
+class AsyncHttpClientFutureHandler private (
     asyncHttpClient: AsyncHttpClient,
     closeClient: Boolean)(implicit ec: ExecutionContext)
     extends AsyncHttpClientHandler[Future, Nothing](asyncHttpClient,
@@ -28,7 +28,7 @@ class FutureAsyncHttpClientHandler private (
     throw new IllegalStateException("This handler does not support streaming")
 }
 
-object FutureAsyncHttpClientHandler {
+object AsyncHttpClientFutureHandler {
 
   /**
     * @param ec The execution context for running non-network related operations,
@@ -37,7 +37,7 @@ object FutureAsyncHttpClientHandler {
     */
   def apply()(implicit ec: ExecutionContext = ExecutionContext.Implicits.global)
     : SttpHandler[Future, Nothing] =
-    new FutureAsyncHttpClientHandler(new DefaultAsyncHttpClient(),
+    new AsyncHttpClientFutureHandler(new DefaultAsyncHttpClient(),
                                      closeClient = true)
 
   /**
@@ -48,7 +48,7 @@ object FutureAsyncHttpClientHandler {
   def usingConfig(cfg: AsyncHttpClientConfig)(
       implicit ec: ExecutionContext = ExecutionContext.Implicits.global)
     : SttpHandler[Future, Nothing] =
-    new FutureAsyncHttpClientHandler(new DefaultAsyncHttpClient(cfg),
+    new AsyncHttpClientFutureHandler(new DefaultAsyncHttpClient(cfg),
                                      closeClient = true)
 
   /**
@@ -59,5 +59,5 @@ object FutureAsyncHttpClientHandler {
   def usingClient(client: AsyncHttpClient)(implicit ec: ExecutionContext =
                                              ExecutionContext.Implicits.global)
     : SttpHandler[Future, Nothing] =
-    new FutureAsyncHttpClientHandler(client, closeClient = false)
+    new AsyncHttpClientFutureHandler(client, closeClient = false)
 }

--- a/async-http-client-handler/monix/src/main/scala/com/softwaremill/sttp/asynchttpclient/monix/AsyncHttpClientMonixHandler.scala
+++ b/async-http-client-handler/monix/src/main/scala/com/softwaremill/sttp/asynchttpclient/monix/AsyncHttpClientMonixHandler.scala
@@ -16,7 +16,7 @@ import org.reactivestreams.Publisher
 
 import scala.util.{Failure, Success}
 
-class MonixAsyncHttpClientHandler private (
+class AsyncHttpClientMonixHandler private (
     asyncHttpClient: AsyncHttpClient,
     closeClient: Boolean)(implicit scheduler: Scheduler)
     extends AsyncHttpClientHandler[Task, Observable[ByteBuffer]](
@@ -33,7 +33,7 @@ class MonixAsyncHttpClientHandler private (
     Observable.fromReactivePublisher(p)
 }
 
-object MonixAsyncHttpClientHandler {
+object AsyncHttpClientMonixHandler {
 
   /**
     * @param s The scheduler used for streaming request bodies. Defaults to the
@@ -41,7 +41,7 @@ object MonixAsyncHttpClientHandler {
     */
   def apply()(implicit s: Scheduler = Scheduler.Implicits.global)
     : SttpHandler[Task, Observable[ByteBuffer]] =
-    new MonixAsyncHttpClientHandler(new DefaultAsyncHttpClient(),
+    new AsyncHttpClientMonixHandler(new DefaultAsyncHttpClient(),
                                     closeClient = true)
 
   /**
@@ -51,7 +51,7 @@ object MonixAsyncHttpClientHandler {
   def usingConfig(cfg: AsyncHttpClientConfig)(implicit s: Scheduler =
                                                 Scheduler.Implicits.global)
     : SttpHandler[Task, Observable[ByteBuffer]] =
-    new MonixAsyncHttpClientHandler(new DefaultAsyncHttpClient(cfg),
+    new AsyncHttpClientMonixHandler(new DefaultAsyncHttpClient(cfg),
                                     closeClient = true)
 
   /**
@@ -61,7 +61,7 @@ object MonixAsyncHttpClientHandler {
   def usingClient(client: AsyncHttpClient)(implicit s: Scheduler =
                                              Scheduler.Implicits.global)
     : SttpHandler[Task, Observable[ByteBuffer]] =
-    new MonixAsyncHttpClientHandler(client, closeClient = false)
+    new AsyncHttpClientMonixHandler(client, closeClient = false)
 }
 
 private[monix] object TaskMonad extends MonadAsyncError[Task] {

--- a/async-http-client-handler/scalaz/src/main/scala/com/softwaremill/sttp/asynchttpclient/scalaz/AsyncHttpClientScalazHandler.scala
+++ b/async-http-client-handler/scalaz/src/main/scala/com/softwaremill/sttp/asynchttpclient/scalaz/AsyncHttpClientScalazHandler.scala
@@ -14,7 +14,7 @@ import org.reactivestreams.Publisher
 import scalaz.{-\/, \/-}
 import scalaz.concurrent.Task
 
-class ScalazAsyncHttpClientHandler private (asyncHttpClient: AsyncHttpClient,
+class AsyncHttpClientScalazHandler private (asyncHttpClient: AsyncHttpClient,
                                             closeClient: Boolean)
     extends AsyncHttpClientHandler[Task, Nothing](asyncHttpClient,
                                                   TaskMonad,
@@ -28,15 +28,15 @@ class ScalazAsyncHttpClientHandler private (asyncHttpClient: AsyncHttpClient,
     throw new IllegalStateException("This handler does not support streaming")
 }
 
-object ScalazAsyncHttpClientHandler {
+object AsyncHttpClientScalazHandler {
   def apply(): SttpHandler[Task, Nothing] =
-    new ScalazAsyncHttpClientHandler(new DefaultAsyncHttpClient(),
+    new AsyncHttpClientScalazHandler(new DefaultAsyncHttpClient(),
                                      closeClient = true)
   def usingConfig(cfg: AsyncHttpClientConfig): SttpHandler[Task, Nothing] =
-    new ScalazAsyncHttpClientHandler(new DefaultAsyncHttpClient(cfg),
+    new AsyncHttpClientScalazHandler(new DefaultAsyncHttpClient(cfg),
                                      closeClient = true)
   def usingClient(client: AsyncHttpClient): SttpHandler[Task, Nothing] =
-    new ScalazAsyncHttpClientHandler(client, closeClient = false)
+    new AsyncHttpClientScalazHandler(client, closeClient = false)
 }
 
 private[scalaz] object TaskMonad extends MonadAsyncError[Task] {

--- a/build.sbt
+++ b/build.sbt
@@ -47,13 +47,13 @@ lazy val rootProject = (project in file("."))
     core,
     akkaHttpHandler,
     asyncHttpClientHandler,
-    futureAsyncHttpClientHandler,
-    scalazAsyncHttpClientHandler,
-    monixAsyncHttpClientHandler,
-    catsAsyncHttpClientHandler,
-    fs2AsyncHttpClientHandler,
-    okhttpClientHandler,
-    okhttpMonixClientHandler,
+    asyncHttpClientFutureHandler,
+    asyncHttpClientScalazHandler,
+    asyncHttpClientMonixHandler,
+    asyncHttpClientCatsHandler,
+    asyncHttpClientFs2Handler,
+    okhttpHandler,
+    okhttpMonixHandler,
     circe,
     tests
   )
@@ -87,14 +87,14 @@ lazy val asyncHttpClientHandler: Project = (project in file(
     )
   ) dependsOn core
 
-lazy val futureAsyncHttpClientHandler: Project = (project in file(
+lazy val asyncHttpClientFutureHandler: Project = (project in file(
   "async-http-client-handler/future"))
   .settings(commonSettings: _*)
   .settings(
     name := "async-http-client-handler-future"
   ) dependsOn asyncHttpClientHandler
 
-lazy val scalazAsyncHttpClientHandler: Project = (project in file(
+lazy val asyncHttpClientScalazHandler: Project = (project in file(
   "async-http-client-handler/scalaz"))
   .settings(commonSettings: _*)
   .settings(
@@ -104,7 +104,7 @@ lazy val scalazAsyncHttpClientHandler: Project = (project in file(
     )
   ) dependsOn asyncHttpClientHandler
 
-lazy val monixAsyncHttpClientHandler: Project = (project in file(
+lazy val asyncHttpClientMonixHandler: Project = (project in file(
   "async-http-client-handler/monix"))
   .settings(commonSettings: _*)
   .settings(
@@ -112,7 +112,7 @@ lazy val monixAsyncHttpClientHandler: Project = (project in file(
     libraryDependencies ++= Seq(monix)
   ) dependsOn asyncHttpClientHandler
 
-lazy val catsAsyncHttpClientHandler: Project = (project in file(
+lazy val asyncHttpClientCatsHandler: Project = (project in file(
   "async-http-client-handler/cats"))
   .settings(commonSettings: _*)
   .settings(
@@ -122,7 +122,7 @@ lazy val catsAsyncHttpClientHandler: Project = (project in file(
     )
   ) dependsOn asyncHttpClientHandler
 
-lazy val fs2AsyncHttpClientHandler: Project = (project in file(
+lazy val asyncHttpClientFs2Handler: Project = (project in file(
   "async-http-client-handler/fs2"))
   .settings(commonSettings: _*)
   .settings(
@@ -132,8 +132,7 @@ lazy val fs2AsyncHttpClientHandler: Project = (project in file(
     )
   ) dependsOn asyncHttpClientHandler
 
-lazy val okhttpClientHandler: Project = (project in file(
-  "okhttp-client-handler"))
+lazy val okhttpHandler: Project = (project in file("okhttp-handler"))
   .settings(commonSettings: _*)
   .settings(
     name := "okhttp-client-handler",
@@ -142,13 +141,12 @@ lazy val okhttpClientHandler: Project = (project in file(
     )
   ) dependsOn core
 
-lazy val okhttpMonixClientHandler: Project = (project in file(
-  "okhttp-client-handler/monix"))
+lazy val okhttpMonixHandler: Project = (project in file("okhttp-handler/monix"))
   .settings(commonSettings: _*)
   .settings(
     name := "okhttp-client-handler-monix",
     libraryDependencies ++= Seq(monix)
-  ) dependsOn okhttpClientHandler
+  ) dependsOn okhttpHandler
 
 lazy val circe: Project = (project in file("circe"))
   .settings(commonSettings: _*)
@@ -174,8 +172,5 @@ lazy val tests: Project = (project in file("tests"))
       "ch.qos.logback" % "logback-classic" % "1.2.3"
     ).map(_ % "test"),
     libraryDependencies += "org.scala-lang" % "scala-compiler" % scalaVersion.value % "test"
-  ) dependsOn (
-  core, akkaHttpHandler, futureAsyncHttpClientHandler, scalazAsyncHttpClientHandler,
-  monixAsyncHttpClientHandler, catsAsyncHttpClientHandler, fs2AsyncHttpClientHandler,
-  okhttpClientHandler, okhttpMonixClientHandler
-)
+  ) dependsOn (core, akkaHttpHandler, asyncHttpClientFutureHandler, asyncHttpClientScalazHandler,
+asyncHttpClientMonixHandler, asyncHttpClientCatsHandler, asyncHttpClientFs2Handler, okhttpMonixHandler)

--- a/core/src/main/scala/com/softwaremill/sttp/HttpURLConnectionHandler.scala
+++ b/core/src/main/scala/com/softwaremill/sttp/HttpURLConnectionHandler.scala
@@ -12,7 +12,7 @@ import scala.annotation.tailrec
 import scala.io.Source
 import scala.collection.JavaConverters._
 
-object HttpURLConnectionSttpHandler extends SttpHandler[Id, Nothing] {
+object HttpURLConnectionHandler extends SttpHandler[Id, Nothing] {
   override def send[T](r: Request[T, Nothing]): Response[T] = {
     val c =
       new URL(r.uri.toString).openConnection().asInstanceOf[HttpURLConnection]

--- a/okhttp-handler/monix/src/main/scala/com/softwaremill/sttp/okhttp/monix/OkHttpMonixHandler.scala
+++ b/okhttp-handler/monix/src/main/scala/com/softwaremill/sttp/okhttp/monix/OkHttpMonixHandler.scala
@@ -4,7 +4,7 @@ import java.nio.ByteBuffer
 import java.util.concurrent.ArrayBlockingQueue
 
 import com.softwaremill.sttp.{SttpHandler, _}
-import com.softwaremill.sttp.okhttp.OkHttpAsyncClientHandler
+import com.softwaremill.sttp.okhttp.OkHttpAsyncHandler
 import monix.eval.Task
 import monix.execution.Ack.Continue
 import monix.execution.{Ack, Cancelable, Scheduler}
@@ -16,10 +16,8 @@ import okio.BufferedSink
 import scala.concurrent.Future
 import scala.util.{Failure, Success, Try}
 
-class OkHttpMonixClientHandler private (client: OkHttpClient)(
-    implicit s: Scheduler)
-    extends OkHttpAsyncClientHandler[Task, Observable[ByteBuffer]](client,
-                                                                   TaskMonad) {
+class OkHttpMonixHandler private (client: OkHttpClient)(implicit s: Scheduler)
+    extends OkHttpAsyncHandler[Task, Observable[ByteBuffer]](client, TaskMonad) {
 
   override def streamToRequestBody(
       stream: Observable[ByteBuffer]): Option[OkHttpRequestBody] =
@@ -78,11 +76,11 @@ class OkHttpMonixClientHandler private (client: OkHttpClient)(
     }
 }
 
-object OkHttpMonixClientHandler {
+object OkHttpMonixHandler {
   def apply(okhttpClient: OkHttpClient = new OkHttpClient())(
       implicit s: Scheduler = Scheduler.Implicits.global)
     : SttpHandler[Task, Observable[ByteBuffer]] =
-    new OkHttpMonixClientHandler(okhttpClient)(s)
+    new OkHttpMonixHandler(okhttpClient)(s)
 }
 
 private[monix] object TaskMonad extends MonadAsyncError[Task] {

--- a/tests/src/test/scala/com/softwaremill/sttp/BasicTests.scala
+++ b/tests/src/test/scala/com/softwaremill/sttp/BasicTests.scala
@@ -14,16 +14,13 @@ import akka.http.scaladsl.server.Route
 import akka.http.scaladsl.server.directives.Credentials
 import akka.util.ByteString
 import better.files._
-import com.softwaremill.sttp.akkahttp.AkkaHttpSttpHandler
-import com.softwaremill.sttp.asynchttpclient.cats.CatsAsyncHttpClientHandler
-import com.softwaremill.sttp.asynchttpclient.future.FutureAsyncHttpClientHandler
-import com.softwaremill.sttp.asynchttpclient.monix.MonixAsyncHttpClientHandler
-import com.softwaremill.sttp.asynchttpclient.scalaz.ScalazAsyncHttpClientHandler
-import com.softwaremill.sttp.okhttp.monix.OkHttpMonixClientHandler
-import com.softwaremill.sttp.okhttp.{
-  OkHttpFutureClientHandler,
-  OkHttpSyncClientHandler
-}
+import com.softwaremill.sttp.akkahttp.AkkaHttpHandler
+import com.softwaremill.sttp.asynchttpclient.cats.AsyncHttpClientCatsHandler
+import com.softwaremill.sttp.asynchttpclient.future.AsyncHttpClientFutureHandler
+import com.softwaremill.sttp.asynchttpclient.monix.AsyncHttpClientMonixHandler
+import com.softwaremill.sttp.asynchttpclient.scalaz.AsyncHttpClientScalazHandler
+import com.softwaremill.sttp.okhttp.monix.OkHttpMonixHandler
+import com.softwaremill.sttp.okhttp.{OkHttpFutureHandler, OkHttpSyncHandler}
 import com.typesafe.scalalogging.StrictLogging
 import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
 import org.scalatest.{path => _, _}
@@ -158,24 +155,22 @@ class BasicTests
 
   var closeHandlers: List[() => Unit] = Nil
 
-  runTests("HttpURLConnection")(HttpURLConnectionSttpHandler,
-                                ForceWrappedValue.id)
-  runTests("Akka HTTP")(AkkaHttpSttpHandler.usingActorSystem(actorSystem),
+  runTests("HttpURLConnection")(HttpURLConnectionHandler, ForceWrappedValue.id)
+  runTests("Akka HTTP")(AkkaHttpHandler.usingActorSystem(actorSystem),
                         ForceWrappedValue.future)
-  runTests("Async Http Client - Future")(FutureAsyncHttpClientHandler(),
+  runTests("Async Http Client - Future")(AsyncHttpClientFutureHandler(),
                                          ForceWrappedValue.future)
-  runTests("Async Http Client - Scalaz")(ScalazAsyncHttpClientHandler(),
+  runTests("Async Http Client - Scalaz")(AsyncHttpClientScalazHandler(),
                                          ForceWrappedValue.scalazTask)
-  runTests("Async Http Client - Monix")(MonixAsyncHttpClientHandler(),
+  runTests("Async Http Client - Monix")(AsyncHttpClientMonixHandler(),
                                         ForceWrappedValue.monixTask)
   runTests("Async Http Client - Cats Effect")(
-    CatsAsyncHttpClientHandler[cats.effect.IO](),
+    AsyncHttpClientCatsHandler[cats.effect.IO](),
     ForceWrappedValue.catsIo)
-  runTests("OkHttpSyncClientHandler")(OkHttpSyncClientHandler(),
-                                      ForceWrappedValue.id)
-  runTests("OkHttpAsyncClientHandler - Future")(OkHttpFutureClientHandler(),
+  runTests("OkHttpSyncClientHandler")(OkHttpSyncHandler(), ForceWrappedValue.id)
+  runTests("OkHttpAsyncClientHandler - Future")(OkHttpFutureHandler(),
                                                 ForceWrappedValue.future)
-  runTests("OkHttpAsyncClientHandler - Monix")(OkHttpMonixClientHandler(),
+  runTests("OkHttpAsyncClientHandler - Monix")(OkHttpMonixHandler(),
                                                ForceWrappedValue.monixTask)
 
   def runTests[R[_]](name: String)(

--- a/tests/src/test/scala/com/softwaremill/sttp/IllTypedTests.scala
+++ b/tests/src/test/scala/com/softwaremill/sttp/IllTypedTests.scala
@@ -12,7 +12,7 @@ class IllTypedTests extends FlatSpec with Matchers {
         import com.softwaremill.sttp._
         import akka.stream.scaladsl.Source
         import akka.util.ByteString
-        implicit val sttpHandler = HttpURLConnectionSttpHandler
+        implicit val sttpHandler = HttpURLConnectionHandler
         sttp.get(uri"http://example.com").response(asStream[Source[ByteString, Any]]).send()
         """)
     }
@@ -25,7 +25,7 @@ class IllTypedTests extends FlatSpec with Matchers {
     val thrown = intercept[ToolBoxError] {
       EvalScala("""
         import com.softwaremill.sttp._
-        implicit val sttpHandler = HttpURLConnectionSttpHandler
+        implicit val sttpHandler = HttpURLConnectionHandler
         sttp.send()
         """)
     }

--- a/tests/src/test/scala/com/softwaremill/sttp/StreamingTests.scala
+++ b/tests/src/test/scala/com/softwaremill/sttp/StreamingTests.scala
@@ -33,10 +33,10 @@ class StreamingTests
 
   var closeHandlers: List[() => Unit] = Nil
 
-  runTests("Akka Http", new AkkaStreamingTests(actorSystem))
-  runTests("Monix Async Http Client", new MonixAHCStreamingTests)
-  runTests("Monix OkHttp", new MonixOKHStreamingTests)
-  runTests("fs2 Async Http Client", new Fs2StreamingTests)
+  runTests("Akka Http", new AkkaHttpStreamingTests(actorSystem))
+  runTests("Monix Async Http Client", new AsyncHttpClientMonixStreamingTests)
+  runTests("Monix OkHttp", new OkHttpMonixStreamingTests)
+  runTests("fs2 Async Http Client", new AsyncHttpClientFs2StreamingTests)
 
   def runTests[R[_], S](
       name: String,

--- a/tests/src/test/scala/com/softwaremill/sttp/streaming/AkkaHttpStreamingTests.scala
+++ b/tests/src/test/scala/com/softwaremill/sttp/streaming/AkkaHttpStreamingTests.scala
@@ -5,17 +5,17 @@ import akka.actor.ActorSystem
 import akka.stream.Materializer
 import akka.stream.scaladsl.Source
 import akka.util.ByteString
+import com.softwaremill.sttp.akkahttp.AkkaHttpHandler
 import com.softwaremill.sttp.{ForceWrappedValue, SttpHandler}
-import com.softwaremill.sttp.akkahttp.AkkaHttpSttpHandler
 
 import scala.concurrent.Future
 
-class AkkaStreamingTests(actorSystem: ActorSystem)(
+class AkkaHttpStreamingTests(actorSystem: ActorSystem)(
     implicit materializer: Materializer)
     extends TestStreamingHandler[Future, Source[ByteString, Any]] {
 
   override implicit val handler: SttpHandler[Future, Source[ByteString, Any]] =
-    AkkaHttpSttpHandler.usingActorSystem(actorSystem)
+    AkkaHttpHandler.usingActorSystem(actorSystem)
 
   override implicit val forceResponse: ForceWrappedValue[Future] =
     ForceWrappedValue.future

--- a/tests/src/test/scala/com/softwaremill/sttp/streaming/AsyncHttpClientFs2StreamingTests.scala
+++ b/tests/src/test/scala/com/softwaremill/sttp/streaming/AsyncHttpClientFs2StreamingTests.scala
@@ -4,15 +4,15 @@ import java.nio.ByteBuffer
 
 import cats.effect._
 import cats.implicits._
-import com.softwaremill.sttp.asynchttpclient.fs2.Fs2AsyncHttpClientHandler
+import com.softwaremill.sttp.asynchttpclient.fs2.AsyncHttpClientFs2Handler
 import com.softwaremill.sttp.{ForceWrappedValue, SttpHandler}
 import fs2._
 
-class Fs2StreamingTests
+class AsyncHttpClientFs2StreamingTests
     extends TestStreamingHandler[IO, Stream[IO, ByteBuffer]] {
 
   override implicit val handler: SttpHandler[IO, Stream[IO, ByteBuffer]] =
-    Fs2AsyncHttpClientHandler[IO]()
+    AsyncHttpClientFs2Handler[IO]()
 
   override implicit val forceResponse: ForceWrappedValue[IO] =
     ForceWrappedValue.catsIo

--- a/tests/src/test/scala/com/softwaremill/sttp/streaming/AsyncHttpClientMonixStreamingTests.scala
+++ b/tests/src/test/scala/com/softwaremill/sttp/streaming/AsyncHttpClientMonixStreamingTests.scala
@@ -3,15 +3,15 @@ package com.softwaremill.sttp.streaming
 import java.nio.ByteBuffer
 
 import com.softwaremill.sttp.SttpHandler
-import com.softwaremill.sttp.asynchttpclient.monix.MonixAsyncHttpClientHandler
+import com.softwaremill.sttp.asynchttpclient.monix.AsyncHttpClientMonixHandler
 import monix.eval.Task
 import monix.reactive.Observable
 
-class MonixAHCStreamingTests extends MonixBaseHandler {
+class AsyncHttpClientMonixStreamingTests extends MonixBaseHandler {
 
   import monix.execution.Scheduler.Implicits.global
 
   override implicit val handler: SttpHandler[Task, Observable[ByteBuffer]] =
-    MonixAsyncHttpClientHandler()
+    AsyncHttpClientMonixHandler()
 
 }

--- a/tests/src/test/scala/com/softwaremill/sttp/streaming/OkHttpMonixStreamingTests.scala
+++ b/tests/src/test/scala/com/softwaremill/sttp/streaming/OkHttpMonixStreamingTests.scala
@@ -3,15 +3,15 @@ package com.softwaremill.sttp.streaming
 import java.nio.ByteBuffer
 
 import com.softwaremill.sttp.SttpHandler
-import com.softwaremill.sttp.okhttp.monix.OkHttpMonixClientHandler
+import com.softwaremill.sttp.okhttp.monix.OkHttpMonixHandler
 import monix.eval.Task
 import monix.reactive.Observable
 
-class MonixOKHStreamingTests extends MonixBaseHandler {
+class OkHttpMonixStreamingTests extends MonixBaseHandler {
 
   import monix.execution.Scheduler.Implicits.global
 
   override implicit val handler: SttpHandler[Task, Observable[ByteBuffer]] =
-    OkHttpMonixClientHandler()
+    OkHttpMonixHandler()
 
 }


### PR DESCRIPTION
To be consistent with the Async Http Client handlers.

You could argue the others should be renamed, to be consistent with the package names :)