### PR TITLE
Fix AkkaHttpBackend `isContentLength` filter to inspect header name

### DIFF
--- a/akka-http-backend/src/main/scala/sttp/client/akkahttp/AkkaHttpBackend.scala
+++ b/akka-http-backend/src/main/scala/sttp/client/akkahttp/AkkaHttpBackend.scala
@@ -305,7 +305,7 @@ class AkkaHttpBackend private (
     header.name.toLowerCase.contains(`Content-Type`.lowercaseName)
 
   private def isContentLength(header: Header) =
-    header.value.toLowerCase.contains(`Content-Length`.lowercaseName)
+    header.name.toLowerCase.contains(`Content-Length`.lowercaseName)
 
   // http://doc.akka.io/docs/akka-http/10.0.7/scala/http/common/de-coding.html
   private def decodeAkkaResponse(response: HttpResponse): HttpResponse = {


### PR DESCRIPTION
Hi all,

It appears the `isContentLength` function in `AkkaHttpBackend` is inspecting header value and not name.  This causes the `Content-Length` header to be passed down to Akka HTTP which then spits out a loud warning every time a request is funneled through our client:

```
WARN  akka.actor.ActorSystemImpl - Explicitly set HTTP header 'Content-Length: 262' is ignored, explicit `Content-Length` header is not allowed. Use the appropriate HttpEntity subtype.
```

It's innocuous but causes a TON of noise in logs; discovered this issue by way of an upgrade of a Lagom project to version 1.6 (and Akka 2.6 under the covers).