### PR TITLE
Adding sttp MonadError instance for cats MonadError

### DIFF
--- a/implementations/cats/src/main/scala/com/softwaremill/sttp/impl/cats/AsyncMonadAsyncError.scala
+++ b/implementations/cats/src/main/scala/com/softwaremill/sttp/impl/cats/AsyncMonadAsyncError.scala
@@ -5,22 +5,11 @@ import com.softwaremill.sttp.MonadAsyncError
 
 import scala.language.higherKinds
 
-class AsyncMonadAsyncError[F[_]](implicit F: Async[F]) extends MonadAsyncError[F] {
+class AsyncMonadAsyncError[F[_]](implicit F: Async[F]) extends CatsMonadError[F] with MonadAsyncError[F] {
 
   override def async[T](register: ((Either[Throwable, T]) => Unit) => Unit): F[T] =
     F.async(register)
 
-  override def unit[T](t: T): F[T] = F.pure(t)
-
-  override def map[T, T2](fa: F[T])(f: (T) => T2): F[T2] = F.map(fa)(f)
-
-  override def flatMap[T, T2](fa: F[T])(f: (T) => F[T2]): F[T2] =
-    F.flatMap(fa)(f)
-
-  override def error[T](t: Throwable): F[T] = F.raiseError(t)
-
-  override protected def handleWrappedError[T](rt: F[T])(h: PartialFunction[Throwable, F[T]]): F[T] =
-    F.recoverWith(rt)(h)
 }
 
 class EffectMonadAsyncError[F[_]](implicit F: Effect[F]) extends AsyncMonadAsyncError[F]

--- a/implementations/cats/src/main/scala/com/softwaremill/sttp/impl/cats/CatsMonadError.scala
+++ b/implementations/cats/src/main/scala/com/softwaremill/sttp/impl/cats/CatsMonadError.scala
@@ -1,0 +1,20 @@
+package com.softwaremill.sttp.impl.cats
+
+import com.softwaremill.sttp.MonadError
+
+import scala.language.higherKinds
+
+class CatsMonadError[F[_]](implicit F: cats.MonadError[F, Throwable]) extends MonadError[F] {
+
+  override def unit[T](t: T): F[T] = F.pure(t)
+
+  override def map[T, T2](fa: F[T])(f: T => T2): F[T2] = F.map(fa)(f)
+
+  override def flatMap[T, T2](fa: F[T])(f: T => F[T2]): F[T2] =
+    F.flatMap(fa)(f)
+
+  override def error[T](t: Throwable): F[T] = F.raiseError(t)
+
+  override protected def handleWrappedError[T](rt: F[T])(h: PartialFunction[Throwable, F[T]]): F[T] =
+    F.recoverWith(rt)(h)
+}


### PR DESCRIPTION
There is `AsyncMonadAsyncError`, which adds `MonadAsyncError` for any `Async[F]` instance, but there was no sync `MonadError` instance basing on cats `MonadError`, so I've added `CatsMonadError`, which is then extended by `AsyncMonadAsyncError`

I'd consider also adding implicits into `com.softwaremill.sttp.impl.cats.implicits`, ideally dividing them into cats-like hierarchy, so:
`implicit.all._` - containing both:
`instances.all._` - `MonadAsyncError`, `MonadError` (with some traits hierarchy to proper order them) 
`syntax.all._` - `mapK`

or simpler 
`implicit._` - containing both:
`instances._` - `MonadAsyncError`, `MonadError` (with some traits hierarchy to proper order them) 
`syntax._` - `mapK`

Pls let me know what's your opinion on this MR, and the implicit proposal ;)