### PR TITLE
Use the most recent Scala versions (2.13.1 and 2.12.10)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ dist: trusty
 scala:
 - 2.12.9
 - 2.11.12
-- 2.13.0
+- 2.13.1
 before_cache:
   - du -h -d 1 $HOME/.ivy2/
   - du -h -d 2 $HOME/.sbt/

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ jdk:
 - oraclejdk8
 dist: trusty
 scala:
-- 2.12.9
+- 2.12.10
 - 2.11.12
 - 2.13.1
 before_cache:

--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ import com.softwaremill.Publish.Release.updateVersionInDocs
 
 val scala2_11 = "2.11.12"
 val scala2_12 = "2.12.9"
-val scala2_13 = "2.13.0"
+val scala2_13 = "2.13.1"
 
 lazy val testServerPort = settingKey[Int]("Port to run the http test server on (used by JS tests)")
 lazy val startTestServer = taskKey[Unit]("Start a http server used by tests (used by JS tests)")

--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@ import sbtrelease.ReleasePlugin.autoImport._
 import com.softwaremill.Publish.Release.updateVersionInDocs
 
 val scala2_11 = "2.11.12"
-val scala2_12 = "2.12.9"
+val scala2_12 = "2.12.10"
 val scala2_13 = "2.13.1"
 
 lazy val testServerPort = settingKey[Int]("Port to run the http test server on (used by JS tests)")


### PR DESCRIPTION
Update Scala
from 2.13.0 to 2.13.1
and from 2.12.9 to 2.12.10
