### PR TITLE
Consecutive responses

### DIFF
--- a/core/shared/src/main/scala/com/softwaremill/sttp/testing/SttpBackendStub.scala
+++ b/core/shared/src/main/scala/com/softwaremill/sttp/testing/SttpBackendStub.scala
@@ -103,6 +103,13 @@ class SttpBackendStub[R[_], S] private (rm: MonadError[R],
       }
       new SttpBackendStub(rm, matchers.orElse(m), fallback)
     }
+    def thenRespondCyclic[T](bodies: T*): SttpBackendStub[R, S] = {
+      thenRespond(bodies.map(body => Response[T](Right(body), 200, "OK")))
+    }
+    def thenRespondCyclicResponses[T](responses: Response[T]*): SttpBackendStub[R, S] = {
+      val iterator = Iterator.continually(responses).flatten
+      thenRespond(iterator.next)
+    }
     def thenRespondWrapped(resp: => R[Response[_]]): SttpBackendStub[R, S] = {
       val m: PartialFunction[Request[_, _], R[Response[_]]] = {
         case r if p(r) => resp

--- a/core/shared/src/main/scala/com/softwaremill/sttp/testing/SttpBackendStub.scala
+++ b/core/shared/src/main/scala/com/softwaremill/sttp/testing/SttpBackendStub.scala
@@ -104,7 +104,7 @@ class SttpBackendStub[R[_], S] private (rm: MonadError[R],
       new SttpBackendStub(rm, matchers.orElse(m), fallback)
     }
     def thenRespondCyclic[T](bodies: T*): SttpBackendStub[R, S] = {
-      thenRespond(bodies.map(body => Response[T](Right(body), 200, "OK")))
+      thenRespondCyclicResponses(bodies.map(body => Response[T](Right(body), 200, "OK")): _*)
     }
     def thenRespondCyclicResponses[T](responses: Response[T]*): SttpBackendStub[R, S] = {
       val iterator = Iterator.continually(responses).flatten

--- a/core/shared/src/test/scala/com/softwaremill/sttp/testing/SttpBackendStubTests.scala
+++ b/core/shared/src/test/scala/com/softwaremill/sttp/testing/SttpBackendStubTests.scala
@@ -193,20 +193,20 @@ class SttpBackendStubTests extends FlatSpec with Matchers with ScalaFutures {
   }
 
   it should "serve consecutive raw responses" in {
-    implicit val s = SttpBackendStub(IdMonad).whenAnyRequest
+    implicit val s: SttpBackend[Id, Nothing] = SttpBackendStub(IdMonad).whenAnyRequest
       .thenRespondCyclic("first", "second", "third")
 
     sttp.get(uri"http://example.org").send().body should be(Right("first"))
     sttp.get(uri"http://example.org").send().body should be(Right("second"))
-    sttp.get(uri"http://example.org").send().body should be(Right("thied"))
+    sttp.get(uri"http://example.org").send().body should be(Right("third"))
     sttp.get(uri"http://example.org").send().body should be(Right("first"))
   }
 
   it should "serve consecutive responses" in {
-    implicit val s = SttpBackendStub(IdMonad).whenAnyRequest
-      .thenRespondCyclic(
-        Response.ok("first"),
-        Response.error("error", 500, "Something went wrong"),
+    implicit val s: SttpBackend[Id, Nothing] = SttpBackendStub(IdMonad).whenAnyRequest
+      .thenRespondCyclicResponses(
+        Response.ok[String]("first"),
+        Response.error[String]("error", 500, "Something went wrong")
       )
 
     sttp.get(uri"http://example.org").send().is200 should be(true)

--- a/core/shared/src/test/scala/com/softwaremill/sttp/testing/SttpBackendStubTests.scala
+++ b/core/shared/src/test/scala/com/softwaremill/sttp/testing/SttpBackendStubTests.scala
@@ -192,6 +192,28 @@ class SttpBackendStubTests extends FlatSpec with Matchers with ScalaFutures {
     (after - before) should be < LongTimeMillis
   }
 
+  it should "serve consecutive raw responses" in {
+    implicit val s = SttpBackendStub(IdMonad).whenAnyRequest
+      .thenRespondCyclic("first", "second", "third")
+
+    sttp.get(uri"http://example.org").send().body should be(Right("first"))
+    sttp.get(uri"http://example.org").send().body should be(Right("second"))
+    sttp.get(uri"http://example.org").send().body should be(Right("thied"))
+    sttp.get(uri"http://example.org").send().body should be(Right("first"))
+  }
+
+  it should "serve consecutive responses" in {
+    implicit val s = SttpBackendStub(IdMonad).whenAnyRequest
+      .thenRespondCyclic(
+        Response.ok("first"),
+        Response.error("error", 500, "Something went wrong"),
+      )
+
+    sttp.get(uri"http://example.org").send().is200 should be(true)
+    sttp.get(uri"http://example.org").send().isServerError should be(true)
+    sttp.get(uri"http://example.org").send().is200 should be(true)
+  }
+
   private val testingStubWithFallback = SttpBackendStub
     .withFallback(testingStub)
     .whenRequestMatches(_.uri.path.startsWith(List("c")))


### PR DESCRIPTION
Easily pass multiple consecutive responses to sttp stub.

Fixes #183 