### PR TITLE
Add websocket support to async-http-client fs2 backend

### DIFF
--- a/async-http-client-backend/fs2/src/main/scala/sttp/client/asynchttpclient/fs2/Fs2WebSocketHandler.scala
+++ b/async-http-client-backend/fs2/src/main/scala/sttp/client/asynchttpclient/fs2/Fs2WebSocketHandler.scala
@@ -13,31 +13,38 @@ object Fs2WebSocketHandler {
   private class Fs2AsyncQueue[F[_], A](queue: InspectableQueue[F, A])(implicit F: Effect[F]) extends AsyncQueue[F, A] {
     override def clear(): Unit =
       F.runAsync(queue.getSize.flatMap { size =>
-        queue.dequeue.take(size.toLong).compile.drain
-      })(IO.fromEither).unsafeRunSync()
+          queue.dequeue.take(size.toLong).compile.drain
+        })(IO.fromEither)
+        .unsafeRunSync()
 
     override def offer(t: A): Unit =
       F.runAsync(queue.offer1(t))(IO.fromEither(_).flatMap {
-        case true => IO.unit
-        case false => IO.raiseError(new WebSocketBufferFull())
-      }).unsafeRunSync()
+          case true  => IO.unit
+          case false => IO.raiseError(new WebSocketBufferFull())
+        })
+        .unsafeRunSync()
 
     override def poll: F[A] = queue.dequeue1
   }
+
   /**
     * Creates a new [[WebSocketHandler]] which should be used *once* to send and receive from a single websocket.
     * @param incomingBufferCapacity Should the buffer of incoming websocket events be bounded. If yes, unreceived
     *                               events will some point cause the websocket to error and close. If no, unreceived
     *                               messages will take up all available memory.
     */
-  def apply[F[_]](incomingBufferCapacity: Option[Int] = None)(implicit F: ConcurrentEffect[F]): F[WebSocketHandler[WebSocket[F]]] =
+  def apply[F[_]](
+      incomingBufferCapacity: Option[Int] = None
+  )(implicit F: ConcurrentEffect[F]): F[WebSocketHandler[WebSocket[F]]] =
     apply(incomingBufferCapacity.fold(InspectableQueue.unbounded[F, WebSocketEvent])(InspectableQueue.bounded))
 
   /**
     * Creates a new [[WebSocketHandler]] which should be used *once* to send and receive from a single websocket.
     * @param createQueue Effect to create an [[InspectableQueue]] which is used to buffer incoming messages.
     */
