### PR TITLE
Add Fs2WebSockets for handling websockets with pipes

### DIFF
--- a/async-http-client-backend/fs2/src/main/scala/sttp/client/asynchttpclient/fs2/Fs2WebSockets.scala
+++ b/async-http-client-backend/fs2/src/main/scala/sttp/client/asynchttpclient/fs2/Fs2WebSockets.scala
@@ -1,0 +1,81 @@
+package sttp.client.asynchttpclient.fs2
+
+import cats.effect.ConcurrentEffect
+import cats.effect.concurrent.Ref
+import cats.effect.implicits._
+import fs2.{Pipe, Stream}
+import sttp.client.ws.{WebSocket, WebSocketEvent}
+import sttp.model.ws.WebSocketFrame
+
+object Fs2WebSockets {
+
+  /**
+    * Handle the websocket through a [[Pipe]] which receives the incoming events and produces the messages to be sent
+    * to the server. Not that by the nature of a [[Pipe]], there no need that these two streams are coupled. Just make sure
+    * to consume the input as otherwise the receiving buffer might overflow (use [[Stream.drain]] if you want to discard).
+    * Messages to be sent need to be coupled with a Boolean indicating whether this frame is a continuation, see [[WebSocket.send()]].
+    * @param ws the websocket to handle
+    * @param sendPongOnPing if true, then automatically handle sending pongs on pings (which are then not passed to the pipe)
+    * @param pipe the pipe to handle the socket
+    * @tparam F the effect type
+    * @return an Unit effect describing the full run of the websocket through the pipe
+    */
+  def handleSocketThroughPipeWithFragmentation[F[_]: ConcurrentEffect](
+      ws: WebSocket[F],
+      sendPongOnPing: Boolean = true
+  )(pipe: Pipe[F, WebSocketFrame.Incoming, (WebSocketFrame, Boolean)]): F[Unit] = {
+    Stream
+      .eval(Ref.of[F, Option[WebSocketFrame.Close]](None))
+      .flatMap { closeRef =>
+        Stream
+          .repeatEval(ws.receive) // read incoming messages
+          .flatMap {
+            case Left(WebSocketEvent.Close(code, reason)) =>
+              Stream.eval(closeRef.set(Some(WebSocketFrame.Close(code, reason)))).as(None)
+            case Right(WebSocketFrame.Ping(payload)) if sendPongOnPing =>
+              Stream.eval(ws.send(WebSocketFrame.Pong(payload))).drain
+            case Right(in) => Stream.emit(Some(in))
+          }
+          .unNoneTerminate // terminate once we got a Close
+          .through(pipe)
+          // end with matching Close or user-provided Close or no Close at all
+          .append(Stream.eval(closeRef.get).unNone.map(_ -> false)) // A Close isn't a continuation
+          .evalMap { case (m, c) => ws.send(m, c) } // send messages
+      }
+      .compile
+      .drain
+      .guarantee(ws.close)
+  }
+
+  /**
+    * Same as [[handleSocketThroughPipeWithFragmentation()]], but assumes all frames are no continuations.
+    * @param ws the websocket to handle
+    * @param sendPongOnPing if true, then automatically handle sending pongs on pings (which are then not passed to the pipe)
+    * @param pipe the pipe to handle the socket
+    * @tparam F the effect type
+    * @return an Unit effect describing the full run of the websocket through the pipe
+    */
+  def handleSocketThroughPipe[F[_]: ConcurrentEffect](
+      ws: WebSocket[F],
+      sendPongOnPing: Boolean = true
+  )(pipe: Pipe[F, WebSocketFrame.Incoming, WebSocketFrame]): F[Unit] =
+    handleSocketThroughPipeWithFragmentation[F](ws, sendPongOnPing)(pipe.andThen(_.map(_ -> false)))
+
+  /**
+    * Like [[handleSocketThroughPipe()]] but extracts the contents of incoming text messages and wraps outgoing messages
+    * in text frames. Helpful for implementing text-only protocols.
+    * Note: It always sends a pong for any received ping.
+    * @param ws the websocket to handle
+    * @param pipe the pipe to handle the socket
+    * @tparam F the effect type
+    * @return an Unit effect describing the full run of the websocket through the pipe
+    */
+  def handleSocketThroughTextPipe[F[_]: ConcurrentEffect](
+    ws: WebSocket[F]
+  )(pipe: Pipe[F, String, Either[WebSocketFrame.Close, String]]): F[Unit] =
+    handleSocketThroughPipe[F](ws, sendPongOnPing = true) {
+      pipe.compose[Stream[F, WebSocketFrame.Incoming]](_.collect { case WebSocketFrame.Text(msg, _, _) => msg })
+        .andThen(_.map(_.fold(identity, WebSocketFrame.text)))
+    }
+
+}

