### PR TITLE
make HttpURLConnectionBackend extensible

### DIFF
--- a/core/jvm/src/main/scala/com/softwaremill/sttp/HttpURLConnectionBackend.scala
+++ b/core/jvm/src/main/scala/com/softwaremill/sttp/HttpURLConnectionBackend.scala
@@ -56,7 +56,7 @@ class HttpURLConnectionBackend protected (opts: SttpBackendOptions, customizeCon
 
   override val responseMonad: MonadError[Id] = IdMonad
 
-  protected def openConnection(uri: Uri): HttpURLConnection = {
+  private def openConnection(uri: Uri): HttpURLConnection = {
     val url = new URL(uri.toString)
     val conn = opts.proxy match {
       case Some(p) if !p.ignoreProxy(uri.host) =>
@@ -68,12 +68,16 @@ class HttpURLConnectionBackend protected (opts: SttpBackendOptions, customizeCon
           })
         }
 
-        url.openConnection(p.asJavaProxy)
-      case _ => url.openConnection()
+        openConnection(url, p.asJavaProxy)
+      case _ => openConnection(url)
     }
 
     conn.asInstanceOf[HttpURLConnection]
   }
+
+  protected def openConnection(url: URL, p: java.net.Proxy): HttpURLConnection = url.openConnection(p)
+
+  protected def openConnection(url: URL): HttpURLConnection = url.openConnection()
 
   private def writeBody(body: RequestBody[Nothing], c: HttpURLConnection): Option[OutputStream] = {
     body match {

--- a/core/jvm/src/main/scala/com/softwaremill/sttp/HttpURLConnectionBackend.scala
+++ b/core/jvm/src/main/scala/com/softwaremill/sttp/HttpURLConnectionBackend.scala
@@ -1,7 +1,7 @@
 package com.softwaremill.sttp
 
 import java.io._
-import java.net.{Authenticator, HttpURLConnection, PasswordAuthentication, URL}
+import java.net.{Authenticator, HttpURLConnection, PasswordAuthentication, URL, URLConnection}
 import java.nio.channels.Channels
 import java.nio.charset.CharacterCodingException
 import java.nio.file.Files
@@ -75,9 +75,9 @@ class HttpURLConnectionBackend protected (opts: SttpBackendOptions, customizeCon
     conn.asInstanceOf[HttpURLConnection]
   }
 
-  protected def openConnection(url: URL, p: java.net.Proxy): HttpURLConnection = url.openConnection(p)
+  protected def openConnection(url: URL, p: java.net.Proxy): URLConnection = url.openConnection(p)
 
-  protected def openConnection(url: URL): HttpURLConnection = url.openConnection()
+  protected def openConnection(url: URL): URLConnection = url.openConnection()
 
   private def writeBody(body: RequestBody[Nothing], c: HttpURLConnection): Option[OutputStream] = {
     body match {

--- a/core/jvm/src/main/scala/com/softwaremill/sttp/HttpURLConnectionBackend.scala
+++ b/core/jvm/src/main/scala/com/softwaremill/sttp/HttpURLConnectionBackend.scala
@@ -16,7 +16,7 @@ import scala.concurrent.duration.Duration
 import scala.io.Source
 import scala.util.Try
 
-class HttpURLConnectionBackend private (opts: SttpBackendOptions, customizeConnection: HttpURLConnection => Unit)
+class HttpURLConnectionBackend protected (opts: SttpBackendOptions, customizeConnection: HttpURLConnection => Unit)
     extends SttpBackend[Id, Nothing] {
 
   override def send[T](r: Request[T, Nothing]): Response[T] = {
@@ -56,7 +56,7 @@ class HttpURLConnectionBackend private (opts: SttpBackendOptions, customizeConne
 
   override val responseMonad: MonadError[Id] = IdMonad
 
-  private def openConnection(uri: Uri): HttpURLConnection = {
+  protected def openConnection(uri: Uri): HttpURLConnection = {
     val url = new URL(uri.toString)
     val conn = opts.proxy match {
       case Some(p) if !p.ignoreProxy(uri.host) =>


### PR DESCRIPTION
Hi, 
We have been using this library in our tool runs in Hadoop YARN and deals with hadoop security that has custom authentication mechanism and special class for (http) authentication - [see](https://github.com/hopshadoop/hops/blob/5c3f2e501840fa123e672b24a53ffabfcd85bd95/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/web/URLConnectionFactory.java#L149). It would be nice if we could just extend HttpURLConnectionBackend and override openConnection.