### PR TITLE
[OpenTracingBackend] Add transformation for generated span

### DIFF
--- a/docs/backends/wrappers/opentracing.md
+++ b/docs/backends/wrappers/opentracing.md
@@ -16,14 +16,26 @@ OpenTracingBackend(wrappedBackend, tracer)
 
 Where tracer is an interface which can be implemented by any compatible library. See examples below.
 
-The backend obtains the current trace context using default spans's propagation mechanisms. There is an additional method exposed to override default operation id:
+The backend obtains the current trace context using default spans's propagation mechanisms. 
+
+There is an additional method exposed to override default operation id:
 
 ```scala
-import sttp.client.brave.OpenTracingBackend._
+import sttp.client.opentracing.OpenTracingBackend._
 
 basicRequest
   .get(...)
-  .tagWithOperationId("register-user"))
+  .tagWithOperationId("register-user")
+```
+
+There is an additional method exposed to customize generated span:
+
+```scala
+import sttp.client.opentracing.OpenTracingBackend._
+
+basicRequest
+  .get(...)
+  .tagWithTransformSpan(_.setTag("custom-tag", "custom-value").setOperationName("new-name").log("my-event"))
 ```
 
 ## Integration with jaeger

--- a/metrics/open-tracing-backend/src/main/scala/sttp/client/opentracing/OpenTracingBackend.scala
+++ b/metrics/open-tracing-backend/src/main/scala/sttp/client/opentracing/OpenTracingBackend.scala
@@ -1,12 +1,14 @@
 package sttp.client.opentracing
 
 import io.opentracing.tag.Tags
-import io.opentracing.Tracer
+import io.opentracing.{Span, Tracer}
 import io.opentracing.propagation.Format
 import sttp.client.monad.MonadError
 import sttp.client.ws.WebSocketResponse
 import sttp.client.{FollowRedirectsBackend, NothingT, Request, Response, SttpBackend}
 import sttp.client.monad.syntax._
+import sttp.client.opentracing.OpenTracingBackend.SpanTransformer
+
 import scala.collection.JavaConverters._
 
 class OpenTracingBackend[F[_], S] private (delegate: SttpBackend[F, S, NothingT], tracer: Tracer)
@@ -17,7 +19,7 @@ class OpenTracingBackend[F[_], S] private (delegate: SttpBackend[F, S, NothingT]
   override def send[T](request: Request[T, S]): F[Response[T]] =
     responseMonad
       .eval {
-        tracer
+        val span = tracer
           .buildSpan(
             request
               .tag(OpenTracingBackend.OperationIdRequestTag)
@@ -27,8 +29,13 @@ class OpenTracingBackend[F[_], S] private (delegate: SttpBackend[F, S, NothingT]
           .withTag(Tags.SPAN_KIND, Tags.SPAN_KIND_CLIENT)
           .withTag(Tags.HTTP_METHOD, request.method.method)
           .withTag(Tags.HTTP_URL, request.uri.toString)
-          .withTag(Tags.COMPONENT, "opentracing-sttp-client")
+          .withTag(Tags.COMPONENT, "sttp2-client")
           .start()
+
+        request
+          .tag(OpenTracingBackend.SpanTransformRequestTag)
+          .collectFirst { case spanTranform: SpanTransformer => spanTranform(span) }
+          .getOrElse(span)
       }
       .flatMap { span =>
         val requestBuilderAdapter = new RequestBuilderAdapter(request)
@@ -62,10 +69,15 @@ class OpenTracingBackend[F[_], S] private (delegate: SttpBackend[F, S, NothingT]
 
 object OpenTracingBackend {
   private val OperationIdRequestTag = "io.opentracing.tag.sttp.operationId"
+  private val SpanTransformRequestTag = "io.opentracing.tag.sttp.transform"
+  type SpanTransformer = Span => Span
 
   implicit class RichRequest[T, S](request: Request[T, S]) {
     def tagWithOperationId(operationId: String): Request[T, S] =
       request.tag(OperationIdRequestTag, operationId)
+
+    def tagWithTransformSpan(transformSpan: SpanTransformer): Request[T, S] =
+      request.tag(SpanTransformRequestTag, transformSpan)
   }
 
   def apply[F[_], S](delegate: SttpBackend[F, S, NothingT], tracer: Tracer): SttpBackend[F, S, NothingT] = {

--- a/metrics/open-tracing-backend/src/main/scala/sttp/client/opentracing/OpenTracingBackend.scala
+++ b/metrics/open-tracing-backend/src/main/scala/sttp/client/opentracing/OpenTracingBackend.scala
@@ -33,8 +33,8 @@ class OpenTracingBackend[F[_], S] private (delegate: SttpBackend[F, S, NothingT]
           .start()
 
         request
-          .tag(OpenTracingBackend.SpanTransformRequestTag)
-          .collectFirst { case spanTranform: SpanTransformer => spanTranform(span) }
+          .tag(OpenTracingBackend.SpanTransformerRequestTag)
+          .collectFirst { case spanTranformer: SpanTransformer => spanTranformer(span) }
           .getOrElse(span)
       }
       .flatMap { span =>
@@ -69,7 +69,7 @@ class OpenTracingBackend[F[_], S] private (delegate: SttpBackend[F, S, NothingT]
 
 object OpenTracingBackend {
   private val OperationIdRequestTag = "io.opentracing.tag.sttp.operationId"
-  private val SpanTransformRequestTag = "io.opentracing.tag.sttp.transform"
+  private val SpanTransformerRequestTag = "io.opentracing.tag.sttp.span.transformer"
   type SpanTransformer = Span => Span
 
   implicit class RichRequest[T, S](request: Request[T, S]) {
@@ -77,7 +77,7 @@ object OpenTracingBackend {
       request.tag(OperationIdRequestTag, operationId)
 
     def tagWithTransformSpan(transformSpan: SpanTransformer): Request[T, S] =
-      request.tag(SpanTransformRequestTag, transformSpan)
+      request.tag(SpanTransformerRequestTag, transformSpan)
   }
 
   def apply[F[_], S](delegate: SttpBackend[F, S, NothingT], tracer: Tracer): SttpBackend[F, S, NothingT] = {


### PR DESCRIPTION
Currently you can customize generated span only by providing custom operation name.
Typically you want to have ability to adjust span by adding some tags or logs - for example, you may want to specify current retry number in the span tag.

This PR adds generic `Span` transformer tag.

Another thing (authors are welcome to change that as well) - I don't think we need to specify opentracing-sttp-client as backend - you can have nested backends so it doesn't really tell you which backend is under the hood (however that would be useful imo - to know whether you are using java NIO, akka-http or some other backend)