### PR TITLE
Add Uri.parse

### DIFF
--- a/core/shared/src/main/scala/com/softwaremill/sttp/Uri.scala
+++ b/core/shared/src/main/scala/com/softwaremill/sttp/Uri.scala
@@ -189,7 +189,7 @@ object Uri {
   def apply(javaUri: URI): Uri = uri"${javaUri.toString}"
 
   def parse(uri: String): Try[Uri] =
-    Try(apply(URI.create(uri)))
+    Try(uri"$uri")
 
   sealed trait QueryFragment
   object QueryFragment {

--- a/core/shared/src/main/scala/com/softwaremill/sttp/Uri.scala
+++ b/core/shared/src/main/scala/com/softwaremill/sttp/Uri.scala
@@ -1,6 +1,7 @@
 package com.softwaremill.sttp
 
 import java.net.URI
+
 import Uri.{QueryFragment, QueryFragmentEncoding, UserInfo}
 import Uri.QueryFragment.{KeyValue, Plain, Value}
 
@@ -8,6 +9,7 @@ import scala.annotation.tailrec
 import scala.collection.immutable.Seq
 import scala.collection.mutable
 import scala.collection.mutable.ListBuffer
+import scala.util.Try
 
 /**
   * A [[https://en.wikipedia.org/wiki/Uniform_Resource_Identifier URI]].
@@ -185,6 +187,9 @@ object Uri {
   def apply(scheme: String, host: String, path: Seq[String]): Uri =
     Uri(scheme, None, host, None, path, Vector.empty, None)
   def apply(javaUri: URI): Uri = uri"${javaUri.toString}"
+
+  def parse(uri: String): Try[Uri] =
+    Try(apply(URI.create(uri)))
 
   sealed trait QueryFragment
   object QueryFragment {

--- a/core/shared/src/test/scala/com/softwaremill/sttp/UriTests.scala
+++ b/core/shared/src/test/scala/com/softwaremill/sttp/UriTests.scala
@@ -3,9 +3,9 @@ package com.softwaremill.sttp
 import java.net.URI
 
 import com.softwaremill.sttp.Uri.{QueryFragment, QueryFragmentEncoding, UserInfo}
-import org.scalatest.{FunSuite, Matchers}
+import org.scalatest.{FunSuite, Matchers, TryValues}
 
-class UriTests extends FunSuite with Matchers {
+class UriTests extends FunSuite with Matchers with TryValues {
 
   val QF = QueryFragment
 
@@ -114,6 +114,11 @@ class UriTests extends FunSuite with Matchers {
   test("should convert from java URI") {
     val uriAsString = "https://sub.example.com:8080/a/b/xyz?p1=v1&p2=v2#f"
     Uri(URI.create(uriAsString)).toString should be(uriAsString)
+  }
+
+  test("should parse raw string") {
+    val uriAsString = "https://sub.example.com:8080/a/b/xyz?p1=v1&p2=v2#f"
+    Uri.parse(uriAsString).success.value.toString should be(uriAsString)
   }
 
   test("should convert to java URI") {

--- a/core/shared/src/test/scala/com/softwaremill/sttp/UriTests.scala
+++ b/core/shared/src/test/scala/com/softwaremill/sttp/UriTests.scala
@@ -119,6 +119,8 @@ class UriTests extends FunSuite with Matchers with TryValues {
   test("should parse raw string") {
     val uriAsString = "https://sub.example.com:8080/a/b/xyz?p1=v1&p2=v2#f"
     Uri.parse(uriAsString).success.value.toString should be(uriAsString)
+    val badString = "xyz://foobar:80:37/?&?"
+    Uri.parse(badString) should be a 'failure
   }
 
   test("should convert to java URI") {


### PR DESCRIPTION
Useful for some cases, for example when implementing a pureconfig reader for `Uri`s