### PR TITLE
Make type signature of AsyncHttpClientZioBackend less scary

### DIFF
--- a/async-http-client-backend/zio/src/main/scala/com/softwaremill/sttp/asynchttpclient/zio/AsyncHttpClientZioBackend.scala
+++ b/async-http-client-backend/zio/src/main/scala/com/softwaremill/sttp/asynchttpclient/zio/AsyncHttpClientZioBackend.scala
@@ -29,13 +29,13 @@ class AsyncHttpClientZioBackend private (asyncHttpClient: AsyncHttpClient, close
 }
 
 object AsyncHttpClientZioBackend {
-  private def apply(asyncHttpClient: AsyncHttpClient, closeClient: Boolean): SttpBackend[IO[Throwable, ?], Nothing] =
-    new FollowRedirectsBackend[IO[Throwable, ?], Nothing](new AsyncHttpClientZioBackend(asyncHttpClient, closeClient))
+  private def apply(asyncHttpClient: AsyncHttpClient, closeClient: Boolean): SttpBackend[Task, Nothing] =
+    new FollowRedirectsBackend[Task, Nothing](new AsyncHttpClientZioBackend(asyncHttpClient, closeClient))
 
-  def apply(options: SttpBackendOptions = SttpBackendOptions.Default): SttpBackend[IO[Throwable, ?], Nothing] =
+  def apply(options: SttpBackendOptions = SttpBackendOptions.Default): SttpBackend[Task, Nothing] =
     AsyncHttpClientZioBackend(AsyncHttpClientBackend.defaultClient(options), closeClient = true)
 
-  def usingConfig(cfg: AsyncHttpClientConfig): SttpBackend[IO[Throwable, ?], Nothing] =
+  def usingConfig(cfg: AsyncHttpClientConfig): SttpBackend[Task, Nothing] =
     AsyncHttpClientZioBackend(new DefaultAsyncHttpClient(cfg), closeClient = true)
 
   /**
@@ -44,12 +44,12 @@ object AsyncHttpClientZioBackend {
   def usingConfigBuilder(
       updateConfig: DefaultAsyncHttpClientConfig.Builder => DefaultAsyncHttpClientConfig.Builder,
       options: SttpBackendOptions = SttpBackendOptions.Default
-  ): SttpBackend[IO[Throwable, ?], Nothing] =
+  ): SttpBackend[Task, Nothing] =
     AsyncHttpClientZioBackend(
       AsyncHttpClientBackend.clientWithModifiedOptions(options, updateConfig),
       closeClient = true
     )
 
-  def usingClient(client: AsyncHttpClient): SttpBackend[IO[Throwable, ?], Nothing] =
+  def usingClient(client: AsyncHttpClient): SttpBackend[Task, Nothing] =
     AsyncHttpClientZioBackend(client, closeClient = false)
 }


### PR DESCRIPTION
# Problem
When Intellij automatically adds the type annotation for this line of code: 
`implicit val backend = AsyncHttpClientZioBackend()`
it becomes the following:
`implicit val backend: SttpBackend[({type λ[β$3$] = ZIO[Any, Throwable, β$3$]})#λ, Nothing] = AsyncHttpClientZioBackend()`.

# Why this PR is needed
This PR simplifies the type signature of the public API of AsyncHttpClientZioBackend, making it easier for people new to ZIO (for e.g. me) to understand how to use it with the sttp client.

# Changes
Change all signatures in AsyncHttpClientZioBackend from `zio.IO[Throwable, ?]` to `zio.Task`

# Notes
This PR should be backwards compatible as an `IO[Throwable, ?]` **is** a `Task`. Nonetheless I have manually tested that declaring 
`implicit val backend: SttpBackend[Task, Nothing] = AsyncHttpClientZioBackend()`
works on v1.7.1 and on this PR.