### PR TITLE
Don't clear incoming WS messages on error

### DIFF
--- a/async-http-client-backend/src/main/scala/sttp/client/asynchttpclient/internal/NativeWebSocketHandler.scala
+++ b/async-http-client-backend/src/main/scala/sttp/client/asynchttpclient/internal/NativeWebSocketHandler.scala
@@ -86,7 +86,6 @@ class AddToQueueListener[F[_]](queue: AsyncQueue[F, WebSocketEvent], isOpen: Ato
 
   override def onError(t: Throwable): Unit = {
     isOpen.set(false)
-    queue.clear() // removing any pending events so that the error is read first
     queue.offer(WebSocketEvent.Error(t))
   }
 

--- a/async-http-client-backend/zio/src/main/scala/sttp/client/asynchttpclient/zio/ZioWebSocketHandler.scala
+++ b/async-http-client-backend/zio/src/main/scala/sttp/client/asynchttpclient/zio/ZioWebSocketHandler.scala
@@ -10,9 +10,6 @@ import zio.{DefaultRuntime, Queue, Runtime, Task, UIO}
 
 object ZioWebSocketHandler {
   private class ZioAsyncQueue[A](queue: Queue[A], runtime: Runtime[Any]) extends AsyncQueue[Task, A] {
-    override def clear(): Unit = {
-      val _ = runtime.unsafeRunToFuture(queue.takeAll)
-    }
     override def offer(t: A): Unit = {
       if (!runtime.unsafeRun(queue.offer(t))) {
         throw new WebSocketBufferFull()

--- a/build.sbt
+++ b/build.sbt
@@ -187,6 +187,7 @@ lazy val rootJVM = project
     modelJVM,
     coreJVM,
     catsJVM,
+    fs2JVM,
     monixJVM,
     scalaz,
     zio,
@@ -218,7 +219,7 @@ lazy val rootJS = project
   .in(file(".js"))
   .settings(commonJvmJsSettings: _*)
   .settings(skip in publish := true, name := "sttpJS")
-  .aggregate(modelJS, coreJS, catsJS, monixJS, jsonCommonJS, circeJS, playJsonJS)
+  .aggregate(modelJS, coreJS, catsJS, fs2JS, monixJS, jsonCommonJS, circeJS, playJsonJS)
 
 lazy val rootNative = project
   .in(file(".native"))
@@ -322,6 +323,23 @@ lazy val cats = crossProject(JSPlatform, JVMPlatform)
   )
 lazy val catsJS = cats.js.dependsOn(coreJS % compileAndTest)
 lazy val catsJVM = cats.jvm.dependsOn(coreJVM % compileAndTest)
+
+val fs2Version = "2.0.1"
+lazy val fs2 = crossProject(JSPlatform, JVMPlatform)
+  .withoutSuffixFor(JVMPlatform)
+  .crossType(CrossType.Pure)
+  .in(file("implementations/fs2"))
+  .jvmSettings(commonJvmSettings: _*)
+  .jsSettings(commonJsSettings: _*)
+  .settings(
+    name := "fs2",
+    publishArtifact in Test := true,
+    libraryDependencies ++= Seq(
+      "co.fs2" %%% "fs2-core" % fs2Version
+    )
+  )
+lazy val fs2JS = fs2.js.dependsOn(coreJS % compileAndTest)
+lazy val fs2JVM = fs2.jvm.dependsOn(coreJVM % compileAndTest)
 
 lazy val monix = crossProject(JSPlatform, JVMPlatform)
   .withoutSuffixFor(JVMPlatform)
@@ -427,7 +445,6 @@ lazy val asyncHttpClientCatsBackend: Project =
   asyncHttpClientBackendProject("cats")
     .dependsOn(catsJVM % compileAndTest)
 
-val fs2Version = "2.0.1"
 lazy val asyncHttpClientFs2Backend: Project =
   asyncHttpClientBackendProject("fs2")
     .settings(
@@ -437,6 +454,7 @@ lazy val asyncHttpClientFs2Backend: Project =
       )
     )
     .dependsOn(catsJVM % compileAndTest)
+    .dependsOn(fs2JVM % compileAndTest)
 
 //-- okhttp
 lazy val okhttpBackend: Project = (project in file("okhttp-backend"))

--- a/core/shared/src/main/scala/sttp/client/ws/internal/AsyncQueue.scala
+++ b/core/shared/src/main/scala/sttp/client/ws/internal/AsyncQueue.scala
@@ -5,11 +5,6 @@ import scala.language.higherKinds
 trait AsyncQueue[F[_], T] {
 
   /**
-    * Eagerly clears the queue.
-    */
-  def clear(): Unit
-
-  /**
     * Eagerly adds the given item to the queue.
     */
   def offer(t: T): Unit

--- a/implementations/fs2/src/main/scala/sttp/client/impl/fs2/Fs2AsyncQueue.scala
+++ b/implementations/fs2/src/main/scala/sttp/client/impl/fs2/Fs2AsyncQueue.scala
@@ -1,0 +1,21 @@
+package sttp.client.impl.fs2
+
+import cats.effect.{Effect, IO}
+import fs2.concurrent.InspectableQueue
+import sttp.client.ws.internal.AsyncQueue
+import sttp.model.ws.WebSocketBufferFull
+
+import scala.language.higherKinds
+
+class Fs2AsyncQueue[F[_], A](queue: InspectableQueue[F, A])(implicit F: Effect[F]) extends AsyncQueue[F, A] {
+  override def offer(t: A): Unit = {
+    F.toIO(queue.offer1(t))
+      .flatMap {
+        case true  => IO.unit
+        case false => IO.raiseError(new WebSocketBufferFull())
+      }
+      .unsafeRunSync()
+  }
+
+  override def poll: F[A] = queue.dequeue1
+}

--- a/implementations/monix/shared/src/main/scala/sttp/client/impl/monix/MonixAsyncQueue.scala
+++ b/implementations/monix/shared/src/main/scala/sttp/client/impl/monix/MonixAsyncQueue.scala
@@ -11,7 +11,6 @@ class MonixAsyncQueue[A](bufferCapacity: Option[Int])(implicit s: Scheduler) ext
     case None           => MAsyncQueue.unbounded[A]()
   }
 
-  override def clear(): Unit = queue.clear()
   override def offer(t: A): Unit = {
     if (!queue.tryOffer(t)) {
       throw new WebSocketBufferFull()


### PR DESCRIPTION
* Remove AsyncQueue.clear()
* Move Fs2AsyncQueue to new implementations/fs2

For background, see discussion on #336