### PR TITLE
Fix NullPointerException of nonProxyHosts

### DIFF
--- a/core/shared/src/main/scala/com/softwaremill/sttp/SttpBackendOptions.scala
+++ b/core/shared/src/main/scala/com/softwaremill/sttp/SttpBackendOptions.scala
@@ -100,7 +100,7 @@ object SttpBackendOptions {
       def port = Try(System.getProperty(portProp).toInt).getOrElse(defaultPort)
       def nonProxyHosts: List[String] = {
         nonProxyHostsPropOption
-          .map(nonProxyHostsProp => Option(System.getProperty(nonProxyHostsProp)).getOrElse("localhost|127.*"))
+          .map(nonProxyHostsProp => Try(Option(System.getProperty(nonProxyHostsProp))).toOption.flatten.getOrElse("localhost|127.*"))
           .map(_.split('|').toList)
           .getOrElse(Nil)
       }

--- a/core/shared/src/main/scala/com/softwaremill/sttp/SttpBackendOptions.scala
+++ b/core/shared/src/main/scala/com/softwaremill/sttp/SttpBackendOptions.scala
@@ -100,7 +100,7 @@ object SttpBackendOptions {
       def port = Try(System.getProperty(portProp).toInt).getOrElse(defaultPort)
       def nonProxyHosts: List[String] = {
         nonProxyHostsPropOption
-          .map(nonProxyHostsProp => Try(System.getProperty(nonProxyHostsProp)).toOption.getOrElse("localhost|127.*"))
+          .map(nonProxyHostsProp => Option(System.getProperty(nonProxyHostsProp)).getOrElse("localhost|127.*"))
           .map(_.split('|').toList)
           .getOrElse(Nil)
       }


### PR DESCRIPTION
When System.getProperty(nonProxyHostsProp) returns null, the value becomes Success(null) by Try and NullPointerException occurs.