--- a/async-http-client-backend/fs2/src/test/scala/sttp/client/asynchttpclient/fs2/AsyncHttpClientHighLevelFs2WebsocketTest.scala
+++ b/async-http-client-backend/fs2/src/test/scala/sttp/client/asynchttpclient/fs2/AsyncHttpClientHighLevelFs2WebsocketTest.scala
@@ -2,7 +2,7 @@ package sttp.client.asynchttpclient.fs2
 
 import cats.effect.{ContextShift, IO, Timer}
 import sttp.client._
-import sttp.client.asynchttpclient.{AsyncHttpCientHighLevelWebsocketTest, WebSocketHandler}
+import sttp.client.asynchttpclient.{AsyncHttpClientHighLevelWebsocketTest, WebSocketHandler}
 import sttp.client.impl.cats.CatsMonadAsyncError
 import sttp.client.monad.MonadError
 import sttp.client.testing.ConvertToFuture
@@ -12,7 +12,7 @@ import scala.concurrent.Future
 import scala.concurrent.duration._
 import cats.implicits._
 
-class AsyncHttpClientHighLevelFs2WebsocketTest extends AsyncHttpCientHighLevelWebsocketTest[IO] {
+class AsyncHttpClientHighLevelFs2WebsocketTest extends AsyncHttpClientHighLevelWebsocketTest[IO] {
   implicit val backend: SttpBackend[IO, Nothing, WebSocketHandler] = AsyncHttpClientFs2Backend[IO]().unsafeRunSync()
   implicit val convertToFuture: ConvertToFuture[IO] = new ConvertToFuture[IO] {
     override def toFuture[T](value: IO[T]): Future[T] = value.unsafeToFuture()

--- a/async-http-client-backend/fs2/src/test/scala/sttp/client/asynchttpclient/fs2/Fs2WebsocketsTest.scala
+++ b/async-http-client-backend/fs2/src/test/scala/sttp/client/asynchttpclient/fs2/Fs2WebsocketsTest.scala
@@ -1,0 +1,58 @@
+package sttp.client.asynchttpclient.fs2
+
+import cats.effect.concurrent.Ref
+import cats.effect.{ContextShift, IO, Timer}
+import cats.implicits._
+import fs2._
+import org.scalatest.{AsyncFlatSpec, Matchers}
+import sttp.client._
+import sttp.client.asynchttpclient.WebSocketHandler
+import sttp.client.impl.cats.CatsMonadAsyncError
+import sttp.client.monad.MonadError
+import sttp.client.testing.{ConvertToFuture, TestHttpServer, ToFutureWrapper}
+import sttp.client.ws.WebSocket
+import sttp.model.ws.WebSocketFrame
+
+import scala.collection.immutable.Queue
+import scala.concurrent.duration._
+import scala.concurrent.Future
+
+class Fs2WebsocketsTest extends AsyncFlatSpec with Matchers with TestHttpServer with ToFutureWrapper {
+  implicit val backend: SttpBackend[IO, Nothing, WebSocketHandler] = AsyncHttpClientFs2Backend[IO]().unsafeRunSync()
+  implicit val convertToFuture: ConvertToFuture[IO] = new ConvertToFuture[IO] {
+    override def toFuture[T](value: IO[T]): Future[T] = value.unsafeToFuture()
+  }
+  implicit val monad: MonadError[IO] = new CatsMonadAsyncError[IO]
+  implicit lazy val contextShift: ContextShift[IO] = IO.contextShift(implicitly)
+  implicit lazy val timer: Timer[IO] = IO.timer(implicitly)
+
+  def createHandler: Option[Int] => IO[WebSocketHandler[WebSocket[IO]]] = Fs2WebSocketHandler[IO](_)
+
+  it should "run a simple echo pipe" in {
+    basicRequest
+      .get(uri"$wsEndpoint/ws/echo")
+      .openWebsocketF(createHandler(None))
+      .product(Ref.of[IO, Queue[String]](Queue.empty))
+      .flatMap { case (response, results) =>
+        Fs2WebSockets.handleSocketThroughTextPipe(response.result) { in =>
+          val receive = in.evalMap(m => results.update(_.enqueue(m)))
+          val send = Stream("Message 1".asRight, "Message 2".asRight, WebSocketFrame.close.asLeft)
+          send merge receive.drain
+        } >> results.get.map(_ should contain theSameElementsInOrderAs List("echo: Message 1", "echo: Message 2"))
+      }
+      .toFuture()
+  }
+
+  it should "run a simple read-only client" in {
+    basicRequest
+      .get(uri"$wsEndpoint/ws/send_and_close")
+      .openWebsocketF(createHandler(None))
+      .product(Ref.of[IO, Queue[String]](Queue.empty))
+      .flatMap { case (response, results) =>
+        Fs2WebSockets.handleSocketThroughTextPipe(response.result) { in =>
+          in.evalMap(m => results.update(_.enqueue(m))).drain
+        } >> results.get.map(_ should contain theSameElementsInOrderAs List("test10", "test20"))
+      }
+      .toFuture()
+  }
+}

--- a/async-http-client-backend/monix/src/test/scala/sttp/client/asynchttpclient/monix/AsyncHttpClientHighLevelMonixWebsocketTest.scala
+++ b/async-http-client-backend/monix/src/test/scala/sttp/client/asynchttpclient/monix/AsyncHttpClientHighLevelMonixWebsocketTest.scala
@@ -3,7 +3,7 @@ package sttp.client.asynchttpclient.monix
 import monix.eval.Task
 import monix.execution.Scheduler.Implicits.global
 import sttp.client._
-import sttp.client.asynchttpclient.{AsyncHttpCientHighLevelWebsocketTest, WebSocketHandler}
+import sttp.client.asynchttpclient.{AsyncHttpClientHighLevelWebsocketTest, WebSocketHandler}
 import sttp.client.impl.monix.{TaskMonadAsyncError, convertMonixTaskToFuture}
 import sttp.client.monad.MonadError
 import sttp.client.testing.ConvertToFuture
@@ -11,7 +11,7 @@ import sttp.client.ws.WebSocket
 
 import scala.concurrent.duration._
 
-class AsyncHttpClientHighLevelMonixWebsocketTest extends AsyncHttpCientHighLevelWebsocketTest[Task] {
+class AsyncHttpClientHighLevelMonixWebsocketTest extends AsyncHttpClientHighLevelWebsocketTest[Task] {
   override implicit val backend: SttpBackend[Task, Nothing, WebSocketHandler] =
     AsyncHttpClientMonixBackend().runSyncUnsafe()
   override implicit val convertToFuture: ConvertToFuture[Task] = convertMonixTaskToFuture

--- a/async-http-client-backend/src/test/scala/sttp/client/asynchttpclient/AsyncHttpClientHighLevelWebsocketTest.scala
+++ b/async-http-client-backend/src/test/scala/sttp/client/asynchttpclient/AsyncHttpClientHighLevelWebsocketTest.scala
@@ -11,7 +11,7 @@ import sttp.model.Uri._
 
 import scala.concurrent.duration._
 
-abstract class AsyncHttpCientHighLevelWebsocketTest[F[_]] extends HighLevelWebsocketTest[F, WebSocketHandler] {
+abstract class AsyncHttpClientHighLevelWebsocketTest[F[_]] extends HighLevelWebsocketTest[F, WebSocketHandler] {
 
   it should "error if the endpoint is not a websocket" in {
     monad

--- a/async-http-client-backend/zio/src/test/scala/sttp/client/asynchttpclient/zio/AsyncHttpClientHighLevelZioWebsocketTest.scala
+++ b/async-http-client-backend/zio/src/test/scala/sttp/client/asynchttpclient/zio/AsyncHttpClientHighLevelZioWebsocketTest.scala
@@ -1,7 +1,7 @@
 package sttp.client.asynchttpclient.zio
 
 import sttp.client._
-import sttp.client.asynchttpclient.{AsyncHttpCientHighLevelWebsocketTest, WebSocketHandler}
+import sttp.client.asynchttpclient.{AsyncHttpClientHighLevelWebsocketTest, WebSocketHandler}
 import sttp.client.impl.zio.{TaskMonadAsyncError, convertZioIoToFuture, runtime}
 import sttp.client.monad.MonadError
 import sttp.client.testing.ConvertToFuture
@@ -12,7 +12,7 @@ import zio.duration._
 
 import scala.concurrent.duration.FiniteDuration
 
-class AsyncHttpClientHighLevelZioWebsocketTest extends AsyncHttpCientHighLevelWebsocketTest[Task] {
+class AsyncHttpClientHighLevelZioWebsocketTest extends AsyncHttpClientHighLevelWebsocketTest[Task] {
   override implicit val backend: SttpBackend[Task, Nothing, WebSocketHandler] =
     runtime.unsafeRun(AsyncHttpClientZioBackend())
   override implicit val convertToFuture: ConvertToFuture[Task] = convertZioIoToFuture

--- a/core/shared/src/main/scala/sttp/client/RequestT.scala
+++ b/core/shared/src/main/scala/sttp/client/RequestT.scala
@@ -259,6 +259,14 @@ case class RequestT[U[_], T, +S](
       isIdInRequest: IsIdInRequest[U]
   ): F[WebSocketResponse[WS_RESULT]] = backend.openWebsocket(asRequest, handler)
 
+  def openWebsocketF[F[_], WS_HANDLER[_], WS_RESULT](
+      handler: F[WS_HANDLER[WS_RESULT]]
+  )(
+      implicit backend: SttpBackend[F, S, WS_HANDLER],
+      isIdInRequest: IsIdInRequest[U]
+  ): F[WebSocketResponse[WS_RESULT]] =
+    backend.responseMonad.flatMap(handler)(handler => backend.openWebsocket(asRequest, handler))
+
   def toCurl(implicit isIdInRequest: IsIdInRequest[U]): String = ToCurlConverter.requestToCurl(asRequest)
 
   @silent("never used")

--- a/docs/requests/websockets.rst
+++ b/docs/requests/websockets.rst
@@ -53,3 +53,24 @@ Example usage with the Monix variant of the :ref:`async-http-client backend <bac
     send.flatMap(_ => receive).flatMap(_ => close)
   }
 
+High-level websocket handling for fs2
+-------------------------------------
+For fs2, there are some high-level helpers collected in ``sttp.client.asynchttpclient.fs2.Fs2Websockets`` which provide means to run the whole websocket communication
+through an fs2.Pipe. Example for a simple echo client like above::
+
+  import cats.effect.IO
+  import cats.implicits._
+  import sttp.client._
+  import sttp.client.ws._
+  import sttp.model.ws.WebSocketFrame
+
+  basicRequest
+    .get(uri"wss://echo.websocket.org")
+    .openWebsocketF(Fs2WebSocketHandler())
+    .flatMap { response =>
+      Fs2WebSockets.handleSocketThroughTextPipe(response.result) { in =>
+        val receive = in.evalMap(m => IO(println("Received"))
+        val send = Stream("Message 1".asRight, "Message 2".asRight, WebSocketFrame.close.asLeft)
+        send merge receive.drain
+      }
+    }


### PR DESCRIPTION
Provides a more fs2-like interface for handling a web socket.

Furthermore:
* add RequestT.openWebsocketF for effectful handler creation
* fix typo in test class naming