### PR TITLE
Allow SttpBackendStub to accept monad with response

### DIFF
--- a/core/src/main/scala/com/softwaremill/sttp/testing/SttpBackendStub.scala
+++ b/core/src/main/scala/com/softwaremill/sttp/testing/SttpBackendStub.scala
@@ -28,7 +28,7 @@ import scala.util.{Failure, Success, Try}
   */
 class SttpBackendStub[R[_], S] private (
     rm: MonadError[R],
-    matchers: PartialFunction[Request[_, _], Response[_]],
+    matchers: PartialFunction[Request[_, _], R[Response[_]]],
     fallback: Option[SttpBackend[R, S]])
     extends SttpBackend[R, S] {
 
@@ -60,13 +60,14 @@ class SttpBackendStub[R[_], S] private (
   def whenRequestMatchesPartial(
       partial: PartialFunction[Request[_, _], Response[_]])
     : SttpBackendStub[R, S] = {
-    new SttpBackendStub(rm, matchers.orElse(partial), fallback)
+    val wrappedPartial = partial.andThen(rm.unit)
+    new SttpBackendStub(rm, matchers.orElse(wrappedPartial), fallback)
   }
 
   override def send[T](request: Request[T, S]): R[Response[T]] = {
     Try(matchers.lift(request)) match {
-      case Success(Some(response)) =>
-        wrapResponse(tryAdjustResponseType(request.response, response))
+      case Success(Some(responseMonad)) =>
+        tryAdjustResponseType(rm, request.response, wrapResponse(responseMonad))
       case Success(None) =>
         fallback match {
           case None =>
@@ -85,6 +86,9 @@ class SttpBackendStub[R[_], S] private (
   private def wrapResponse[T](r: Response[_]): R[Response[T]] =
     rm.unit(r.asInstanceOf[Response[T]])
 
+  private def wrapResponse[T](r: R[Response[_]]): R[Response[T]] =
+    rm.map(r)(_.asInstanceOf[Response[T]])
+
   override def close(): Unit = {}
 
   override def responseMonad: MonadError[R] = rm
@@ -99,12 +103,13 @@ class SttpBackendStub[R[_], S] private (
     def thenRespondWithCode(code: Int,
                             msg: String = ""): SttpBackendStub[R, S] = {
       val body = if (code >= 200 && code < 300) Right(msg) else Left(msg)
-      thenRespond(Response(body, code, msg, Nil, Nil))
+      thenRespondWithMonad(rm.unit(Response(body, code, msg, Nil, Nil)))
     }
     def thenRespond[T](body: T): SttpBackendStub[R, S] =
-      thenRespond(Response[T](Right(body), 200, "OK", Nil, Nil))
-    def thenRespond[T](resp: => Response[T]): SttpBackendStub[R, S] = {
-      val m: PartialFunction[Request[_, _], Response[_]] = {
+      thenRespondWithMonad(
+        rm.unit(Response[T](Right(body), 200, "OK", Nil, Nil)))
+    def thenRespondWithMonad(resp: => R[Response[_]]): SttpBackendStub[R, S] = {
+      val m: PartialFunction[Request[_, _], R[Response[_]]] = {
         case r if p(r) => resp
       }
       new SttpBackendStub(rm, matchers.orElse(m), fallback)
@@ -159,13 +164,19 @@ object SttpBackendStub {
                                PartialFunction.empty,
                                Some(fallback))
 
-  private[sttp] def tryAdjustResponseType[T, U](ra: ResponseAs[T, _],
-                                                r: Response[U]): Response[_] = {
-    r.body match {
-      case Left(_) => r
-      case Right(body) =>
-        val newBody: Any = tryAdjustResponseBody(ra, body).getOrElse(body)
-        r.copy(body = Right(newBody))
+  private[sttp] def tryAdjustResponseType[DesiredRType, RType, M[_]](
+      rm: MonadError[M],
+      ra: ResponseAs[DesiredRType, _],
+      m: M[Response[RType]]): M[Response[DesiredRType]] = {
+    rm.map[Response[RType], Response[DesiredRType]](m) { r =>
+      r.body match {
+        case Left(_) => r.asInstanceOf[Response[DesiredRType]]
+        case Right(body) =>
+          val newBody: Any = tryAdjustResponseBody(ra, body).getOrElse(body)
+          r.copy(
+            body =
+              Right[String, DesiredRType](newBody.asInstanceOf[DesiredRType]))
+      }
     }
   }
 

--- a/core/src/test/scala/com/softwaremill/sttp/testing/SttpBackendStubTests.scala
+++ b/core/src/test/scala/com/softwaremill/sttp/testing/SttpBackendStubTests.scala
@@ -28,6 +28,8 @@ class SttpBackendStubTests extends FlatSpec with Matchers with ScalaFutures {
             List("partialAda")) =>
         Response(Right("Ada"), 200, "OK", Nil, Nil)
     })
+    .whenRequestMatches(_.uri.port.exists(_ == 8080))
+    .thenRespondWithMonad(Response(Right("OK from monad"), 200, "OK", Nil, Nil))
 
   "backend stub" should "use the first rule if it matches" in {
     implicit val b = testingStub
@@ -50,6 +52,14 @@ class SttpBackendStubTests extends FlatSpec with Matchers with ScalaFutures {
     val r = sttp.get(uri"http://example.org/a/b/c?p=v").send()
     r.is200 should be(true)
     r.body should be('right)
+  }
+
+  it should "respond with monad with set response" in {
+    implicit val b = testingStub
+    val r = sttp.post(uri"http://example.org:8080").send()
+    r.is200 should be(true)
+    r.body should be('right)
+    r.body.right.get should be("OK from monad")
   }
 
   it should "use the default response if no rule matches" in {

--- a/core/src/test/scala/com/softwaremill/sttp/testing/SttpBackendStubTests.scala
+++ b/core/src/test/scala/com/softwaremill/sttp/testing/SttpBackendStubTests.scala
@@ -159,18 +159,15 @@ class SttpBackendStubTests extends FlatSpec with Matchers with ScalaFutures {
 
   it should "not hold the calling thread when passed a future monad" in {
     val LongTimeMillis = 10000L
-
-    val fm = new FutureMonad()
-    val f = Future {
-      Thread.sleep(LongTimeMillis)
-      Response(Right("OK"), 200, "", Nil, Nil)
-    }
-
     val before = System.currentTimeMillis()
-    implicit val s = SttpBackendStub(fm).whenAnyRequest
-      .thenRespondWithMonad(f)
 
-    val result = sttp
+    implicit val s = SttpBackendStub(new FutureMonad()).whenAnyRequest
+      .thenRespondWithMonad(Future {
+        Thread.sleep(LongTimeMillis)
+        Response(Right("OK"), 200, "", Nil, Nil)
+      })
+
+    sttp
       .get(uri"http://example.org")
       .send()
 

--- a/core/src/test/scala/com/softwaremill/sttp/testing/SttpBackendStubTests.scala
+++ b/core/src/test/scala/com/softwaremill/sttp/testing/SttpBackendStubTests.scala
@@ -79,7 +79,7 @@ class SttpBackendStubTests extends FlatSpec with Matchers with ScalaFutures {
   it should "handle exceptions thrown instead of a response (synchronous)" in {
     implicit val s = SttpBackendStub(HttpURLConnectionBackend())
       .whenRequestMatches(_ => true)
-      .thenRespondWithMonad(throw new TimeoutException())
+      .thenRespond(throw new TimeoutException())
 
     a[TimeoutException] should be thrownBy {
       sttp.get(uri"http://example.org").send()
@@ -89,7 +89,7 @@ class SttpBackendStubTests extends FlatSpec with Matchers with ScalaFutures {
   it should "handle exceptions thrown instead of a response (asynchronous)" in {
     implicit val s = SttpBackendStub(new FutureMonad())
       .whenRequestMatches(_ => true)
-      .thenRespondWithMonad(throw new TimeoutException())
+      .thenRespond(throw new TimeoutException())
 
     val result = sttp.get(uri"http://example.org").send()
     result.failed.futureValue shouldBe a[TimeoutException]

--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -49,6 +49,18 @@ It is also possible to match requests by partial function, returning a response.
 
 This approach to testing has one caveat: the responses are not type-safe. That is, the stub backend cannot match on or verify that the type of the response body matches the response body type requested.
 
+Another way to specify the behaviour is passing a response monad to Stub. It is useful if you need to test scenario with slow server, when response should be not returned immediately but after some time.
+Example with Futures: ::
+
+  implicit val testingBackend = SttpBackendStub(new FutureMonad()).whenAnyRequest
+    .thenRespondWithMonad(Future {
+      Thread.sleep(5000)
+      Response(Right("OK"), 200, "", Nil, Nil)
+    })
+
+  val respFuture = sttp.get(uri"http://example.org").send()
+  // responseFuture will complete after 10 seconds with "OK" response
+
 Simulating exceptions
 ---------------------
 


### PR DESCRIPTION
This is the only way not to hold thread busy when testing with SttpBackendStub and Futures with long response time (to test, well, scenario when server takes a long time to respond).