### PR TITLE
Depend on json4s interface instead of native implementation

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -356,12 +356,15 @@ lazy val circe = crossProject(JSPlatform, JVMPlatform)
 lazy val circeJS = circe.js.dependsOn(coreJS)
 lazy val circeJVM = circe.jvm.dependsOn(coreJVM)
 
+lazy val json4sVersion = "3.6.0"
+
 lazy val json4s: Project = (project in file("json/json4s"))
   .settings(commonJvmSettings: _*)
   .settings(
     name := "json4s",
     libraryDependencies ++= Seq(
-      "org.json4s" %% "json4s-native" % "3.6.0",
+      "org.json4s" %% "json4s-core" % json4sVersion,
+      "org.json4s" %% "json4s-native" % json4sVersion % "test",
       "org.scalatest" %% "scalatest" % scalaTestVersion % "test"
     )
   )

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -36,6 +36,7 @@ Required dependencies::
   libraryDependencies ++= List(
     "com.softwaremill.sttp" %% "akka-http-backend" % "1.3.8",
     "com.softwaremill.sttp" %% "json4s" % "1.3.8"
+    "org.json4s" %% "json4s-native" % "3.6.0"
   )
 
 Example code::
@@ -48,6 +49,7 @@ Example code::
 
   case class HttpBinResponse(origin: String, headers: Map[String, String])
 
+  implicit val serialization =  org.json4s.native.Serialization
   val request = sttp
     .get(uri"https://httpbin.org/get")
     .response(asJson[HttpBinResponse])

--- a/docs/json.rst
+++ b/docs/json.rst
@@ -33,11 +33,14 @@ This module adds a method to the request and a function that can be given to a r
 Json4s
 ------
 
-To encode and decode json using json4s-native, add the following dependency to your project::
+To encode and decode json using json4s, add the following dependency to your project::
 
   "com.softwaremill.sttp" %% "json4s" % "1.3.8"
+  "org.json4s" %% "json4s-native" % "3.6.0"
 
-Using this module it is possible to set request bodies and read response bodies as case classes, using the implicitly available ``org.json4s.Formats`` (which defaults to ``org.json4s.DefaultFormats``).
+Note that in this example we are using the json4s-native backend, but you can use any other json4s backend.
+
+Using this module it is possible to set request bodies and read response bodies as case classes, using the implicitly available ``org.json4s.Formats`` (which defaults to ``org.json4s.DefaultFormats``), and by bringing an implicit ``Serialization`` into scope.
 
 Usage example::
 
@@ -50,6 +53,8 @@ Usage example::
   case class MyResponse(...)
 
   val requestPayload: Payload = Payload(...)
+
+  implicit val serialization =  org.json4s.native.Serialization
   
   val response: Response[MyResponse] =
     sttp

--- a/docs/json.rst
+++ b/docs/json.rst
@@ -40,7 +40,7 @@ To encode and decode json using json4s, add the following dependency to your pro
 
 Note that in this example we are using the json4s-native backend, but you can use any other json4s backend.
 
-Using this module it is possible to set request bodies and read response bodies as case classes, using the implicitly available ``org.json4s.Formats`` (which defaults to ``org.json4s.DefaultFormats``), and by bringing an implicit ``Serialization`` into scope.
+Using this module it is possible to set request bodies and read response bodies as case classes, using the implicitly available ``org.json4s.Formats`` (which defaults to ``org.json4s.DefaultFormats``), and by bringing an implicit ``org.json4s.Serialization`` into scope.
 
 Usage example::
 

--- a/json/json4s/src/main/scala/com/softwaremill/sttp/json4s/package.scala
+++ b/json/json4s/src/main/scala/com/softwaremill/sttp/json4s/package.scala
@@ -3,12 +3,12 @@ package com.softwaremill.sttp
 import com.softwaremill.sttp.internal._
 
 import org.json4s._
-import org.json4s.native.Serialization.{read, write}
+import org.json4s.Serialization
 
 package object json4s {
-  implicit def json4sBodySerializer[B <: AnyRef](implicit formats: Formats = DefaultFormats): BodySerializer[B] =
-    b => StringBody(write(b), Utf8, Some(MediaTypes.Json))
+  implicit def json4sBodySerializer[B <: AnyRef](implicit formats: Formats = DefaultFormats, serialization: Serialization): BodySerializer[B] =
+    b => StringBody(serialization.write(b), Utf8, Some(MediaTypes.Json))
 
-  def asJson[B: Manifest](implicit formats: Formats = DefaultFormats): ResponseAs[B, Nothing] =
-    asString(Utf8).map(s => read[B](s))
+  def asJson[B: Manifest](implicit formats: Formats = DefaultFormats, serialization: Serialization): ResponseAs[B, Nothing] =
+    asString(Utf8).map(s => serialization.read[B](s))
 }

--- a/json/json4s/src/test/scala/com/softwaremill/sttp/Json4sTests.scala
+++ b/json/json4s/src/test/scala/com/softwaremill/sttp/Json4sTests.scala
@@ -3,13 +3,13 @@ package com.softwaremill.sttp
 import com.softwaremill.sttp.internal._
 
 import org.json4s.ParserUtil.ParseException
-import org.json4s.jackson
+import org.json4s.native
 import org.scalatest._
 
 import scala.language.higherKinds
 
 class Json4sTests extends FlatSpec with Matchers with EitherValues {
-  implicit val serialization = jackson.Serialization
+  implicit val serialization = native.Serialization
   import json4s._
   import Json4sTests._
 

--- a/json/json4s/src/test/scala/com/softwaremill/sttp/Json4sTests.scala
+++ b/json/json4s/src/test/scala/com/softwaremill/sttp/Json4sTests.scala
@@ -3,11 +3,13 @@ package com.softwaremill.sttp
 import com.softwaremill.sttp.internal._
 
 import org.json4s.ParserUtil.ParseException
+import org.json4s.jackson
 import org.scalatest._
 
 import scala.language.higherKinds
 
 class Json4sTests extends FlatSpec with Matchers with EitherValues {
+  implicit val serialization = jackson.Serialization
   import json4s._
   import Json4sTests._
 


### PR DESCRIPTION
I'm wondering why the json4s module explicitely depends on the json4s-native implementation, instead of using the interfaces and let the user choose a backend.

This is what https://github.com/hseeberger/akka-http-json is doing, I guess there must be a reason why you chose to do it that way?