### PR TITLE
Add support for obtaining non 2xx response body.

### DIFF
--- a/akka-http-backend/src/main/scala/com/softwaremill/sttp/akkahttp/AkkaHttpBackend.scala
+++ b/akka-http-backend/src/main/scala/com/softwaremill/sttp/akkahttp/AkkaHttpBackend.scala
@@ -72,7 +72,7 @@ class AkkaHttpBackend private (actorSystem: ActorSystem,
           .map(_._2)
           .flatMap(encodingFromContentType)
 
-        val body = if (com.softwaremill.sttp.StatusCodes.isSuccess(code)) {
+        val body = if (r.parseResponseCondition(code)) {
           bodyFromAkka(r.response, decodeAkkaResponse(hr), charsetFromHeaders)
             .map(Right(_))
         } else {

--- a/core/js/src/main/scala/com/softwaremill/sttp/AbstractFetchBackend.scala
+++ b/core/js/src/main/scala/com/softwaremill/sttp/AbstractFetchBackend.scala
@@ -107,7 +107,7 @@ abstract class AbstractFetchBackend[R[_], S](options: FetchOptions)(rm: MonadErr
         }
       }
       .flatMap { resp =>
-        val body: R[Either[Array[Byte], T]] = if (resp.ok) {
+        val body: R[Either[Array[Byte], T]] = if (request.parseResponseCondition(resp.status)) {
           readResponseBody(resp, request.response).map(Right.apply)
         } else {
           transformPromise(resp.text()).map(t => Left(t.getBytes(Utf8)))

--- a/core/jvm/src/test/scala/com/softwaremill/sttp/testing/TestHttpServer.scala
+++ b/core/jvm/src/test/scala/com/softwaremill/sttp/testing/TestHttpServer.scala
@@ -90,6 +90,22 @@ private class HttpServer(port: Int) extends AutoCloseable with CorsDirectives {
             .mkString(" "))
         }
       } ~
+        pathPrefix("custom_status") {
+          path(IntNumber) { status =>
+            post {
+              entity(as[String]) { body: String =>
+                complete(
+                  HttpResponse(
+                    status,
+                    entity = List("POST", s"/echo/custom_status/$status", body)
+                      .filter(_.nonEmpty)
+                      .mkString(" ")
+                  )
+                )
+              }
+            }
+          }
+        } ~
         post {
           parameterMap { params =>
             entity(as[String]) { body: String =>

--- a/core/native/src/main/scala/com/softwaremill/sttp/AbstractCurlBackend.scala
+++ b/core/native/src/main/scala/com/softwaremill/sttp/AbstractCurlBackend.scala
@@ -70,7 +70,7 @@ abstract class AbstractCurlBackend[R[_], S](rm: MonadError[R], verbose: Boolean)
       free(spaces.httpCode.cast[Ptr[CSignedChar]])
       curl.cleanup()
 
-      val body: R[Either[Array[CSignedChar], T]] = if (StatusCodes.isSuccess(httpCode)) {
+      val body: R[Either[Array[CSignedChar], T]] = if (request.parseResponseCondition(httpCode)) {
         responseMonad.map(readResponseBody(responseBody, request.response, responseHeaders))(Right.apply)
       } else {
         responseMonad.map(toByteArray(responseBody))(Left.apply)

--- a/core/shared/src/main/scala/com/softwaremill/sttp/RequestT.scala
+++ b/core/shared/src/main/scala/com/softwaremill/sttp/RequestT.scala
@@ -36,7 +36,8 @@ case class RequestT[U[_], T, +S](
     headers: Seq[(String, String)],
     response: ResponseAs[T, S],
     options: RequestOptions,
-    tags: Map[String, Any]
+    tags: Map[String, Any],
+    parseResponseCondition: StatusCode => Boolean = StatusCodes.isSuccess
 ) extends RequestTExtensions[U, T, S] {
   def get(uri: Uri): Request[T, S] =
     this.copy[Id, T, S](uri = uri, method = Method.GET)
@@ -215,6 +216,9 @@ case class RequestT[U[_], T, +S](
     this.copy(tags = tags + (k -> v))
 
   def tag(k: String): Option[Any] = tags.get(k)
+
+  def parseResponseIf(f: StatusCode => Boolean): RequestT[U, T, S] =
+    this.copy(parseResponseCondition = f)
 
   def send[R[_]]()(implicit backend: SttpBackend[R, S], isIdInRequest: IsIdInRequest[U]): R[Response[T]] = {
     // we could avoid the asInstanceOf by creating an artificial copy

--- a/core/shared/src/test/scala/com/softwaremill/sttp/testing/HttpTest.scala
+++ b/core/shared/src/test/scala/com/softwaremill/sttp/testing/HttpTest.scala
@@ -83,6 +83,34 @@ trait HttpTest[R[_]]
           response.unsafeBody.toList should be(params)
         }
     }
+
+    "as string with expected unsuccessful response" in {
+      val expectedStatus = 400
+      sttp
+        .post(uri"$endpoint/echo/custom_status/$expectedStatus")
+        .body(testBody)
+        .response(asString)
+        .parseResponseIf(_ == expectedStatus)
+        .send()
+        .toFuture()
+        .map { response =>
+          response.body should be(Right(s"POST /echo/custom_status/$expectedStatus $testBody"))
+        }
+    }
+
+    "as error string if status code is not supported" in {
+      val unexpectedStatus = 200
+      sttp
+        .post(uri"$endpoint/echo/custom_status/$unexpectedStatus")
+        .body(testBody)
+        .response(asString)
+        .parseResponseIf(_ != unexpectedStatus)
+        .send()
+        .toFuture()
+        .map { response =>
+          response.body should be(Left(s"POST /echo/custom_status/$unexpectedStatus $testBody"))
+        }
+    }
   }
 
   "parameters" - {

--- a/docs/credits.rst
+++ b/docs/credits.rst
@@ -10,3 +10,4 @@ Credits
 * `Gabriele Petronella <https://github.com/gabro>`_
 * `Paweł Stawicki <https://github.com/amorfis>`_
 * `Michał Siatkowski <https://github.com/atais>`_
+* `Marcin Kubala <https://github.com/mkubala>`_

--- a/docs/json.rst
+++ b/docs/json.rst
@@ -5,6 +5,8 @@ JSON
 
 Adding support for JSON (or other format) bodies in requests/responses is a matter of providing a :ref:`body serializer <requestbody_custom>` and/or a :ref:`response body specification <responsebodyspec_custom>`. Both are quite straightforward to implement, so integrating with your favorite JSON library shouldn't be a problem. However, there are some integrations available out-of-the-box.
 
+Also read about :ref:`handling non 2xx responses <responsebodyspec_handlenon2xx>` if you need to unmarshal error responses.
+
 Circe
 -----
 

--- a/docs/responses/basics.rst
+++ b/docs/responses/basics.rst
@@ -7,7 +7,7 @@ If sending the request fails, either due to client or connection errors, an exce
 
 .. note::
 
-  If the request completes, but results in a non-2xx return code, the request is still considered successful, that is, a ``Response[T]`` will be returned. See :ref:`response body specifications <responsebodyspec>` for details on how such cases are handled.
+  If the request completes, but results in a non-2xx return code, the request is still considered successful, that is, a ``Response[T]`` will be returned. See :ref:`response body specifications <responsebodyspec>` and/or :ref:`handling non 2xx responses <responsebodyspec_handlenon2xx>` for details on how such cases are handled.
 
 Response code
 -------------
@@ -40,11 +40,13 @@ Obtaining the response body
 
 The response body can be obtained through the ``.body: Either[String, T]`` lazy value or the ``.rawErrorBody: Either[Array[Byte], T]`` property. ``T`` is the body deserialized as specified in the request - see the next section on :ref:`response body specifications <responsebodyspec>`.
 
-The response body is an either as the body can only be deserialized if the server responded with a success code (2xx). Otherwise, the response body is most probably an error message.
+The response body is an either as the body can only be deserialized if the server responded with one of the expected status codes (by default it's any 2xx code). Otherwise, the response body is most probably an error message.
 
 Hence, ``response.body`` will be a:
 
-* ``Left(errorMessage)`` if the request is successful, but response code is not 2xx.
-* ``Right(deserializedBody``) if the request is successful and the response code is 2xx.
+* ``Left(errorMessage)`` if the request is successful, but response code is not expected (non 2xx by default).
+* ``Right(deserializedBody``) if the request is successful and the response code is expected (2xx by default).
+
+To learn how to obtain non 2xx response body see :ref:`this section <responsebodyspec_handlenon2xx>`.
 
 You can also forcibly get the deserialized body, regardless of the response code and risking an exception being thrown, using the ``response.unsafeBody`` method.

--- a/docs/responses/body.rst
+++ b/docs/responses/body.rst
@@ -37,6 +37,22 @@ And to save the response to a file::
 
   As the handling of response is specified upfront, there's no need to "consume" the response body. It can be safely discarded if not needed.
 
+.. _responsebodyspec_handlenon2xx:
+
+Handling non 2xx responses
+--------------------------
+
+By default only a successful (2xx) response body can be obtained. To customize this behaviour use ``.parseResponseIf`` method::
+
+  val response =
+    sttp
+      .post(uri"...")
+      .body(requestPayload)
+      .response(asXxx)
+      .parseResponseIf(status => status == 400 || status == 200)
+      .send()
+
+
 .. _responsebodyspec_custom:
 
 Custom body deserializers


### PR DESCRIPTION
This PR is aimed to bring support for obtaining unsuccessful response bodies. 

This will be especially helpful when working with endpoints that in case of error respond with a JSON object containing more detailed information about the failure cause (i.e. validation errors or service-specific error codes & reason descriptions).