### PR TITLE
Update to fs2 v1.0.0-RC1

### DIFF
--- a/async-http-client-backend/fs2/src/test/scala/com/softwaremill/sttp/asynchttpclient/fs2/AsyncHttpClientFs2HttpStreamingTest.scala
+++ b/async-http-client-backend/fs2/src/test/scala/com/softwaremill/sttp/asynchttpclient/fs2/AsyncHttpClientFs2HttpStreamingTest.scala
@@ -2,7 +2,7 @@ package com.softwaremill.sttp.asynchttpclient.fs2
 
 import java.nio.ByteBuffer
 
-import cats.effect.{ContextShift, IO, Timer}
+import cats.effect.{ContextShift, IO}
 import cats.instances.string._
 import com.softwaremill.sttp.SttpBackend
 import com.softwaremill.sttp.testing.streaming.StreamingTest
@@ -14,7 +14,6 @@ import scala.concurrent.{Future, ExecutionContext}
 class AsyncHttpClientFs2HttpStreamingTest extends StreamingTest[IO, Stream[IO, ByteBuffer]] {
 
   private implicit val cs: ContextShift[IO] = IO.contextShift(ExecutionContext.Implicits.global)
-  private implicit val t: Timer[IO] = IO.timer(ExecutionContext.Implicits.global)
 
   override implicit val backend: SttpBackend[IO, Stream[IO, ByteBuffer]] = AsyncHttpClientFs2Backend[IO]()
 

--- a/async-http-client-backend/fs2/src/test/scala/com/softwaremill/sttp/asynchttpclient/fs2/AsyncHttpClientFs2HttpTest.scala
+++ b/async-http-client-backend/fs2/src/test/scala/com/softwaremill/sttp/asynchttpclient/fs2/AsyncHttpClientFs2HttpTest.scala
@@ -9,7 +9,6 @@ import scala.concurrent.{ExecutionContext, Future}
 class AsyncHttpClientFs2HttpTest extends HttpTest[IO] {
 
   private implicit val cs: ContextShift[IO] = IO.contextShift(ExecutionContext.Implicits.global)
-  private implicit val t: Timer[IO] = IO.timer(ExecutionContext.Implicits.global)
 
   override implicit val backend: SttpBackend[IO, Nothing] = AsyncHttpClientFs2Backend()
   override implicit val convertToFuture: ConvertToFuture[IO] = new ConvertToFuture[IO] {

--- a/build.sbt
+++ b/build.sbt
@@ -308,7 +308,7 @@ lazy val asyncHttpClientFs2Backend: Project =
   asyncHttpClientBackendProject("fs2")
     .settings(
       libraryDependencies ++= Seq(
-        "com.github.zainab-ali" %% "fs2-reactive-streams" % "0.8.0"
+        "co.fs2" %% "fs2-reactive-streams" % "1.0.0-RC1"
       )
     )
     .dependsOn(catsJVM % "compile->compile;test->test")

--- a/core/shared/src/main/scala/com/softwaremill/sttp/SttpApi.scala
+++ b/core/shared/src/main/scala/com/softwaremill/sttp/SttpApi.scala
@@ -7,7 +7,6 @@ import com.softwaremill.sttp.internal._
 
 import scala.collection.immutable.Seq
 import scala.concurrent.duration._
-import scala.language.higherKinds
 
 trait SttpApi extends SttpExtensions {
 


### PR DESCRIPTION
Note: We probably don't want a release that depends on RC1 since 1.0.0 is scheduled for ~October 5. I opened this to make sure sttp is source compatible with the latest release candidate.

Highlights: fs2-reactive-streams is now published in the `co.fs2` organization