### PR TITLE
Add usingConfigBuilder for Async HTTP Client backend

### DIFF
--- a/async-http-client-backend/cats/src/main/scala/com/softwaremill/sttp/asynchttpclient/cats/AsyncHttpClientCatsBackend.scala
+++ b/async-http-client-backend/cats/src/main/scala/com/softwaremill/sttp/asynchttpclient/cats/AsyncHttpClientCatsBackend.scala
@@ -7,7 +7,12 @@ import com.softwaremill.sttp.asynchttpclient.AsyncHttpClientBackend
 import com.softwaremill.sttp.impl.cats.AsyncMonadAsyncError
 import com.softwaremill.sttp.{FollowRedirectsBackend, SttpBackend, SttpBackendOptions}
 import io.netty.buffer.ByteBuf
-import org.asynchttpclient.{AsyncHttpClient, AsyncHttpClientConfig, DefaultAsyncHttpClient}
+import org.asynchttpclient.{
+  AsyncHttpClient,
+  AsyncHttpClientConfig,
+  DefaultAsyncHttpClient,
+  DefaultAsyncHttpClientConfig
+}
 import org.reactivestreams.Publisher
 
 import scala.language.higherKinds
@@ -40,6 +45,15 @@ object AsyncHttpClientCatsBackend {
 
   def usingConfig[F[_]: Async](cfg: AsyncHttpClientConfig): SttpBackend[F, Nothing] =
     AsyncHttpClientCatsBackend(new DefaultAsyncHttpClient(cfg), closeClient = true)
+
+  def usingConfigBuilder[F[_]: Async](
+      updateConfig: DefaultAsyncHttpClientConfig.Builder => DefaultAsyncHttpClientConfig.Builder,
+      options: SttpBackendOptions = SttpBackendOptions.Default
+  ): SttpBackend[F, Nothing] =
+    AsyncHttpClientCatsBackend(
+      AsyncHttpClientBackend.clientWithModifiedOptions(options, updateConfig),
+      closeClient = true
+    )
 
   def usingClient[F[_]: Async](client: AsyncHttpClient): SttpBackend[F, Nothing] =
     AsyncHttpClientCatsBackend(client, closeClient = false)

--- a/async-http-client-backend/fs2/src/main/scala/com/softwaremill/sttp/asynchttpclient/fs2/AsyncHttpClientFs2Backend.scala
+++ b/async-http-client-backend/fs2/src/main/scala/com/softwaremill/sttp/asynchttpclient/fs2/AsyncHttpClientFs2Backend.scala
@@ -11,7 +11,12 @@ import com.softwaremill.sttp.internal._
 import fs2._
 import fs2.interop.reactivestreams._
 import io.netty.buffer.{ByteBuf, Unpooled}
-import org.asynchttpclient.{AsyncHttpClient, AsyncHttpClientConfig, DefaultAsyncHttpClient}
+import org.asynchttpclient.{
+  AsyncHttpClient,
+  AsyncHttpClientConfig,
+  DefaultAsyncHttpClient,
+  DefaultAsyncHttpClientConfig
+}
 import org.reactivestreams.Publisher
 
 import scala.language.higherKinds
@@ -54,6 +59,15 @@ object AsyncHttpClientFs2Backend {
 
   def usingConfig[F[_]: ConcurrentEffect](cfg: AsyncHttpClientConfig): SttpBackend[F, Stream[F, ByteBuffer]] =
     apply[F](new DefaultAsyncHttpClient(cfg), closeClient = true)
+
+  def usingConfigBuilder[F[_]: ConcurrentEffect](
+      updateConfig: DefaultAsyncHttpClientConfig.Builder => DefaultAsyncHttpClientConfig.Builder,
+      options: SttpBackendOptions = SttpBackendOptions.Default
+  ): SttpBackend[F, Stream[F, ByteBuffer]] =
+    AsyncHttpClientFs2Backend[F](
+      AsyncHttpClientBackend.clientWithModifiedOptions(options, updateConfig),
+      closeClient = true
+    )
 
   def usingClient[F[_]: ConcurrentEffect](client: AsyncHttpClient): SttpBackend[F, Stream[F, ByteBuffer]] =
     apply[F](client, closeClient = false)

--- a/async-http-client-backend/future/src/main/scala/com/softwaremill/sttp/asynchttpclient/future/AsyncHttpClientFutureBackend.scala
+++ b/async-http-client-backend/future/src/main/scala/com/softwaremill/sttp/asynchttpclient/future/AsyncHttpClientFutureBackend.scala
@@ -5,7 +5,12 @@ import java.nio.ByteBuffer
 import com.softwaremill.sttp.asynchttpclient.AsyncHttpClientBackend
 import com.softwaremill.sttp.{FollowRedirectsBackend, FutureMonad, SttpBackend, SttpBackendOptions}
 import io.netty.buffer.ByteBuf
-import org.asynchttpclient.{AsyncHttpClient, AsyncHttpClientConfig, DefaultAsyncHttpClient}
+import org.asynchttpclient.{
+  AsyncHttpClient,
+  AsyncHttpClientConfig,
+  DefaultAsyncHttpClient,
+  DefaultAsyncHttpClientConfig
+}
 import org.reactivestreams.Publisher
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -50,6 +55,20 @@ object AsyncHttpClientFutureBackend {
       cfg: AsyncHttpClientConfig
   )(implicit ec: ExecutionContext = ExecutionContext.Implicits.global): SttpBackend[Future, Nothing] =
     AsyncHttpClientFutureBackend(new DefaultAsyncHttpClient(cfg), closeClient = true)
+
+  /**
+    * @param ec The execution context for running non-network related operations,
+    *           e.g. mapping responses. Defaults to the global execution
+    *           context.
+    */
+  def usingConfigBuilder(
+      updateConfig: DefaultAsyncHttpClientConfig.Builder => DefaultAsyncHttpClientConfig.Builder,
+      options: SttpBackendOptions = SttpBackendOptions.Default
+  )(implicit ec: ExecutionContext = ExecutionContext.Implicits.global): SttpBackend[Future, Nothing] =
+    AsyncHttpClientFutureBackend(
+      AsyncHttpClientBackend.clientWithModifiedOptions(options, updateConfig),
+      closeClient = true
+    )
 
   /**
     * @param ec The execution context for running non-network related operations,

--- a/async-http-client-backend/monix/src/main/scala/com/softwaremill/sttp/asynchttpclient/monix/AsyncHttpClientMonixBackend.scala
+++ b/async-http-client-backend/monix/src/main/scala/com/softwaremill/sttp/asynchttpclient/monix/AsyncHttpClientMonixBackend.scala
@@ -10,7 +10,12 @@ import io.netty.buffer.{ByteBuf, Unpooled}
 import monix.eval.Task
 import monix.execution.Scheduler
 import monix.reactive.Observable
-import org.asynchttpclient.{AsyncHttpClient, AsyncHttpClientConfig, DefaultAsyncHttpClient}
+import org.asynchttpclient.{
+  AsyncHttpClient,
+  AsyncHttpClientConfig,
+  DefaultAsyncHttpClient,
+  DefaultAsyncHttpClientConfig
+}
 import org.reactivestreams.Publisher
 
 class AsyncHttpClientMonixBackend private (asyncHttpClient: AsyncHttpClient, closeClient: Boolean)(
@@ -57,6 +62,19 @@ object AsyncHttpClientMonixBackend {
       cfg: AsyncHttpClientConfig
   )(implicit s: Scheduler = Scheduler.Implicits.global): SttpBackend[Task, Observable[ByteBuffer]] =
     AsyncHttpClientMonixBackend(new DefaultAsyncHttpClient(cfg), closeClient = true)
+
+  /**
+    * @param s The scheduler used for streaming request bodies. Defaults to the
+    *          global scheduler.
+    */
+  def usingConfigBuilder(
+      updateConfig: DefaultAsyncHttpClientConfig.Builder => DefaultAsyncHttpClientConfig.Builder,
+      options: SttpBackendOptions = SttpBackendOptions.Default
+  )(implicit s: Scheduler = Scheduler.Implicits.global): SttpBackend[Task, Observable[ByteBuffer]] =
+    AsyncHttpClientMonixBackend(
+      AsyncHttpClientBackend.clientWithModifiedOptions(options, updateConfig),
+      closeClient = true
+    )
 
   /**
     * @param s The scheduler used for streaming request bodies. Defaults to the

--- a/async-http-client-backend/scalaz/src/main/scala/com/softwaremill/sttp/asynchttpclient/scalaz/AsyncHttpClientScalazBackend.scala
+++ b/async-http-client-backend/scalaz/src/main/scala/com/softwaremill/sttp/asynchttpclient/scalaz/AsyncHttpClientScalazBackend.scala
@@ -6,9 +6,13 @@ import com.softwaremill.sttp.asynchttpclient.AsyncHttpClientBackend
 import com.softwaremill.sttp.impl.scalaz.TaskMonadAsyncError
 import com.softwaremill.sttp.{FollowRedirectsBackend, SttpBackend, SttpBackendOptions}
 import io.netty.buffer.ByteBuf
-import org.asynchttpclient.{AsyncHttpClient, AsyncHttpClientConfig, DefaultAsyncHttpClient}
+import org.asynchttpclient.{
+  AsyncHttpClient,
+  AsyncHttpClientConfig,
+  DefaultAsyncHttpClient,
+  DefaultAsyncHttpClientConfig
+}
 import org.reactivestreams.Publisher
-
 import scalaz.concurrent.Task
 
 class AsyncHttpClientScalazBackend private (asyncHttpClient: AsyncHttpClient, closeClient: Boolean)
@@ -33,6 +37,15 @@ object AsyncHttpClientScalazBackend {
 
   def usingConfig(cfg: AsyncHttpClientConfig): SttpBackend[Task, Nothing] =
     AsyncHttpClientScalazBackend(new DefaultAsyncHttpClient(cfg), closeClient = true)
+
+  def usingConfigBuilder(
+      updateConfig: DefaultAsyncHttpClientConfig.Builder => DefaultAsyncHttpClientConfig.Builder,
+      options: SttpBackendOptions = SttpBackendOptions.Default
+  ): SttpBackend[Task, Nothing] =
+    AsyncHttpClientScalazBackend(
+      AsyncHttpClientBackend.clientWithModifiedOptions(options, updateConfig),
+      closeClient = true
+    )
 
   def usingClient(client: AsyncHttpClient): SttpBackend[Task, Nothing] =
     AsyncHttpClientScalazBackend(client, closeClient = false)

--- a/async-http-client-backend/src/main/scala/com/softwaremill/sttp/asynchttpclient/AsyncHttpClientBackend.scala
+++ b/async-http-client-backend/src/main/scala/com/softwaremill/sttp/asynchttpclient/AsyncHttpClientBackend.scala
@@ -11,7 +11,7 @@ import io.netty.buffer.ByteBuf
 import io.netty.handler.codec.http.HttpHeaders
 import org.asynchttpclient.AsyncHandler.State
 import org.asynchttpclient.handler.StreamedAsyncHandler
-import org.asynchttpclient.proxy.{ProxyServer, ProxyType}
+import org.asynchttpclient.proxy.ProxyServer
 import org.asynchttpclient.request.body.multipart.{ByteArrayPart, FilePart, StringPart}
 import org.asynchttpclient.{
   AsyncCompletionHandler,
@@ -317,7 +317,7 @@ object AsyncHttpClientBackend {
     options.proxy match {
       case None => configBuilder
       case Some(p) =>
-        val proxyType: ProxyType =
+        val proxyType: org.asynchttpclient.proxy.ProxyType =
           p.proxyType match {
             case Socks => org.asynchttpclient.proxy.ProxyType.SOCKS_V5
             case Http  => org.asynchttpclient.proxy.ProxyType.HTTP

--- a/async-http-client-backend/zio/src/main/scala/com/softwaremill/sttp/asynchttpclient/zio/AsyncHttpClientZioBackend.scala
+++ b/async-http-client-backend/zio/src/main/scala/com/softwaremill/sttp/asynchttpclient/zio/AsyncHttpClientZioBackend.scala
@@ -6,9 +6,13 @@ import com.softwaremill.sttp.asynchttpclient.AsyncHttpClientBackend
 import com.softwaremill.sttp.impl.zio.IOMonadAsyncError
 import com.softwaremill.sttp.{FollowRedirectsBackend, SttpBackend, SttpBackendOptions}
 import io.netty.buffer.ByteBuf
-import org.asynchttpclient.{AsyncHttpClient, AsyncHttpClientConfig, DefaultAsyncHttpClient}
+import org.asynchttpclient.{
+  AsyncHttpClient,
+  AsyncHttpClientConfig,
+  DefaultAsyncHttpClient,
+  DefaultAsyncHttpClientConfig
+}
 import org.reactivestreams.Publisher
-import scalaz.zio._
 
 class AsyncHttpClientZioBackend private (asyncHttpClient: AsyncHttpClient, closeClient: Boolean)
     extends AsyncHttpClientBackend[IO[Throwable, ?], Nothing](asyncHttpClient, IOMonadAsyncError, closeClient) {
@@ -32,6 +36,15 @@ object AsyncHttpClientZioBackend {
 
   def usingConfig(cfg: AsyncHttpClientConfig): SttpBackend[IO[Throwable, ?], Nothing] =
     AsyncHttpClientZioBackend(new DefaultAsyncHttpClient(cfg), closeClient = true)
+
+  def usingConfigBuilder(
+      updateConfig: DefaultAsyncHttpClientConfig.Builder => DefaultAsyncHttpClientConfig.Builder,
+      options: SttpBackendOptions = SttpBackendOptions.Default
+  ): SttpBackend[IO[Throwable, ?], Nothing] =
+    AsyncHttpClientZioBackend(
+      AsyncHttpClientBackend.clientWithModifiedOptions(options, updateConfig),
+      closeClient = true
+    )
 
   def usingClient(client: AsyncHttpClient): SttpBackend[IO[Throwable, ?], Nothing] =
     AsyncHttpClientZioBackend(client, closeClient = false)

--- a/docs/backends/asynchttpclient.rst
+++ b/docs/backends/asynchttpclient.rst
@@ -34,7 +34,7 @@ Next you'll need to add an implicit value::
   
   // or, if you're using the scalaz version:
   implicit val sttpBackend = AsyncHttpClientScalazBackend()
-  
+
   // or, if you're using the zio version:
   implicit val sttpBackend = AsyncHttpClientZioBackend()
   
@@ -43,7 +43,7 @@ Next you'll need to add an implicit value::
   
   // or, if you're using the cats effect version:
   implicit val sttpBackend = AsyncHttpClientCatsBackend[cats.effect.IO]()
-  
+
   // or, if you're using the fs2 version:
   implicit val sttpBackend = AsyncHttpClientFs2Backend[cats.effect.IO]()
   

--- a/docs/backends/asynchttpclient.rst
+++ b/docs/backends/asynchttpclient.rst
@@ -17,7 +17,7 @@ To use, add the following dependency to your project::
 
 This backend depends on `async-http-client <https://github.com/AsyncHttpClient/async-http-client>`_.
 A fully **asynchronous** backend, which uses `Netty <http://netty.io>`_ behind the
-scenes.
+scenes. 
 
 The responses are wrapped depending on the dependency chosen in either a:
 
@@ -31,28 +31,28 @@ The responses are wrapped depending on the dependency chosen in either a:
 Next you'll need to add an implicit value::
 
   implicit val sttpBackend = AsyncHttpClientFutureBackend()
-
+  
   // or, if you're using the scalaz version:
   implicit val sttpBackend = AsyncHttpClientScalazBackend()
-
+  
   // or, if you're using the zio version:
   implicit val sttpBackend = AsyncHttpClientZioBackend()
-
+  
   // or, if you're using the monix version:
   implicit val sttpBackend = AsyncHttpClientMonixBackend()
-
+  
   // or, if you're using the cats effect version:
   implicit val sttpBackend = AsyncHttpClientCatsBackend[cats.effect.IO]()
-
+  
   // or, if you're using the fs2 version:
   implicit val sttpBackend = AsyncHttpClientFs2Backend[cats.effect.IO]()
-
+  
   // or, if you'd like to use custom configuration:
   implicit val sttpBackend = AsyncHttpClientFutureBackend.usingConfig(asyncHttpClientConfig)
-
+  
   // or, if you'd like to use adjust the configuration sttp creates:
   implicit val sttpBackend = AsyncHttpClientFutureBackend.usingConfigBuilder(adjustFunction, sttpOptions)
-
+  
   // or, if you'd like to instantiate the AsyncHttpClient yourself:
   implicit val sttpBackend = AsyncHttpClientFutureBackend.usingClient(asyncHttpClient)
 
@@ -63,10 +63,10 @@ The Monix backend supports streaming (as both Monix and Async Http Client suppor
 
   import com.softwaremill.sttp._
   import com.softwaremill.sttp.asynchttpclient.monix._
-
+  
   import java.nio.ByteBuffer
   import monix.reactive.Observable
-
+  
   implicit val sttpBackend = AsyncHttpClientMonixBackend()
 
   val obs: Observable[ByteBuffer] =  ...
@@ -79,15 +79,15 @@ And receive responses as an observable stream::
 
   import com.softwaremill.sttp._
   import com.softwaremill.sttp.asynchttpclient.monix._
-
+  
   import java.nio.ByteBuffer
   import monix.eval.Task
   import monix.reactive.Observable
   import scala.concurrent.duration.Duration
 
   implicit val sttpBackend = AsyncHttpClientMonixBackend()
-
-  val response: Task[Response[Observable[ByteBuffer]]] =
+  
+  val response: Task[Response[Observable[ByteBuffer]]] = 
     sttp
       .post(uri"...")
       .response(asStream[Observable[ByteBuffer]])

--- a/docs/backends/asynchttpclient.rst
+++ b/docs/backends/asynchttpclient.rst
@@ -17,7 +17,7 @@ To use, add the following dependency to your project::
 
 This backend depends on `async-http-client <https://github.com/AsyncHttpClient/async-http-client>`_.
 A fully **asynchronous** backend, which uses `Netty <http://netty.io>`_ behind the
-scenes. 
+scenes.
 
 The responses are wrapped depending on the dependency chosen in either a:
 
@@ -31,25 +31,28 @@ The responses are wrapped depending on the dependency chosen in either a:
 Next you'll need to add an implicit value::
 
   implicit val sttpBackend = AsyncHttpClientFutureBackend()
-  
+
   // or, if you're using the scalaz version:
   implicit val sttpBackend = AsyncHttpClientScalazBackend()
 
   // or, if you're using the zio version:
   implicit val sttpBackend = AsyncHttpClientZioBackend()
-  
+
   // or, if you're using the monix version:
   implicit val sttpBackend = AsyncHttpClientMonixBackend()
-  
+
   // or, if you're using the cats effect version:
   implicit val sttpBackend = AsyncHttpClientCatsBackend[cats.effect.IO]()
 
   // or, if you're using the fs2 version:
   implicit val sttpBackend = AsyncHttpClientFs2Backend[cats.effect.IO]()
-  
+
   // or, if you'd like to use custom configuration:
   implicit val sttpBackend = AsyncHttpClientFutureBackend.usingConfig(asyncHttpClientConfig)
-  
+
+  // or, if you'd like to use adjust the configuration sttp creates:
+  implicit val sttpBackend = AsyncHttpClientFutureBackend.usingConfigBuilder(adjustFunction, sttpOptions)
+
   // or, if you'd like to instantiate the AsyncHttpClient yourself:
   implicit val sttpBackend = AsyncHttpClientFutureBackend.usingClient(asyncHttpClient)
 
@@ -60,10 +63,10 @@ The Monix backend supports streaming (as both Monix and Async Http Client suppor
 
   import com.softwaremill.sttp._
   import com.softwaremill.sttp.asynchttpclient.monix._
-  
+
   import java.nio.ByteBuffer
   import monix.reactive.Observable
-  
+
   implicit val sttpBackend = AsyncHttpClientMonixBackend()
 
   val obs: Observable[ByteBuffer] =  ...
@@ -76,15 +79,15 @@ And receive responses as an observable stream::
 
   import com.softwaremill.sttp._
   import com.softwaremill.sttp.asynchttpclient.monix._
-  
+
   import java.nio.ByteBuffer
   import monix.eval.Task
   import monix.reactive.Observable
   import scala.concurrent.duration.Duration
 
   implicit val sttpBackend = AsyncHttpClientMonixBackend()
-  
-  val response: Task[Response[Observable[ByteBuffer]]] = 
+
+  val response: Task[Response[Observable[ByteBuffer]]] =
     sttp
       .post(uri"...")
       .response(asStream[Observable[ByteBuffer]])


### PR DESCRIPTION
Sometimes one wants to change one single option in the underlying client, but with what sttp currently offers one can only create the complete config oneself (which means manually setting all the things sttp usually gets from `SttpBackendOptions`) - this PR allows to modify the config after it was initialised by sttp, making custom setups easier and less boilerplaty.