### PR TITLE
Add implicit MonadError, MonadAsyncError for their cats equivalents

### DIFF
--- a/implementations/cats/src/main/scala/com/softwaremill/sttp/impl/cats/implicits.scala
+++ b/implementations/cats/src/main/scala/com/softwaremill/sttp/impl/cats/implicits.scala
@@ -1,16 +1,23 @@
 package com.softwaremill.sttp.impl.cats
 
-import com.softwaremill.sttp.{MonadError, Request, Response, SttpBackend}
+import cats.effect.Async
+import com.softwaremill.sttp.{MonadAsyncError, MonadError, Request, Response, SttpBackend}
 import cats.~>
 
 import scala.language.higherKinds
 
 object implicits extends CatsImplicits
 
-trait CatsImplicits {
+trait CatsImplicits extends LowLevelCatsImplicits {
   implicit def sttpBackendToCatsMappableSttpBackend[R[_], S](
       sttpBackend: SttpBackend[R, S]
   ): MappableSttpBackend[R, S] = new MappableSttpBackend(sttpBackend)
+
+  implicit def asyncMonadError[F[_]: Async]: MonadAsyncError[F] = new AsyncMonadAsyncError[F]
+}
+
+trait LowLevelCatsImplicits {
+  implicit def catsMonadError[F[_]](implicit E: cats.MonadError[F, Throwable]): MonadError[F] = new CatsMonadError[F]
 }
 
 class MappableSttpBackend[R[_], S] private[cats] (val sttpBackend: SttpBackend[R, S]) extends AnyVal {


### PR DESCRIPTION
Added implicits in `com.softwaremill.sttp.impl.cats.implicits` for `MonadError`, `MonadAsyncError` basing on `CatsMonadError` and `AsyncMonadAsyncError`.

This was proposed earlier in previous MR:
https://github.com/softwaremill/sttp/pull/203

The change is breaking, as if someone has already implemented their own instances of sttp `MonadError` and has it in scope. On the other hand there is probably low benefit of having own instance, as it most probably is completely the same.