### PR TITLE
Make ResponseAs covariant on T

### DIFF
--- a/async-http-client-backend/cats/src/main/scala/sttp/client/asynchttpclient/cats/AsyncHttpClientCatsBackend.scala
+++ b/async-http-client-backend/cats/src/main/scala/sttp/client/asynchttpclient/cats/AsyncHttpClientCatsBackend.scala
@@ -22,7 +22,7 @@ import cats.implicits._
 
 import scala.language.higherKinds
 
-class AsyncHttpClientCatsBackend[F[_]: Async: ContextShift] private (
+class AsyncHttpClientCatsBackend[F[+_]: Async: ContextShift] private (
     asyncHttpClient: AsyncHttpClient,
     closeClient: Boolean,
     customizeRequest: BoundRequestBuilder => BoundRequestBuilder
@@ -45,7 +45,7 @@ class AsyncHttpClientCatsBackend[F[_]: Async: ContextShift] private (
 }
 
 object AsyncHttpClientCatsBackend {
-  private def apply[F[_]: Async: ContextShift](
+  private def apply[F[+_]: Async: ContextShift](
       asyncHttpClient: AsyncHttpClient,
       closeClient: Boolean,
       customizeRequest: BoundRequestBuilder => BoundRequestBuilder
@@ -57,7 +57,7 @@ object AsyncHttpClientCatsBackend {
   /**
     * After sending a request, always shifts to the thread pool backing the given `ContextShift[F]`.
     */
-  def apply[F[_]: Async: ContextShift](
+  def apply[F[+_]: Async: ContextShift](
       options: SttpBackendOptions = SttpBackendOptions.Default,
       customizeRequest: BoundRequestBuilder => BoundRequestBuilder = identity
   ): F[SttpBackend[F, Nothing, WebSocketHandler]] =
@@ -69,7 +69,7 @@ object AsyncHttpClientCatsBackend {
     * Makes sure the backend is closed after usage.
     * After sending a request, always shifts to the thread pool backing the given `ContextShift[F]`.
     */
-  def resource[F[_]: Async: ContextShift](
+  def resource[F[+_]: Async: ContextShift](
       options: SttpBackendOptions = SttpBackendOptions.Default,
       customizeRequest: BoundRequestBuilder => BoundRequestBuilder = identity
   ): Resource[F, SttpBackend[F, Nothing, WebSocketHandler]] =
@@ -78,7 +78,7 @@ object AsyncHttpClientCatsBackend {
   /**
     * After sending a request, always shifts to the thread pool backing the given `ContextShift[F]`.
     */
-  def usingConfig[F[_]: Async: ContextShift](
+  def usingConfig[F[+_]: Async: ContextShift](
       cfg: AsyncHttpClientConfig,
       customizeRequest: BoundRequestBuilder => BoundRequestBuilder = identity
   ): F[SttpBackend[F, Nothing, WebSocketHandler]] =
@@ -88,7 +88,7 @@ object AsyncHttpClientCatsBackend {
     * Makes sure the backend is closed after usage.
     * After sending a request, always shifts to the thread pool backing the given `ContextShift[F]`.
     */
-  def resourceUsingConfig[F[_]: Async: ContextShift](
+  def resourceUsingConfig[F[+_]: Async: ContextShift](
       cfg: AsyncHttpClientConfig,
       customizeRequest: BoundRequestBuilder => BoundRequestBuilder = identity
   ): Resource[F, SttpBackend[F, Nothing, WebSocketHandler]] =
@@ -98,7 +98,7 @@ object AsyncHttpClientCatsBackend {
     * After sending a request, always shifts to the thread pool backing the given `ContextShift[F]`.
     * @param updateConfig A function which updates the default configuration (created basing on `options`).
     */
-  def usingConfigBuilder[F[_]: Async: ContextShift](
+  def usingConfigBuilder[F[+_]: Async: ContextShift](
       updateConfig: DefaultAsyncHttpClientConfig.Builder => DefaultAsyncHttpClientConfig.Builder,
       options: SttpBackendOptions = SttpBackendOptions.Default,
       customizeRequest: BoundRequestBuilder => BoundRequestBuilder = identity
@@ -116,7 +116,7 @@ object AsyncHttpClientCatsBackend {
     * After sending a request, always shifts to the thread pool backing the given `ContextShift[F]`.
     * @param updateConfig A function which updates the default configuration (created basing on `options`).
     */
-  def resourceUsingConfigBuilder[F[_]: Async: ContextShift](
+  def resourceUsingConfigBuilder[F[+_]: Async: ContextShift](
       updateConfig: DefaultAsyncHttpClientConfig.Builder => DefaultAsyncHttpClientConfig.Builder,
       options: SttpBackendOptions = SttpBackendOptions.Default,
       customizeRequest: BoundRequestBuilder => BoundRequestBuilder = identity
@@ -126,7 +126,7 @@ object AsyncHttpClientCatsBackend {
   /**
     * After sending a request, always shifts to the thread pool backing the given `ContextShift[F]`.
     */
-  def usingClient[F[_]: Async: ContextShift](
+  def usingClient[F[+_]: Async: ContextShift](
       client: AsyncHttpClient,
       customizeRequest: BoundRequestBuilder => BoundRequestBuilder = identity
   ): SttpBackend[F, Nothing, WebSocketHandler] =

--- a/async-http-client-backend/fs2/src/main/scala/sttp/client/asynchttpclient/fs2/AsyncHttpClientFs2Backend.scala
+++ b/async-http-client-backend/fs2/src/main/scala/sttp/client/asynchttpclient/fs2/AsyncHttpClientFs2Backend.scala
@@ -20,7 +20,7 @@ import sttp.client.{FollowRedirectsBackend, SttpBackend, SttpBackendOptions, _}
 import scala.concurrent.ExecutionContext
 import scala.language.higherKinds
 
-class AsyncHttpClientFs2Backend[F[_]: ConcurrentEffect: ContextShift] private (
+class AsyncHttpClientFs2Backend[F[+_]: ConcurrentEffect: ContextShift] private (
     asyncHttpClient: AsyncHttpClient,
     closeClient: Boolean,
     customizeRequest: BoundRequestBuilder => BoundRequestBuilder
@@ -62,7 +62,7 @@ class AsyncHttpClientFs2Backend[F[_]: ConcurrentEffect: ContextShift] private (
 }
 
 object AsyncHttpClientFs2Backend {
-  private def apply[F[_]: ConcurrentEffect: ContextShift](
+  private def apply[F[+_]: ConcurrentEffect: ContextShift](
       asyncHttpClient: AsyncHttpClient,
       closeClient: Boolean,
       customizeRequest: BoundRequestBuilder => BoundRequestBuilder

--- a/async-http-client-backend/src/main/scala/sttp/client/asynchttpclient/AsyncHttpClientBackend.scala
+++ b/async-http-client-backend/src/main/scala/sttp/client/asynchttpclient/AsyncHttpClientBackend.scala
@@ -63,7 +63,7 @@ import scala.collection.immutable.Seq
 import scala.language.higherKinds
 import scala.util.Try
 
-abstract class AsyncHttpClientBackend[F[_], S](
+abstract class AsyncHttpClientBackend[F[+_], S](
     asyncHttpClient: AsyncHttpClient,
     private implicit val monad: MonadAsyncError[F],
     closeClient: Boolean,

--- a/core/js/src/main/scala/sttp/client/AbstractFetchBackend.scala
+++ b/core/js/src/main/scala/sttp/client/AbstractFetchBackend.scala
@@ -48,7 +48,7 @@ final case class FetchOptions(
   *
   * @see https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API
   */
-abstract class AbstractFetchBackend[F[_], S](options: FetchOptions, customizeRequest: FetchRequest => FetchRequest)(
+abstract class AbstractFetchBackend[F[+_], S](options: FetchOptions, customizeRequest: FetchRequest => FetchRequest)(
     monad: MonadError[F]
 ) extends SttpBackend[F, S, NothingT] {
   override implicit def responseMonad: MonadError[F] = monad

--- a/core/shared/src/main/scala/sttp/client/ResponseAs.scala
+++ b/core/shared/src/main/scala/sttp/client/ResponseAs.scala
@@ -12,7 +12,7 @@ import scala.util.{Failure, Success, Try}
   * @tparam T Target type as which the response will be read.
   * @tparam S If `T` is a stream, the type of the stream. Otherwise, `Nothing`.
   */
-sealed trait ResponseAs[T, +S] {
+sealed trait ResponseAs[+T, +S] {
   def map[T2](f: T => T2): ResponseAs[T2, S] = mapWithMetadata { case (t, _) => f(t) }
   def mapWithMetadata[T2](f: (T, ResponseMetadata) => T2): ResponseAs[T2, S] = MappedResponseAs[T, T2, S](this, f)
 }
@@ -21,14 +21,14 @@ sealed trait ResponseAs[T, +S] {
   * Response handling specification which isn't derived from another response
   * handling method, but needs to be handled directly by the backend.
   */
-sealed trait BasicResponseAs[T, +S] extends ResponseAs[T, S]
+sealed trait BasicResponseAs[+T, +S] extends ResponseAs[T, S]
 
 case object IgnoreResponse extends BasicResponseAs[Unit, Nothing]
 case object ResponseAsByteArray extends BasicResponseAs[Array[Byte], Nothing]
 case class ResponseAsStream[T, S]()(implicit val responseIsStream: S =:= T) extends BasicResponseAs[T, S]
 case class ResponseAsFile(output: SttpFile) extends BasicResponseAs[SttpFile, Nothing]
 
-case class ResponseAsFromMetadata[T, S](f: ResponseMetadata => ResponseAs[T, S]) extends ResponseAs[T, S]
+case class ResponseAsFromMetadata[+T, S](f: ResponseMetadata => ResponseAs[T, S]) extends ResponseAs[T, S]
 
 case class MappedResponseAs[T, T2, S](raw: ResponseAs[T, S], g: (T, ResponseMetadata) => T2) extends ResponseAs[T2, S] {
   override def mapWithMetadata[T3](f: (T2, ResponseMetadata) => T3): ResponseAs[T3, S] =


### PR DESCRIPTION
closes #408

Make `F[_]` also covariant to avoid unsafe casting [here](https://github.com/softwaremill/sttp/blob/8945531eb8da41055cadcb50b5aba04322217de3/async-http-client-backend/src/main/scala/sttp/client/asynchttpclient/AsyncHttpClientBackend.scala#L200)
and similar places.