### PR TITLE
Fixing tests for Core Native

### DIFF
--- a/core/jvm/src/test/scala/com/softwaremill/sttp/testing/HttpTestExtensions.scala
+++ b/core/jvm/src/test/scala/com/softwaremill/sttp/testing/HttpTestExtensions.scala
@@ -94,7 +94,7 @@ trait HttpTestExtensions[R[_]] extends TestHttpServer { self: HttpTest[R] =>
     }
   }
 
-  // scalajs only supports US_ASCII, ISO_8859_1, UTF_8, UTF_16BE, UTF_16LE, UTF_16
+  // scalajs and scala native only support US_ASCII, ISO_8859_1, UTF_8, UTF_16BE, UTF_16LE, UTF_16
   "encoding" - {
     "read response body encoded using ISO-8859-2, as specified in the header, overriding the default" in {
       val request = sttp.get(uri"$endpoint/respond_with_iso_8859_2")

--- a/core/native/src/main/scala/com/softwaremill/sttp/FileHelpers.scala
+++ b/core/native/src/main/scala/com/softwaremill/sttp/FileHelpers.scala
@@ -2,6 +2,7 @@ package com.softwaremill.sttp
 
 import com.softwaremill.sttp.internal._
 import java.io.{File, FileOutputStream, IOException, InputStream}
+import java.nio.file.AccessDeniedException
 
 object FileHelpers {
 
@@ -10,7 +11,11 @@ object FileHelpers {
       if (file.getParentFile != null) {
         file.getParentFile.mkdirs()
       }
-      file.createNewFile()
+      try {
+        file.createNewFile()
+      } catch {
+        case e: AccessDeniedException => throw new IOException("Permission denied", e) // aligns SN bahavior with Java
+      }
     } else if (!overwrite) {
       throw new IOException(s"File ${file.getAbsolutePath} exists - overwriting prohibited")
     }

--- a/core/native/src/test/scala/com/softwaremill/sttp/testing/SyncHttpTestExtensions.scala
+++ b/core/native/src/test/scala/com/softwaremill/sttp/testing/SyncHttpTestExtensions.scala
@@ -49,16 +49,6 @@ trait SyncHttpTestExtensions {
     }
   }
 
-  // scalajs only supports US_ASCII, ISO_8859_1, UTF_8, UTF_16BE, UTF_16LE, UTF_16
-  "encoding" - {
-    "read response body encoded using ISO-8859-2, as specified in the header, overriding the default" in {
-      val request = sttp.get(uri"$endpoint/respond_with_iso_8859_2")
-
-      val response = request.send()
-        response.unsafeBody should be("Żółć!")
-    }
-  }
-
   private def withTemporaryFile[T](content: Option[Array[Byte]])(f: File => T): T = {
     val file = Files.createTempFile("sttp", "sttp")
     content match {


### PR DESCRIPTION
There were two tests failing:
* different error message when file creation fails - 8af00ec unifies the behavior with JVM.
* missing `ISO-8859-2` support - similarly to ScalaJS, Native doesn't support that encoding, but on the way, I detected that no support for response content encoding was implemented. 09b2298 adds it.