### PR TITLE
Maybe parse response based on returned metadata.

### DIFF
--- a/akka-http-backend/src/main/scala/com/softwaremill/sttp/akkahttp/AkkaHttpBackend.scala
+++ b/akka-http-backend/src/main/scala/com/softwaremill/sttp/akkahttp/AkkaHttpBackend.scala
@@ -79,7 +79,7 @@ class AkkaHttpBackend private (actorSystem: ActorSystem,
           .flatMap(encodingFromContentType)
 
         val responseMetadata = ResponseMetadata(headers, code, statusText)
-        val body = if (r.options.parseResponseIf(code)) {
+        val body = if (r.options.parseResponseIf(responseMetadata)) {
           bodyFromAkka(r.response, decodeAkkaResponse(hr), charsetFromHeaders, responseMetadata)
             .map(Right(_))
         } else {

--- a/async-http-client-backend/src/main/scala/com/softwaremill/sttp/asynchttpclient/AsyncHttpClientBackend.scala
+++ b/async-http-client-backend/src/main/scala/com/softwaremill/sttp/asynchttpclient/AsyncHttpClientBackend.scala
@@ -129,7 +129,7 @@ abstract class AsyncHttpClientBackend[R[_], S](asyncHttpClient: AsyncHttpClient,
           val baseResponse = readResponseNoBody(builder.build())
           val p = publisher.getOrElse(EmptyPublisher)
           val s = publisherToStreamBody(p)
-          val b = if (parseCondition(baseResponse.code)) {
+          val b = if (parseCondition(baseResponse)) {
             rm.unit(Right(handleBody(s, responseAs, baseResponse).asInstanceOf[T]))
           } else {
             rm.map(publisherToBytes(p))(Left(_))
@@ -231,7 +231,7 @@ abstract class AsyncHttpClientBackend[R[_], S](asyncHttpClient: AsyncHttpClient,
     val base = readResponseNoBody(response)
 
     val responseMetadata = ResponseMetadata(base.headers, base.code, base.statusText)
-    val body = if (parseCondition(base.code)) {
+    val body = if (parseCondition(responseMetaData)) {
       rm.map(eagerResponseHandler(response).handle(responseAs, rm, base))(Right(_))
     } else {
       rm.map(eagerResponseHandler(response).handle(asByteArray, rm, base))(Left(_))

--- a/core/js/src/main/scala/com/softwaremill/sttp/AbstractFetchBackend.scala
+++ b/core/js/src/main/scala/com/softwaremill/sttp/AbstractFetchBackend.scala
@@ -107,9 +107,10 @@ abstract class AbstractFetchBackend[R[_], S](options: FetchOptions)(rm: MonadErr
       }
       .flatMap { resp =>
         val headers = convertResponseHeaders(resp.headers)
+        val metadata = ResponseMetadata(headers, resp.status, resp.statusText)
 
-        val body: R[Either[Array[Byte], T]] = if (request.options.parseResponseIf(resp.status)) {
-          readResponseBody(resp, request.response, ResponseMetadata(headers, resp.status, resp.statusText))
+        val body: R[Either[Array[Byte], T]] = if (request.options.parseResponseIf(metadata)) {
+          readResponseBody(resp, request.response, metadata)
             .map(Right.apply)
         } else {
           transformPromise(resp.text()).map(t => Left(t.getBytes(Utf8)))

--- a/core/jvm/src/main/scala/com/softwaremill/sttp/HttpURLConnectionBackend.scala
+++ b/core/jvm/src/main/scala/com/softwaremill/sttp/HttpURLConnectionBackend.scala
@@ -212,7 +212,7 @@ class HttpURLConnectionBackend private (opts: SttpBackendOptions, customizeConne
   private def readResponse[T](c: HttpURLConnection,
                               is: InputStream,
                               responseAs: ResponseAs[T, Nothing],
-                              parseCondition: StatusCode => Boolean): Response[T] = {
+                              parseCondition: ResponseMetadata => Boolean): Response[T] = {
 
     val headers = c.getHeaderFields.asScala.toVector
       .filter(_._1 != null)
@@ -225,7 +225,7 @@ class HttpURLConnectionBackend private (opts: SttpBackendOptions, customizeConne
     val code = c.getResponseCode
     val wrappedIs = wrapInput(contentEncoding, handleNullInput(is))
     val responseMetadata = ResponseMetadata(headers, code, c.getResponseMessage)
-    val body = if (parseCondition(code)) {
+    val body = if (parseCondition(responseMetadata)) {
       Right(readResponseBody(wrappedIs, responseAs, charsetFromHeaders, responseMetadata))
     } else {
       Left(readResponseBody(wrappedIs, asByteArray, charsetFromHeaders, responseMetadata))

--- a/core/native/src/main/scala/com/softwaremill/sttp/AbstractCurlBackend.scala
+++ b/core/native/src/main/scala/com/softwaremill/sttp/AbstractCurlBackend.scala
@@ -74,7 +74,7 @@ abstract class AbstractCurlBackend[R[_], S](rm: MonadError[R], verbose: Boolean)
       val responseHeaders = responseHeaders_.tail
       val responseMetadata = ResponseMetadata(responseHeaders, httpCode, statusText)
 
-      val body: R[Either[Array[CSignedChar], T]] = if (request.options.parseResponseIf(httpCode)) {
+      val body: R[Either[Array[CSignedChar], T]] = if (request.options.parseResponseIf(responseMetadata)) {
         responseMonad.map(readResponseBody(responseBody, request.response, responseMetadata))(Right.apply)
       } else {
         responseMonad.map(toByteArray(responseBody))(Left.apply)

--- a/core/shared/src/main/scala/com/softwaremill/sttp/RequestT.scala
+++ b/core/shared/src/main/scala/com/softwaremill/sttp/RequestT.scala
@@ -219,6 +219,9 @@ case class RequestT[U[_], T, +S](
   def tag(k: String): Option[Any] = tags.get(k)
 
   def parseResponseIf(f: StatusCode => Boolean): RequestT[U, T, S] =
+    parseResponseIfMetadata(m => f(m.code))
+
+  def parseResponseIfMetadata(f: ResponseMetadata => Boolean): RequestT[U, T, S] =
     this.copy(options = options.copy(parseResponseIf = f))
 
   /**
@@ -284,6 +287,6 @@ case class RequestOptions(
     followRedirects: Boolean,
     readTimeout: Duration,
     maxRedirects: Int,
-    parseResponseIf: StatusCode => Boolean,
+    parseResponseIf: ResponseMetadata => Boolean,
     redirectToGet: Boolean
 )

--- a/core/shared/src/main/scala/com/softwaremill/sttp/SttpApi.scala
+++ b/core/shared/src/main/scala/com/softwaremill/sttp/SttpApi.scala
@@ -25,7 +25,7 @@ trait SttpApi extends SttpExtensions {
       RequestOptions(followRedirects = true,
                      DefaultReadTimeout,
                      FollowRedirectsBackend.MaxRedirects,
-                     StatusCodes.isSuccess,
+                     m => StatusCodes.isSuccess(m.code),
                      redirectToGet = false),
       Map()
     )

--- a/core/shared/src/test/scala/com/softwaremill/sttp/testing/HttpTest.scala
+++ b/core/shared/src/test/scala/com/softwaremill/sttp/testing/HttpTest.scala
@@ -98,6 +98,20 @@ trait HttpTest[R[_]]
         }
     }
 
+    "as string with expected unsuccessful response via metadata" in {
+      val expectedStatus = 400
+      sttp
+        .post(uri"$endpoint/echo/custom_status/$expectedStatus")
+        .body(testBody)
+        .response(asString)
+        .parseResponseIfMetadata(_.code == expectedStatus)
+        .send()
+        .toFuture()
+        .map { response =>
+          response.body should be(Right(s"POST /echo/custom_status/$expectedStatus $testBody"))
+        }
+    }
+
     "as string with expected unsuccessful response" in {
       val expectedStatus = 400
       sttp

--- a/okhttp-backend/src/main/scala/com/softwaremill/sttp/okhttp/OkHttpBackend.scala
+++ b/okhttp-backend/src/main/scala/com/softwaremill/sttp/okhttp/OkHttpBackend.scala
@@ -89,7 +89,7 @@ abstract class OkHttpBackend[R[_], S](client: OkHttpClient, closeClient: Boolean
 
   private[okhttp] def readResponse[T](res: OkHttpResponse,
                                       responseAs: ResponseAs[T, S],
-                                      parseCondition: StatusCode => Boolean): R[Response[T]] = {
+                                      parseCondition: ResponseMetadata => Boolean): R[Response[T]] = {
 
     val code = res.code()
 
@@ -101,7 +101,7 @@ abstract class OkHttpBackend[R[_], S](client: OkHttpClient, closeClient: Boolean
       .toList
 
     val responseMetadata = ResponseMetadata(headers, res.code(), res.message())
-    val body = if (parseCondition(code)) {
+    val body = if (parseCondition(responseMetadata)) {
       responseMonad.map(responseHandler(res).handle(responseAs, responseMonad, responseMetadata))(Right(_))
     } else {
       responseMonad.map(responseHandler(res).handle(asByteArray, responseMonad, responseMetadata))(Left(_))


### PR DESCRIPTION
This extends `parseResponseIf` to cover the whole metadata, not only the status code.

I'm suggesting this because I have a case where I really also want to check some of the returned headers (e.g. content type) to skip parsing the returned response as a file.