### PR TITLE
Filter out Some(null)

### DIFF
--- a/core/js/src/main/scala/com/softwaremill/sttp/AbstractFetchBackend.scala
+++ b/core/js/src/main/scala/com/softwaremill/sttp/AbstractFetchBackend.scala
@@ -209,6 +209,7 @@ abstract class AbstractFetchBackend[R[_], S](options: FetchOptions)(rm: MonadErr
         val charset = response.headers
           .get(HeaderNames.ContentType)
           .toOption
+          .filter(_ != null)
           .flatMap(encodingFromContentType)
           .getOrElse(enc)
         if (charset.compareToIgnoreCase(Utf8) == 0) transformPromise(response.text())


### PR DESCRIPTION
When `response.headers.get(HeaderNames.ContentType)` returns `null`, then `_.toOption` returns `Some(null)`. The implementation of `encodingFromContentType` suggests that it is not what you expected.