### PR TITLE
Loading system proxy values by default

### DIFF
--- a/core/src/main/scala/com/softwaremill/sttp/SttpBackendOptions.scala
+++ b/core/src/main/scala/com/softwaremill/sttp/SttpBackendOptions.scala
@@ -47,7 +47,7 @@ object SttpBackendOptions {
     Empty.copy(proxy = loadSystemProxy)
 
   def connectionTimeout(ct: FiniteDuration): SttpBackendOptions =
-    Empty.connectionTimeout(ct)
+    Default.connectionTimeout(ct)
 
   def httpProxy(host: String, port: Int): SttpBackendOptions =
     Empty.httpProxy(host, port)

--- a/docs/conf/proxy.rst
+++ b/docs/conf/proxy.rst
@@ -1,7 +1,16 @@
 Proxy support
 =============
 
-A proxy can be specified when creating a backend::
+sttp library by default checks for your System proxy properties (`docs <https://docs.oracle.com/javase/8/docs/api/java/net/doc-files/net-properties.html>`_):
+
+Following settings are checked:
+
+1. ``socksProxyHost`` and ``socksProxyPort`` *(default: 1080)*
+2. ``http.proxyHost`` and ``http.proxyPort`` *(default: 80)*
+
+Settings are loaded **in given order** and the **first existing value** is being used.
+
+Otherwise, proxy values can be specified manually when creating a backend::
  
   import com.softwaremill.sttp._
   

--- a/docs/credits.rst
+++ b/docs/credits.rst
@@ -9,3 +9,4 @@ Credits
 * `Piotr Gabara <https://github.com/bhop>`_
 * `Gabriele Petronella <https://github.com/gabro>`_
 * `Paweł Stawicki <https://github.com/amorfis>`_
+* `Michał Siatkowski <https://github.com/atais>`_

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.0.2
+sbt.version=1.0.3


### PR DESCRIPTION
Like I have suggested in #10 I believe loading of System proxy values should be added.

I have created a simple code to handle that action.

----
Just a quick note:

I have found that generally, proxy topic is a bit broader: [link](https://stackoverflow.com/a/120802/1549135)

> Also don't forget the http.nonProxyHosts property! 

So this would mean some extra logic in the lib. However, I did not dive deeper into this as I did not find it necessary. Just mentioning fyi. 

Thanks!