### PR TITLE
Curl Backend: fixing unpredictable behavior when empty response

### DIFF
--- a/core/native/src/main/scala/com/softwaremill/sttp/AbstractCurlBackend.scala
+++ b/core/native/src/main/scala/com/softwaremill/sttp/AbstractCurlBackend.scala
@@ -143,10 +143,10 @@ abstract class AbstractCurlBackend[R[_], S](rm: MonadError[R], verbose: Boolean)
 
   private def responseSpace: CurlSpaces = {
     val bodyResp = malloc(sizeof[CurlFetch]).cast[Ptr[CurlFetch]]
-    !bodyResp._1 = malloc(4096).cast[CString]
+    !bodyResp._1 = calloc(4096, sizeof[CChar]).cast[CString]
     !bodyResp._2 = 0
     val headersResp = malloc(sizeof[CurlFetch]).cast[Ptr[CurlFetch]]
-    !headersResp._1 = malloc(4096).cast[CString]
+    !headersResp._1 = calloc(4096, sizeof[CChar]).cast[CString]
     !headersResp._2 = 0
     val httpCode = malloc(sizeof[Long]).cast[Ptr[Long]]
     new CurlSpaces(bodyResp, headersResp, httpCode)


### PR DESCRIPTION
The space allocated via `malloc` contains garbage and if there is no zero-terminated content in the response from curl, that space stays untouched and garbage is returned to the user.