### PR TITLE
Fixing the parsing of nonProxyHosts

### DIFF
--- a/core/shared/src/main/scala/com/softwaremill/sttp/SttpBackendOptions.scala
+++ b/core/shared/src/main/scala/com/softwaremill/sttp/SttpBackendOptions.scala
@@ -101,7 +101,7 @@ object SttpBackendOptions {
       def nonProxyHosts: List[String] = {
         nonProxyHostsPropOption
           .map(nonProxyHostsProp => Try(System.getProperty(nonProxyHostsProp)).toOption.getOrElse("localhost|127.*"))
-          .map(_.split("|").toList)
+          .map(_.split('|').toList)
           .getOrElse(Nil)
       }
       host.map(make(_, port, nonProxyHosts))


### PR DESCRIPTION
related to #132 

Passing the regex `"|"` to the split function would split the string on each character, i.e. `"localhost|127.*"` into `List("l", "o", "c", "a", ...)`. By passing `'|'` instead, the string will be splitted correctly into `List("localhost", "127.*")`.