### PR TITLE
Add support for variable request method

### DIFF
--- a/core/shared/src/main/scala/com/softwaremill/sttp/RequestT.scala
+++ b/core/shared/src/main/scala/com/softwaremill/sttp/RequestT.scala
@@ -52,6 +52,8 @@ case class RequestT[U[_], T, +S](
     this.copy[Id, T, S](uri = uri, method = Method.OPTIONS)
   def patch(uri: Uri): Request[T, S] =
     this.copy[Id, T, S](uri = uri, method = Method.PATCH)
+  def method(method: Method, uri: Uri): Request[T, S] =
+    this.copy[Id, T, S](uri = uri, method = method)
 
   def contentType(ct: String): RequestT[U, T, S] =
     header(HeaderNames.ContentType, ct, replaceExisting = true)


### PR DESCRIPTION
In some cases, one may have a generic way of constructing a request out
of several pieces, where the method is passed as a variable of type
`Method`. Add a `method` setter that both set the method and the uri
amkes this possible.