### PR TITLE
Add proxy auth

### DIFF
--- a/async-http-client-backend/src/main/scala/com/softwaremill/sttp/asynchttpclient/AsyncHttpClientBackend.scala
+++ b/async-http-client-backend/src/main/scala/com/softwaremill/sttp/asynchttpclient/AsyncHttpClientBackend.scala
@@ -22,6 +22,7 @@ import org.asynchttpclient.{
   HttpResponseBodyPart,
   HttpResponseStatus,
   Param,
+  Realm,
   RequestBuilder,
   Request => AsyncRequest,
   Response => AsyncResponse
@@ -304,6 +305,10 @@ object AsyncHttpClientBackend {
           new ProxyServer.Builder(p.host, p.port)
             .setProxyType(proxyType) // Fix issue #145
             .setNonProxyHosts(p.nonProxyHosts.asJava)
+            .setRealm(p.auth
+              .map(proxyAuth =>
+                new Realm.Builder(proxyAuth.username, proxyAuth.password).setScheme(Realm.AuthScheme.BASIC))
+              .orNull)
             .build())
     }
 

--- a/core/shared/src/main/scala/com/softwaremill/sttp/SttpBackendOptions.scala
+++ b/core/shared/src/main/scala/com/softwaremill/sttp/SttpBackendOptions.scala
@@ -18,12 +18,21 @@ case class SttpBackendOptions(
     this.copy(connectionTimeout = ct)
   def httpProxy(host: String, port: Int): SttpBackendOptions =
     this.copy(proxy = Some(Proxy(host, port, ProxyType.Http)))
+  def httpProxy(host: String, port: Int, username: String, password: String): SttpBackendOptions =
+    this.copy(proxy = Some(Proxy(host, port, ProxyType.Http, auth = Some(ProxyAuth(username, password)))))
   def socksProxy(host: String, port: Int): SttpBackendOptions =
     this.copy(proxy = Some(Proxy(host, port, ProxyType.Socks)))
+  def socksProxy(host: String, port: Int, username: String, password: String): SttpBackendOptions =
+    this.copy(proxy = Some(Proxy(host, port, ProxyType.Socks, auth = Some(ProxyAuth(username, password)))))
 }
 
 object SttpBackendOptions {
-  case class Proxy(host: String, port: Int, proxyType: ProxyType, nonProxyHosts: List[String] = Nil) {
+  case class ProxyAuth(username: String, password: String)
+  case class Proxy(host: String,
+                   port: Int,
+                   proxyType: ProxyType,
+                   nonProxyHosts: List[String] = Nil,
+                   auth: Option[ProxyAuth] = None) {
 
     //only matches prefix or suffix wild card(*)
     private def isWildCardMatch(targetHost: String, nonProxyHost: String): Boolean = {
@@ -94,8 +103,14 @@ object SttpBackendOptions {
   def httpProxy(host: String, port: Int): SttpBackendOptions =
     Empty.httpProxy(host, port)
 
+  def httpProxy(host: String, port: Int, username: String, password: String): SttpBackendOptions =
+    Empty.httpProxy(host, port, username, password)
+
   def socksProxy(host: String, port: Int): SttpBackendOptions =
     Empty.socksProxy(host, port)
+
+  def socksProxy(host: String, port: Int, username: String, password: String): SttpBackendOptions =
+    Empty.socksProxy(host, port, username, password)
 
   private def loadSystemProxy: Option[Proxy] = {
     def system(hostProp: String,

--- a/docs/conf/proxy.rst
+++ b/docs/conf/proxy.rst
@@ -22,4 +22,5 @@ Otherwise, proxy values can be specified manually when creating a backend::
     .get(uri"...")
     .send() // uses the proxy
 
-  
+Or in case your proxy requires authentication (supported by the ``akka-http``, ``async-http-client`` and ``okhttp`` backends)::
+  SttpBackendOptions.httpProxy("some.host", 8080, "username", "password")


### PR DESCRIPTION
Some proxies (in my case luminati.io, but it's a general thing) require authentication and sttp so far models this in a way (on `RequestT`, setting the `Proxy-Authentication` header there) which doesn't work for all proxies - forcing the user to manually create the underlying backend before being able to use such a proxy with sttp.

This PR extends `SttpBackendOptions` to allow proxy username and password to be passed and adapts the `akka-http`, `async-http-client` and `okhttp` backends (these seem to be all which support this) to set themselves up accordingly.

I unfortunately don't know where to get a proper proxy set up with authentication, therefore no dedicated tests…if someone has an idea, please let me know!