### PR TITLE
Fix NPE in HTTPUrlConnBackend in case of empty response

### DIFF
--- a/core/src/main/scala/com/softwaremill/sttp/HttpURLConnectionBackend.scala
+++ b/core/src/main/scala/com/softwaremill/sttp/HttpURLConnectionBackend.scala
@@ -204,7 +204,7 @@ class HttpURLConnectionBackend private (
       .flatMap { case (k, vv) => vv.asScala.map((k, _)) }
     val contentEncoding = Option(c.getHeaderField(ContentEncodingHeader))
     val code = c.getResponseCode
-    val wrappedIs = wrapInput(contentEncoding, is)
+    val wrappedIs = wrapInput(contentEncoding, handleNullInput(is))
     val body = if (codeIsSuccess(code)) {
       Right(readResponseBody(wrappedIs, responseAs))
     } else {
@@ -246,6 +246,12 @@ class HttpURLConnectionBackend private (
 
     }
   }
+
+  private def handleNullInput(is: InputStream): InputStream =
+    if (is == null)
+      new ByteArrayInputStream(Array.empty[Byte])
+    else
+      is
 
   private def wrapInput(contentEncoding: Option[String],
                         is: InputStream): InputStream =

--- a/tests/src/test/scala/com/softwaremill/sttp/BasicTests.scala
+++ b/tests/src/test/scala/com/softwaremill/sttp/BasicTests.scala
@@ -170,6 +170,17 @@ class BasicTests
         akka.pattern.after(1.second, using = actorSystem.scheduler)(
           Future.successful("Done"))
       }
+    } ~ path("empty_unauthorized_response") {
+      post {
+        import akka.http.scaladsl.model._
+        complete(
+          HttpResponse(
+            status = StatusCodes.Unauthorized,
+            headers = Nil,
+            entity = HttpEntity.Empty,
+            protocol = HttpProtocols.`HTTP/1.1`
+          ))
+      }
     }
 
   override def port = 51823
@@ -220,6 +231,7 @@ class BasicTests
     multipartTests()
     redirectTests()
     timeoutTests()
+    emptyResponseTests()
 
     def parseResponseTests(): Unit = {
       name should "parse response as string" in {
@@ -662,6 +674,18 @@ class BasicTests
           .response(asString)
 
         request.send().force().unsafeBody should be("Done")
+      }
+    }
+
+    def emptyResponseTests(): Unit = {
+      val postEmptyResponse = sttp
+        .post(uri"$endpoint/empty_unauthorized_response")
+        .body("{}")
+        .contentType("application/json")
+
+      name should "parse an empty error response as empty string" in {
+        val response = postEmptyResponse.send().force()
+        response.body should be(Left(""))
       }
     }
   }


### PR DESCRIPTION
I'm not sure of the exact conditions under which `HTTPUrlConnection#getInputStream()` can return null, but I added a test for the exact scenario that I encountered: client sends a POST request, server responds with a 401 with no body and no content-type.

Fixed with a simple null check.