### PR TITLE
Differentiate between readTimeout and requestTimeout

### DIFF
--- a/async-http-client-backend/src/main/scala/com/softwaremill/sttp/asynchttpclient/AsyncHttpClientBackend.scala
+++ b/async-http-client-backend/src/main/scala/com/softwaremill/sttp/asynchttpclient/AsyncHttpClientBackend.scala
@@ -152,6 +152,7 @@ abstract class AsyncHttpClientBackend[R[_], S](asyncHttpClient: AsyncHttpClient,
     val rb = new RequestBuilder(r.method.m)
       .setUrl(r.uri.toString)
       .setReadTimeout(if (readTimeout.isFinite()) readTimeout.toMillis.toInt else -1)
+      .setRequestTimeout(if (readTimeout.isFinite()) readTimeout.toMillis.toInt else -1)
     r.headers.foreach { case (k, v) => rb.setHeader(k, v) }
     setBody(r, r.body, rb)
     rb.build()

--- a/docs/backends/asynchttpclient.rst
+++ b/docs/backends/asynchttpclient.rst
@@ -74,13 +74,15 @@ And receive responses as an observable stream::
   import java.nio.ByteBuffer
   import monix.eval.Task
   import monix.reactive.Observable
-  
+  import scala.concurrent.duration.Duration
+
   implicit val sttpBackend = AsyncHttpClientMonixBackend()
   
   val response: Task[Response[Observable[ByteBuffer]]] = 
     sttp
       .post(uri"...")
       .response(asStream[Observable[ByteBuffer]])
+      .readTimeout(Duration.Inf)
       .send()
 
 Streaming using fs2
@@ -113,6 +115,7 @@ Responses can also be streamed::
   import java.nio.ByteBuffer
   import cats.effect.IO
   import fs2.Stream
+  import scala.concurrent.duration.Duration
 
   implicit val sttpBackend = AsyncHttpClientFs2Backend[IO]()
 
@@ -120,4 +123,5 @@ Responses can also be streamed::
     sttp
       .post(uri"...")
       .response(asStream[Stream[IO, ByteBuffer]])
+      .readTimeout(Duration.Inf)
       .send()


### PR DESCRIPTION
Up until version 1.1.14, configuring the `readTimeout` for an sttp request actually configured the `requestTimeout` internally for the asynchttpclient request. However, this behavior was modified in this PR https://github.com/softwaremill/sttp/pull/90 to make things more consistent where setting the `readTimeout` for an sttp request also set the `readTimeout` for an asynchttpclient request.

It appears, however, that this is not enough when making long-lived, streaming requests similar to the following:

    val response: IO[Response[Stream[IO, ByteBuffer]]] =
      sttp
        .post(uri"...")
        .response(asStream[Stream[IO, ByteBuffer]])
        .send()
Which always keep timing out after 60,000ms. Using `readTimeout` to try to prolong the request timeout obviously has no effect.

What this means is that we need to expose the ability to configure the `requestTimeout` in addition to the `readTimeout`. 