### PR TITLE
Ability to flat map response in the core

### DIFF
--- a/core/shared/src/main/scala/com/softwaremill/sttp/RequestT.scala
+++ b/core/shared/src/main/scala/com/softwaremill/sttp/RequestT.scala
@@ -204,6 +204,9 @@ case class RequestT[U[_], T, +S](
   def mapResponse[T2](f: T => T2): RequestT[U, T2, S] =
     this.copy(response = response.map(f))
 
+  def flatMapResponse[T2, S2 >: S](f: T => Request[T2, S2]) =
+    this.copy(response = response.flatMap(f))
+
   def followRedirects(fr: Boolean): RequestT[U, T, S] =
     this.copy(options = options.copy(followRedirects = fr))
 


### PR DESCRIPTION
In a few words: 
- Preserving style of `mapResponse` in `RequestT` I added `flatMapResponse` there
- As well as `FlatMappedResponseAs` to response mappers. It's made in a bit different fashion - to imprint all the transformation stages as values, but not as functions (as in `MappedResponseAs`) to be able to process it appropriately in Backends later on.

I tried different approaches to this problem (#231), this one seemed the most simple and compliant with library design to me. So we're no saying that ReqestT is full-fledged monad with map, flatMap and everything, but we leave the ability to compose requests using this specific approach. 

What do you think?