-  def apply[F[_]](createQueue: F[InspectableQueue[F, WebSocketEvent]])(implicit F: Effect[F]): F[WebSocketHandler[WebSocket[F]]] = {
+  def apply[F[_]](
+      createQueue: F[InspectableQueue[F, WebSocketEvent]]
+  )(implicit F: Effect[F]): F[WebSocketHandler[WebSocket[F]]] = {
     createQueue.flatMap { queue =>
       F.delay {
         NativeWebSocketHandler[F](

--- a/async-http-client-backend/fs2/src/main/scala/sttp/client/asynchttpclient/fs2/Fs2WebSocketHandler.scala
+++ b/async-http-client-backend/fs2/src/main/scala/sttp/client/asynchttpclient/fs2/Fs2WebSocketHandler.scala
@@ -1,0 +1,50 @@
+package sttp.client.asynchttpclient.fs2
+
+import cats.effect._
+import cats.implicits._
+import fs2.concurrent.InspectableQueue
+import sttp.client.asynchttpclient.WebSocketHandler
+import sttp.client.asynchttpclient.internal.{AsyncQueue, NativeWebSocketHandler}
+import sttp.client.impl.cats.CatsMonadAsyncError
+import sttp.client.ws.{WebSocket, WebSocketEvent}
+import sttp.model.ws.WebSocketBufferFull
+
+object Fs2WebSocketHandler {
+  private class Fs2AsyncQueue[F[_], A](queue: InspectableQueue[F, A])(implicit F: Effect[F]) extends AsyncQueue[F, A] {
+    override def clear(): Unit =
+      F.runAsync(queue.getSize.flatMap { size =>
+        queue.dequeue.take(size.toLong).compile.drain
+      })(IO.fromEither).unsafeRunSync()
+
+    override def offer(t: A): Unit =
+      F.runAsync(queue.offer1(t))(IO.fromEither(_).flatMap {
+        case true => IO.unit
+        case false => IO.raiseError(new WebSocketBufferFull())
+      }).unsafeRunSync()
+
+    override def poll: F[A] = queue.dequeue1
+  }
+  /**
+    * Creates a new [[WebSocketHandler]] which should be used *once* to send and receive from a single websocket.
+    * @param incomingBufferCapacity Should the buffer of incoming websocket events be bounded. If yes, unreceived
+    *                               events will some point cause the websocket to error and close. If no, unreceived
+    *                               messages will take up all available memory.
+    */
+  def apply[F[_]](incomingBufferCapacity: Option[Int] = None)(implicit F: ConcurrentEffect[F]): F[WebSocketHandler[WebSocket[F]]] =
+    apply(incomingBufferCapacity.fold(InspectableQueue.unbounded[F, WebSocketEvent])(InspectableQueue.bounded))
+
+  /**
+    * Creates a new [[WebSocketHandler]] which should be used *once* to send and receive from a single websocket.
+    * @param createQueue Effect to create an [[InspectableQueue]] which is used to buffer incoming messages.
+    */
+  def apply[F[_]](createQueue: F[InspectableQueue[F, WebSocketEvent]])(implicit F: Effect[F]): F[WebSocketHandler[WebSocket[F]]] = {
+    createQueue.flatMap { queue =>
+      F.delay {
+        NativeWebSocketHandler[F](
+          new Fs2AsyncQueue[F, WebSocketEvent](queue),
+          new CatsMonadAsyncError
+        )
+      }
+    }
+  }
+}

--- a/async-http-client-backend/fs2/src/test/scala/sttp/client/asynchttpclient/fs2/AsyncHttpClientFs2WebsocketTest.scala
+++ b/async-http-client-backend/fs2/src/test/scala/sttp/client/asynchttpclient/fs2/AsyncHttpClientFs2WebsocketTest.scala
@@ -1,0 +1,107 @@
+package sttp.client.asynchttpclient.fs2
+
+import java.io.IOException
+import java.util.concurrent.ConcurrentLinkedQueue
+
+import cats.effect.{ContextShift, IO}
+import com.github.ghik.silencer.silent
+import org.asynchttpclient.ws.{WebSocketListener, WebSocket => AHCWebSocket}
+import org.scalatest.concurrent.{Eventually, IntegrationPatience}
+import org.scalatest.{AsyncFlatSpec, Matchers}
+import sttp.client._
+import sttp.client.asynchttpclient.WebSocketHandler
+import sttp.client.testing.{ConvertToFuture, TestHttpServer, ToFutureWrapper}
+
+import scala.collection.JavaConverters._
+import scala.concurrent.Future
+
+class AsyncHttpClientFs2WebsocketTest
+    extends AsyncFlatSpec
+    with Matchers
+    with TestHttpServer
+    with ToFutureWrapper
+    with Eventually
+    with IntegrationPatience {
+  implicit val cs: ContextShift[IO] = IO.contextShift(implicitly)
+  implicit val backend: SttpBackend[IO, Nothing, WebSocketHandler] = AsyncHttpClientFs2Backend[IO]().unsafeRunSync()
+  implicit val convertToFuture: ConvertToFuture[IO] = new ConvertToFuture[IO] {
+    override def toFuture[T](value: IO[T]): Future[T] = value.unsafeToFuture()
+  }
+
+  it should "send and receive two messages" in {
+    val received = new ConcurrentLinkedQueue[String]()
+    basicRequest
+      .get(uri"$wsEndpoint/ws/echo")
+      .openWebsocket(WebSocketHandler.fromListener(collectingListener(received)))
+      .map { response =>
+        response.result.sendTextFrame("test1").await()
+        response.result.sendTextFrame("test2").await()
+        eventually {
+          received.asScala.toList shouldBe List("echo: test1", "echo: test2")
+        }
+        response.result.sendCloseFrame().await()
+        succeed
+      }
+      .toFuture
+  }
+
+  it should "send and receive two messages (pipe version)" in {
+    val received = new ConcurrentLinkedQueue[String]()
+    basicRequest
+      .get(uri"$wsEndpoint/ws/echo")
+      .openWebsocket(WebSocketHandler.fromListener(collectingListener(received)))
+      .map { response =>
+        response.result.sendTextFrame("test1").await()
+        response.result.sendTextFrame("test2").await()
+        eventually {
+          received.asScala.toList shouldBe List("echo: test1", "echo: test2")
+        }
+        response.result.sendCloseFrame().await()
+        succeed
+      }
+      .toFuture
+  }
+
+  it should "receive two messages" in {
+    val received = new ConcurrentLinkedQueue[String]()
+    basicRequest
+      .get(uri"$wsEndpoint/ws/send_and_close")
+      .openWebsocket(WebSocketHandler.fromListener(collectingListener(received)))
+      .map { _ =>
+        eventually {
+          received.asScala.toList shouldBe List("test10", "test20")
+        }
+      }
+      .toFuture
+  }
+
+  it should "error if the endpoint is not a websocket" in {
+    basicRequest
+      .get(uri"$wsEndpoint/echo")
+      .openWebsocket(WebSocketHandler.fromListener(new WebSocketListener {
+        override def onOpen(websocket: AHCWebSocket): Unit = {}
+        override def onClose(websocket: AHCWebSocket, code: Int, reason: String): Unit = {}
+        override def onError(t: Throwable): Unit = {}
+      }))
+      .redeemWith(IO.pure, _ => IO.raiseError(new NoSuchElementException("Should be a failed")))
+      .map { t =>
+        t shouldBe a[IOException]
+      }
+      .toFuture()
+  }
+
+  def collectingListener(queue: ConcurrentLinkedQueue[String]): WebSocketListener = new WebSocketListener {
+    override def onOpen(websocket: AHCWebSocket): Unit = {}
+    override def onClose(websocket: AHCWebSocket, code: Int, reason: String): Unit = {}
+    override def onError(t: Throwable): Unit = {}
+    @silent("discarded")
+    override def onTextFrame(payload: String, finalFragment: Boolean, rsv: Int): Unit = {
+      queue.add(payload)
+    }
+  }
+
+  override protected def afterAll(): Unit = {
+    backend.close().toFuture
+    super.afterAll()
+  }
+}

--- a/async-http-client-backend/fs2/src/test/scala/sttp/client/asynchttpclient/fs2/Fs2WebsocketHandlerTest.scala
+++ b/async-http-client-backend/fs2/src/test/scala/sttp/client/asynchttpclient/fs2/Fs2WebsocketHandlerTest.scala
@@ -1,0 +1,28 @@
+package sttp.client.asynchttpclient.fs2
+
+import cats.effect.{ContextShift, IO, Timer}
+import sttp.client._
+import sttp.client.asynchttpclient.{WebSocketHandler, WebsocketHandlerTest}
+import sttp.client.impl.cats.CatsMonadAsyncError
+import sttp.client.monad.MonadError
+import sttp.client.testing.ConvertToFuture
+import sttp.client.ws.WebSocket
+
+import scala.concurrent.Future
+
+class Fs2WebsocketHandlerTest extends WebsocketHandlerTest[IO] {
+  implicit val backend: SttpBackend[IO, Nothing, WebSocketHandler] = AsyncHttpClientFs2Backend[IO]().unsafeRunSync()
+  implicit val convertToFuture: ConvertToFuture[IO] = new ConvertToFuture[IO] {
+    override def toFuture[T](value: IO[T]): Future[T] = value.unsafeToFuture()
+  }
+  override implicit val monad: MonadError[IO] = new CatsMonadAsyncError[IO]
+  implicit lazy val contextShift: ContextShift[IO] = IO.contextShift(implicitly)
+  implicit lazy val timer: Timer[IO] = IO.timer(implicitly)
+
+  override def createHandler: Option[Int] => WebSocketHandler[WebSocket[IO]] = Fs2WebSocketHandler[IO](_).unsafeRunSync()
+
+  override protected def afterAll(): Unit = {
+    backend.close().toFuture
+    super.afterAll()
+  }
+}

--- a/async-http-client-backend/fs2/src/test/scala/sttp/client/asynchttpclient/fs2/Fs2WebsocketHandlerTest.scala
+++ b/async-http-client-backend/fs2/src/test/scala/sttp/client/asynchttpclient/fs2/Fs2WebsocketHandlerTest.scala
@@ -19,7 +19,8 @@ class Fs2WebsocketHandlerTest extends WebsocketHandlerTest[IO] {
   implicit lazy val contextShift: ContextShift[IO] = IO.contextShift(implicitly)
   implicit lazy val timer: Timer[IO] = IO.timer(implicitly)
 
-  override def createHandler: Option[Int] => WebSocketHandler[WebSocket[IO]] = Fs2WebSocketHandler[IO](_).unsafeRunSync()
+  override def createHandler: Option[Int] => WebSocketHandler[WebSocket[IO]] =
+    Fs2WebSocketHandler[IO](_).unsafeRunSync()
 
   override protected def afterAll(): Unit = {
     backend.close().toFuture

--- a/docs/backends/asynchttpclient.rst
+++ b/docs/backends/asynchttpclient.rst
@@ -19,7 +19,7 @@ To use, add the following dependency to your project::
 
 This backend depends on `async-http-client <https://github.com/AsyncHttpClient/async-http-client>`_.
 A fully **asynchronous** backend, which uses `Netty <http://netty.io>`_ behind the
-scenes. 
+scenes.
 
 The responses are wrapped depending on the dependency chosen in either a:
 
@@ -33,7 +33,7 @@ The responses are wrapped depending on the dependency chosen in either a:
 Next you'll need to add an implicit value::
 
   implicit val sttpBackend = AsyncHttpClientFutureBackend()
-  
+
   // or, if you're using the scalaz version:
   implicit val sttpBackend = AsyncHttpClientScalazBackend()
 
@@ -42,22 +42,22 @@ Next you'll need to add an implicit value::
 
   // or, if you're using the zio version with zio-streams for http streaming:
   implicit val sttpBackend = AsyncHttpClientZioStreamsBackend()
-  
+
   // or, if you're using the monix version:
   implicit val sttpBackend = AsyncHttpClientMonixBackend()
-  
+
   // or, if you're using the cats effect version:
   implicit val sttpBackend = AsyncHttpClientCatsBackend[cats.effect.IO]()
 
   // or, if you're using the fs2 version:
   implicit val sttpBackend = AsyncHttpClientFs2Backend[cats.effect.IO]()
-  
+
   // or, if you'd like to use custom configuration:
   implicit val sttpBackend = AsyncHttpClientFutureBackend.usingConfig(asyncHttpClientConfig)
-  
+
   // or, if you'd like to use adjust the configuration sttp creates:
   implicit val sttpBackend = AsyncHttpClientFutureBackend.usingConfigBuilder(adjustFunction, sttpOptions)
-  
+
   // or, if you'd like to instantiate the AsyncHttpClient yourself:
   implicit val sttpBackend = AsyncHttpClientFutureBackend.usingClient(asyncHttpClient)
 
@@ -68,10 +68,10 @@ The Monix backend supports streaming (as both Monix and Async Http Client suppor
 
   import sttp.client._
   import sttp.client.asynchttpclient.monix._
-  
+
   import java.nio.ByteBuffer
   import monix.reactive.Observable
-  
+
   AsyncHttpClientMonixBackend().flatMap { implicit backend =>
     val obs: Observable[ByteBuffer] =  ...
 
@@ -84,7 +84,7 @@ And receive responses as an observable stream::
 
   import sttp.client._
   import sttp.client.asynchttpclient.monix._
-  
+
   import java.nio.ByteBuffer
   import monix.eval.Task
   import monix.reactive.Observable
@@ -153,7 +153,7 @@ The async-http-client backend supports websockets, where the websocket handler i
 
 First, given an async-http-client-native ``org.asynchttpclient.ws.WebSocketListener``, you can lift it to a web socket handler using ``WebSocketHandler.fromListener``. This listener will receive lifecycle callbacks, as well as a callback each time a message is received. Note that the callbacks will be executed on the Netty (network) thread, so make sure not to run any blocking operations there, and delegate to other executors/thread pools if necessary. The value returned in the ``WebSocketResponse`` will be an instance of ``org.asynchttpclient.ws.WebSocket``, which allows sending messages.
 
-The second approach, available when using the Monix and ZIO backends, is to pass a ``MonixWebSocketHandler()`` or ``ZIOWebSocketHandler()``. This will create a listener, which will internally buffer incoming messages, and expose a ``sttp.client.ws.WebSocket[Task]`` interface for sending/receiving messages.
+The second approach, available when using the Monix, ZIO and fs2 backends, is to pass a ``MonixWebSocketHandler()``, ``ZIOWebSocketHandler()`` or ``Fs2WebSocketHandler()``. This will create a listener, which will internally buffer incoming messages, and expose a ``sttp.client.ws.WebSocket[Task]`` (``sttp.client.ws.WebSocket[F]`` for fs2 and any ``F[_] : ConcurrentEffect``) interface for sending/receiving messages.
 
 Specifically, the ``WebSocket[Task]`` interface contains two methods, both of which return a ``Task`` (a lazily-evaluated description of a side-effecting, asynchronous process):
 


### PR DESCRIPTION
Adds an implementation of `AsyncQueue` based on what fs2 offers so that users of the fs2 backend can use WebSocket support as well.

Once this PR is merged, I'll try to add a handler which takes a `fs2.Pipe` to handle incoming and outgoing messages on an even higher level than the current API offers.