### PR TITLE
Add play-json support

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -146,6 +146,7 @@ lazy val rootJVM = project
     circeJVM,
     json4s,
     sprayJson,
+    playJsonJVM,
     braveBackend,
     prometheusBackend
   )
@@ -154,7 +155,7 @@ lazy val rootJS = project
   .in(file(".js"))
   .settings(commonJvmJsSettings: _*)
   .settings(skip in publish := true, name := "sttpJS")
-  .aggregate(coreJS, catsJS, monixJS, circeJS)
+  .aggregate(coreJS, catsJS, monixJS, circeJS, playJsonJS)
 
 lazy val rootNative = project
   .in(file(".native"))
@@ -376,6 +377,22 @@ lazy val sprayJson: Project = (project in file("json/spray-json"))
     )
   )
   .dependsOn(coreJVM)
+
+lazy val playJson = crossProject(JSPlatform, JVMPlatform)
+  .withoutSuffixFor(JVMPlatform)
+  .crossType(CrossType.Pure)
+  .in(file("json/play-json"))
+  .jsSettings(commonJsSettings: _*)
+  .jvmSettings(commonJvmSettings: _*)
+  .settings(
+    name := "play-json",
+    libraryDependencies ++= Seq(
+      "com.typesafe.play" %%% "play-json" % "2.6.10",
+      "org.scalatest" %%% "scalatest" % scalaTestVersion % "test"
+    )
+  )
+lazy val playJsonJS = playJson.js.dependsOn(coreJS)
+lazy val playJsonJVM = playJson.jvm.dependsOn(coreJVM)
 
 lazy val braveVersion = "5.2.0"
 

--- a/json/play-json/src/main/scala/com/softwaremill/sttp/playjson/package.scala
+++ b/json/play-json/src/main/scala/com/softwaremill/sttp/playjson/package.scala
@@ -1,0 +1,22 @@
+package com.softwaremill.sttp
+
+import scala.util.{Try, Failure, Success}
+
+import play.api.libs.json._
+import com.softwaremill.sttp.internal.Utf8
+
+package object playJson {
+  implicit def playJsonBodySerializer[B : Writes]: BodySerializer[B] =
+    b => StringBody(Json.stringify(Json.toJson(b)), Utf8, Some(MediaTypes.Json))
+
+  // Note: None of the play-json utilities attempt to catch invalid
+  // json, so Json.parse needs to be wrapped in Try
+  def asJson[B : Reads]: ResponseAs[Either[DeserializationError[JsError], B], Nothing] =
+    asString(Utf8).map { string =>
+      val parsed: Either[JsError, B] = Try(Json.parse(string)) match {
+        case Failure(t) => Left(JsError(t.getMessage))
+        case Success(json) => Json.fromJson(json).asEither.left.map(JsError(_))
+      }
+      parsed.left.map(e => DeserializationError(string, e, Json.prettyPrint(JsError.toJson(e))))
+    }
+}

--- a/json/play-json/src/test/scala/com/softwaremill/sttp/PlayJsonTests.scala
+++ b/json/play-json/src/test/scala/com/softwaremill/sttp/PlayJsonTests.scala
@@ -1,0 +1,102 @@
+package com.softwaremill.sttp
+
+import com.softwaremill.sttp.internal._
+import com.softwaremill.sttp.playJson._
+
+import play.api.libs.json._
+import org.scalatest._
+
+class PlayJsonTests extends FlatSpec with Matchers with EitherValues {
+
+  "The play-json module" should "write arbitrary bodies given a Format" in {
+    implicitly[Format[Outer]]
+
+    val body = Outer(Inner(42, true, "horses"), "cats")
+    val expected = """{"foo":{"a":42,"b":true,"c":"horses"},"bar":"cats"}"""
+
+    val req = sttp.body(body)
+
+    extractBody(req) shouldBe expected
+  }
+
+  it should "read arbitrary bodies" in {
+    val body = """{"foo":{"a":42,"b":true,"c":"horses"},"bar":"cats"}"""
+    val expected = Outer(Inner(42, true, "horses"), "cats")
+
+    val responseAs = asJson[Outer]
+
+    runJsonResponseAs(responseAs)(body).right.value shouldBe expected
+  }
+
+  it should "fail to read invalid json" in {
+    val body = """not valid json"""
+
+    val responseAs = asJson[Outer]
+
+    val result = runJsonResponseAs(responseAs)(body).left.value
+    result.original shouldBe body
+  }
+
+  it should "read and write back to the same thing" in {
+    val outer = Outer(Inner(42, true, "horses"), "cats")
+
+    val encoded = extractBody(sttp.body(outer))
+    val decoded = runJsonResponseAs(asJson[Outer])(encoded)
+
+    decoded.right.value shouldBe outer
+  }
+
+  it should "set the content type" in {
+    val body = Outer(Inner(42, true, "horses"), "cats")
+    val req = sttp.body(body)
+
+    val ct = req.headers.toMap.get("Content-Type")
+
+    ct shouldBe Some(contentTypeWithEncoding(MediaTypes.Json, Utf8))
+  }
+
+  it should "only set the content type if it was not set earlier" in {
+    val body = Outer(Inner(42, true, "horses"), "cats")
+    val req = sttp.contentType("horses/cats").body(body)
+
+    val ct = req.headers.toMap.get("Content-Type")
+
+    ct shouldBe Some("horses/cats")
+  }
+
+  case class Inner(a: Int, b: Boolean, c: String)
+
+  object Inner {
+    implicit val innerReads: Reads[Inner] = Json.reads[Inner]
+    implicit val innerWrites: OWrites[Inner] = Json.writes[Inner]
+  }
+
+  case class Outer(foo: Inner, bar: String)
+
+  object Outer {
+    implicit val outerReads: Reads[Outer] = Json.reads[Outer]
+    implicit val outerWrites: OWrites[Outer] = Json.writes[Outer]
+  }
+
+  def extractBody[A[_], B, C](request: RequestT[A, B, C]): String =
+    request.body match {
+      case StringBody(body, "utf-8", Some(MediaTypes.Json)) =>
+        body
+      case wrongBody =>
+        fail(s"Request body does not serialize to correct StringBody: $wrongBody")
+    }
+
+  def runJsonResponseAs[A](responseAs: ResponseAs[A, Nothing]): String => A =
+    responseAs match {
+      case responseAs: MappedResponseAs[_, A, Nothing] =>
+        responseAs.raw match {
+          case ResponseAsString("utf-8") =>
+            responseAs.g
+          case ResponseAsString(encoding) =>
+            fail(s"MappedResponseAs wraps a ResponseAsString with wrong encoding: $encoding")
+          case _ =>
+            fail("MappedResponseAs does not wrap a ResponseAsString")
+        }
+      case _ => fail("ResponseAs is not a MappedResponseAs")
+    }
+}


### PR DESCRIPTION
As of play 2.6, play-json is a standalone library, so we can support it without needing all of play framework as a dependency.

For more information: https://www.playframework.com/documentation/2.6.x/Migration26#Play-JSON-moved-to-separate-project