### PR TITLE
Add TryMonad, implement a delegating TryBackend

### DIFF
--- a/core/src/main/scala/com/softwaremill/sttp/MonadError.scala
+++ b/core/src/main/scala/com/softwaremill/sttp/MonadError.scala
@@ -44,11 +44,12 @@ object IdMonad extends MonadError[Id] {
 object TryMonad extends MonadError[Try] {
   override def unit[T](t: T): Try[T] = Success(t)
   override def map[T, T2](fa: Try[T])(f: (T) => T2): Try[T2] = fa.map(f)
-  override def flatMap[T, T2](fa: Try[T])(f: (T) => Try[T2]): Try[T2] = fa.flatMap(f)
+  override def flatMap[T, T2](fa: Try[T])(f: (T) => Try[T2]): Try[T2] =
+    fa.flatMap(f)
 
   override def error[T](t: Throwable): Try[T] = Failure(t)
   override protected def handleWrappedError[T](rt: Try[T])(
-    h: PartialFunction[Throwable, Try[T]]): Try[T] = rt.recoverWith(h)
+      h: PartialFunction[Throwable, Try[T]]): Try[T] = rt.recoverWith(h)
 }
 class FutureMonad(implicit ec: ExecutionContext)
     extends MonadAsyncError[Future] {

--- a/core/src/main/scala/com/softwaremill/sttp/MonadError.scala
+++ b/core/src/main/scala/com/softwaremill/sttp/MonadError.scala
@@ -41,7 +41,15 @@ object IdMonad extends MonadError[Id] {
   override protected def handleWrappedError[T](rt: Id[T])(
       h: PartialFunction[Throwable, Id[T]]): Id[T] = rt
 }
+object TryMonad extends MonadError[Try] {
+  override def unit[T](t: T): Try[T] = Success(t)
+  override def map[T, T2](fa: Try[T])(f: (T) => T2): Try[T2] = fa.map(f)
+  override def flatMap[T, T2](fa: Try[T])(f: (T) => Try[T2]): Try[T2] = fa.flatMap(f)
 
+  override def error[T](t: Throwable): Try[T] = Failure(t)
+  override protected def handleWrappedError[T](rt: Try[T])(
+    h: PartialFunction[Throwable, Try[T]]): Try[T] = rt.recoverWith(h)
+}
 class FutureMonad(implicit ec: ExecutionContext)
     extends MonadAsyncError[Future] {
 

--- a/core/src/main/scala/com/softwaremill/sttp/TryBackend.scala
+++ b/core/src/main/scala/com/softwaremill/sttp/TryBackend.scala
@@ -19,11 +19,10 @@ class TryBackend[-S](delegate: SttpBackend[Id, S]) extends SttpBackend[Try, S] {
   override def responseMonad: MonadError[Try] = TryMonad
 }
 
-object TryBackend {
+object TryHttpUrlConnectionBackend {
   def apply(options: SttpBackendOptions = SttpBackendOptions.Default,
-            customizeConnection: HttpURLConnection => Unit = { _ =>
-              ()
-            }): SttpBackend[Try, Nothing] =
+            customizeConnection: HttpURLConnection => Unit = _ => ())
+    : SttpBackend[Try, Nothing] =
     new TryBackend[Nothing](
       HttpURLConnectionBackend(options, customizeConnection))
 }

--- a/core/src/main/scala/com/softwaremill/sttp/TryBackend.scala
+++ b/core/src/main/scala/com/softwaremill/sttp/TryBackend.scala
@@ -1,0 +1,29 @@
+package com.softwaremill.sttp
+
+import java.net.HttpURLConnection
+
+import scala.util.Try
+
+/** A Backend that safely wraps SttpBackend exceptions in Try's
+  *
+  * @param delegate An SttpBackend which to which this backend forwards all requests
+  * @tparam S The type of streams that are supported by the backend. `Nothing`,
+  *           if streaming requests/responses is not supported by this backend.
+  */
+class TryBackend[-S](delegate: SttpBackend[Id, S]) extends SttpBackend[Try, S] {
+  override def send[T](request: Request[T, S]): Try[Response[T]] =
+    Try(delegate.send(request))
+
+  override def close(): Unit = delegate.close()
+
+  override def responseMonad: MonadError[Try] = TryMonad
+}
+
+object TryBackend {
+  def apply(options: SttpBackendOptions = SttpBackendOptions.Default,
+            customizeConnection: HttpURLConnection => Unit = { _ =>
+              ()
+            }): SttpBackend[Try, Nothing] =
+    new TryBackend[Nothing](
+      HttpURLConnectionBackend(options, customizeConnection))
+}

--- a/docs/backends/summary.rst
+++ b/docs/backends/summary.rst
@@ -18,6 +18,7 @@ Below is a summary of all the backends. See the sections on individual backend i
 Class                            Response wrapper             Supported stream type
 ================================ ============================ ================================================
 ``HttpURLConnectionBackend``     None (``Id``)                n/a 
+``TryBackend``                   ``scala.util.Try``                      n/a
 ``AkkaHttpBackend``              ``scala.concurrent.Future``  ``akka.stream.scaladsl.Source[ByteString, Any]``
 ``AsyncHttpClientFutureBackend`` ``scala.concurrent.Future``  n/a
 ``AsyncHttpClientScalazBackend`` ``scalaz.concurrent.Task``   n/a

--- a/docs/backends/summary.rst
+++ b/docs/backends/summary.rst
@@ -18,7 +18,7 @@ Below is a summary of all the backends. See the sections on individual backend i
 Class                            Response wrapper             Supported stream type
 ================================ ============================ ================================================
 ``HttpURLConnectionBackend``     None (``Id``)                n/a 
-``TryBackend``                   ``scala.util.Try``                      n/a
+``TryHttpURLConnectionBackend``  ``scala.util.Try``           n/a
 ``AkkaHttpBackend``              ``scala.concurrent.Future``  ``akka.stream.scaladsl.Source[ByteString, Any]``
 ``AsyncHttpClientFutureBackend`` ``scala.concurrent.Future``  n/a
 ``AsyncHttpClientScalazBackend`` ``scalaz.concurrent.Task``   n/a

--- a/tests/src/test/scala/com/softwaremill/sttp/BasicTests.scala
+++ b/tests/src/test/scala/com/softwaremill/sttp/BasicTests.scala
@@ -197,6 +197,10 @@ class BasicTests
 
   runTests("HttpURLConnection")(HttpURLConnectionBackend(),
                                 ForceWrappedValue.id)
+
+  runTests("TryHttpURLConnection")(TryHttpUrlConnectionBackend(),
+                                   ForceWrappedValue.scalaTry)
+
   runTests("Akka HTTP")(AkkaHttpBackend.usingActorSystem(actorSystem),
                         ForceWrappedValue.future)
   runTests("Async Http Client - Future")(AsyncHttpClientFutureBackend(),

--- a/tests/src/test/scala/com/softwaremill/sttp/testHelpers.scala
+++ b/tests/src/test/scala/com/softwaremill/sttp/testHelpers.scala
@@ -15,6 +15,7 @@ import org.scalatest.{BeforeAndAfterAll, Suite}
 import scala.concurrent.Future
 import scala.concurrent.duration._
 import scala.language.higherKinds
+import scala.util.Try
 import scalaz._
 
 trait TestHttpServer
@@ -50,6 +51,11 @@ object ForceWrappedValue extends ScalaFutures with TestingPatience {
     override def force[T](wrapped: Id[T]): T =
       wrapped
   }
+
+  val scalaTry = new ForceWrappedValue[Try] {
+    override def force[T](wrapped: Try[T]): T = wrapped.get
+  }
+
   val future = new ForceWrappedValue[Future] {
 
     override def force[T](wrapped: Future[T]): T =


### PR DESCRIPTION
Allows users to use a simple synchronous HTTP backend which doesn't throw exception.