### PR TITLE
Removing usage of java.net.URLDecoder from core

### DIFF
--- a/core/shared/src/main/scala/com/softwaremill/sttp/ResponseAs.scala
+++ b/core/shared/src/main/scala/com/softwaremill/sttp/ResponseAs.scala
@@ -1,7 +1,5 @@
 package com.softwaremill.sttp
 
-import java.net.URLDecoder
-
 import com.softwaremill.sttp.internal.SttpFile
 
 import scala.collection.immutable.Seq
@@ -44,7 +42,7 @@ object ResponseAs {
       .flatMap(kv =>
         kv.split("=", 2) match {
           case Array(k, v) =>
-            Some((URLDecoder.decode(k, encoding), URLDecoder.decode(v, encoding)))
+            Some((Rfc3986.decode()(k, encoding), Rfc3986.decode()(v, encoding)))
           case _ => None
       })
   }

--- a/core/shared/src/main/scala/com/softwaremill/sttp/Rfc3986.scala
+++ b/core/shared/src/main/scala/com/softwaremill/sttp/Rfc3986.scala
@@ -41,7 +41,7 @@ object Rfc3986 {
     sb.toString
   }
 
-  def decode(plusAsSpace: Boolean = false)(s: String): String = {
+  def decode(plusAsSpace: Boolean = false)(s: String, enc: String = Utf8): String = {
     // Copied from URLDecoder.decode with additional + handling (first case)
 
     var needToChange = false
@@ -86,7 +86,7 @@ object Rfc3986 {
             // "%x" will cause an exception to be thrown
             if ((i < numChars) && (c == '%'))
               throw new IllegalArgumentException("URLDecoder: Incomplete trailing escape (%) pattern")
-            sb.append(new String(bytes, 0, pos, Utf8))
+            sb.append(new String(bytes, 0, pos, enc))
           } catch {
             case e: NumberFormatException =>
               throw new IllegalArgumentException(


### PR DESCRIPTION
Since there is no `java.net.URLDecoder` in `scala-native` and the decode functionality is implemented in `Rfc3986` class, it would be handy to get rid of that dependency in the entire `core` module.