### PR TITLE
#51 When stubbing using with thenRespondWithCode, treat 2xx as a success and return Right(body)

### DIFF
--- a/core/src/main/scala/com/softwaremill/sttp/testing/SttpBackendStub.scala
+++ b/core/src/main/scala/com/softwaremill/sttp/testing/SttpBackendStub.scala
@@ -91,8 +91,10 @@ class SttpBackendStub[R[_], S] private (
     def thenRespondServerError(): SttpBackendStub[R, S] =
       thenRespondWithCode(500, "Internal server error")
     def thenRespondWithCode(code: Int,
-                            msg: String = ""): SttpBackendStub[R, S] =
-      thenRespond(Response[Nothing](Left(msg), code, Nil, Nil))
+                            msg: String = ""): SttpBackendStub[R, S] = {
+      val body = if (code >= 200 && code < 300) Right(msg) else Left(msg)
+      thenRespond(Response(body, code, Nil, Nil))
+    }
     def thenRespond[T](body: T): SttpBackendStub[R, S] =
       thenRespond(Response[T](Right(body), 200, Nil, Nil))
     def thenRespond[T](resp: => Response[T]): SttpBackendStub[R, S] = {

--- a/core/src/test/scala/com/softwaremill/sttp/testing/SttpBackendStubTests.scala
+++ b/core/src/test/scala/com/softwaremill/sttp/testing/SttpBackendStubTests.scala
@@ -31,7 +31,7 @@ class SttpBackendStubTests extends FlatSpec with Matchers with ScalaFutures {
     implicit val b = testingStub
     val r = sttp.get(uri"http://example.org/a/b/c").send()
     r.is200 should be(true)
-    r.body should be('left)
+    r.body should be('right)
   }
 
   it should "use subsequent rules if the first doesn't match" in {
@@ -47,7 +47,7 @@ class SttpBackendStubTests extends FlatSpec with Matchers with ScalaFutures {
     implicit val b = testingStub
     val r = sttp.get(uri"http://example.org/a/b/c?p=v").send()
     r.is200 should be(true)
-    r.body should be('left)
+    r.body should be('right)
   }
 
   it should "use the default response if no rule matches" in {
@@ -105,6 +105,58 @@ class SttpBackendStubTests extends FlatSpec with Matchers with ScalaFutures {
       .send()
 
     result.body should be(Right(20))
+  }
+
+  it should "handle a 201 as a success" in {
+    implicit val s = SttpBackendStub(HttpURLConnectionBackend())
+      .whenAnyRequest
+      .thenRespondWithCode(201)
+
+    val result = sttp
+      .get(uri"http://example.org")
+      .send()
+
+    result.body should be(Right(""))
+
+  }
+
+  it should "handle a 300 as a failure" in {
+    implicit val s = SttpBackendStub(HttpURLConnectionBackend())
+      .whenAnyRequest
+      .thenRespondWithCode(300)
+
+    val result = sttp
+      .get(uri"http://example.org")
+      .send()
+
+    result.body should be(Left(""))
+
+  }
+
+  it should "handle a 400 as a failure" in {
+    implicit val s = SttpBackendStub(HttpURLConnectionBackend())
+      .whenAnyRequest
+      .thenRespondWithCode(400)
+
+    val result = sttp
+      .get(uri"http://example.org")
+      .send()
+
+    result.body should be(Left(""))
+
+  }
+
+  it should "handle a 500 as a failure" in {
+    implicit val s = SttpBackendStub(HttpURLConnectionBackend())
+      .whenAnyRequest
+      .thenRespondWithCode(500)
+
+    val result = sttp
+      .get(uri"http://example.org")
+      .send()
+
+    result.body should be(Left(""))
+
   }
 
   private val testingStubWithFallback = SttpBackendStub


### PR DESCRIPTION
Change SttpBackendStub so that response obey the contract that a 2xx will be returned as Right(xxx) and other codes will be Left(xxx).