### PR TITLE
Remove dependence on StringTokenizer

### DIFF
--- a/core/src/main/scala/com/softwaremill/sttp/Response.scala
+++ b/core/src/main/scala/com/softwaremill/sttp/Response.scala
@@ -3,13 +3,7 @@ package com.softwaremill.sttp
 import java.net.HttpCookie
 import java.text.SimpleDateFormat
 import java.time.ZonedDateTime
-import java.util.{
-  Calendar,
-  GregorianCalendar,
-  Locale,
-  StringTokenizer,
-  TimeZone
-}
+import java.util.{Calendar, GregorianCalendar, Locale, TimeZone}
 
 import scala.collection.JavaConverters._
 import scala.collection.immutable.Seq
@@ -75,12 +69,11 @@ object Cookie {
     // hand-parsing in such case to preserve the values from the cookie
     val lch = h.toLowerCase
     val (expires, maxAge) = if (lch.contains("expires=")) {
-      val tokenizer = new StringTokenizer(h, ";")
+      val tokens = h.split(";")
       var e: Option[ZonedDateTime] = None
       var ma: Option[Long] = None
 
-      while (tokenizer.hasMoreTokens) {
-        val t = tokenizer.nextToken()
+      for (t <- tokens) {
         val nv = t.split("=", 2)
         if (nv(0).toLowerCase.contains("expires") && nv.length > 1) {
           e = expiryDate2ZonedDateTime(nv(1).trim())


### PR DESCRIPTION
StringTokenizer is not supported by Scala.js (#57 ), and rather than implement it, since the [official docs](https://docs.oracle.com/javase/7/docs/api/java/util/StringTokenizer.html) claims that   
  
>StringTokenizer is a legacy class that is retained for compatibility reasons although its use is discouraged in new code. It is recommended that anyone seeking this functionality use the split method of String or the java.util.regex package instead.
  
I figure it is easier to just use `String.split`


