### PR TITLE
Add .resource for resource-safe backend allocation

### DIFF
--- a/async-http-client-backend/fs2/src/main/scala/sttp/client/asynchttpclient/fs2/AsyncHttpClientFs2Backend.scala
+++ b/async-http-client-backend/fs2/src/main/scala/sttp/client/asynchttpclient/fs2/AsyncHttpClientFs2Backend.scala
@@ -78,6 +78,15 @@ object AsyncHttpClientFs2Backend {
     implicitly[Sync[F]]
       .delay(apply[F](AsyncHttpClientBackend.defaultClient(options), closeClient = true, customizeRequest))
 
+  /**
+    * Makes sure the backend is closed after usage.
+    */
+  def resource[F[_]: ConcurrentEffect: ContextShift](
+    options: SttpBackendOptions = SttpBackendOptions.Default,
+    customizeRequest: BoundRequestBuilder => BoundRequestBuilder = identity
+  ): Resource[F, SttpBackend[F, Stream[F, ByteBuffer], WebSocketHandler]] =
+    Resource.make(apply(options, customizeRequest))(_.close())
+
   def usingConfig[F[_]: ConcurrentEffect: ContextShift](
       cfg: AsyncHttpClientConfig,
       customizeRequest: BoundRequestBuilder => BoundRequestBuilder = identity

--- a/okhttp-backend/monix/src/main/scala/sttp/client/okhttp/monix/OkHttpMonixBackend.scala
+++ b/okhttp-backend/monix/src/main/scala/sttp/client/okhttp/monix/OkHttpMonixBackend.scala
@@ -3,6 +3,7 @@ package sttp.client.okhttp.monix
 import java.nio.ByteBuffer
 import java.util.concurrent.ArrayBlockingQueue
 
+import cats.effect.Resource
 import monix.eval.Task
 import monix.execution.Ack.Continue
 import monix.execution.{Ack, Scheduler}
@@ -90,6 +91,13 @@ object OkHttpMonixBackend {
     Task.eval(
       OkHttpMonixBackend(OkHttpBackend.defaultClient(DefaultReadTimeout.toMillis, options), closeClient = true)(s)
     )
+
+  def resource(
+    options: SttpBackendOptions = SttpBackendOptions.Default
+  )(
+    implicit s: Scheduler = Scheduler.Implicits.global
+  ): Resource[Task, SttpBackend[Task, Observable[ByteBuffer], WebSocketHandler]] =
+    Resource.make(apply(options))(_.close())
 
   def usingClient(
       client: OkHttpClient


### PR DESCRIPTION
For all cats-effect based backends, taking care of closing the backend once it was used, so it's impossible to forget `.close` and leak the underlying resources.