### PR TITLE
fix error with empty charset in header

### DIFF
--- a/core/shared/src/main/scala/com/softwaremill/sttp/internal/package.scala
+++ b/core/shared/src/main/scala/com/softwaremill/sttp/internal/package.scala
@@ -11,7 +11,7 @@ package object internal {
 
   private[sttp] def encodingFromContentType(ct: String): Option[String] =
     ct.split(";").map(_.trim.toLowerCase).collectFirst {
-      case s if s.startsWith("charset=") && s.substring(8) != "" => s.substring(8)
+      case s if s.startsWith("charset=") && s.substring(8).trim != "" => s.substring(8).trim
     }
 
   private[sttp] def transfer(is: InputStream, os: OutputStream): Unit = {

--- a/core/shared/src/main/scala/com/softwaremill/sttp/internal/package.scala
+++ b/core/shared/src/main/scala/com/softwaremill/sttp/internal/package.scala
@@ -11,7 +11,7 @@ package object internal {
 
   private[sttp] def encodingFromContentType(ct: String): Option[String] =
     ct.split(";").map(_.trim.toLowerCase).collectFirst {
-      case s if s.startsWith("charset=") => s.substring(8)
+      case s if s.startsWith("charset=") && s.substring(8) != "" => s.substring(8)
     }
 
   private[sttp] def transfer(is: InputStream, os: OutputStream): Unit = {


### PR DESCRIPTION
I had an issue with a RSS feed that gave a bad header.

```
implicit val backend = HttpURLConnectionBackend()
sttp.get(uri"http://rss.dw.com/xml/podcast_inside-europe").send()
```
This threw an exeception. `java.nio.charset.IllegalCharsetNameException`

With `curl` I get a this header.
```
HTTP/1.1 200 OK
Date: Fri, 20 Jul 2018 20:04:26 GMT
Content-Type: application/xml; charset=
Vary: Accept-Encoding
Access-Control-Allow-Origin: *
Set-Cookie: SERVERID=s2; path=/
Cache-control: private
Age: 0
Accept-Ranges: bytes
Connection: keep-alive
```

The `charset` is not defined properly.

This PR fixes the problem and allows me to get the data from the RSS feed.

If you need more details let me know.