### PR TITLE
Added toString to ResponseMetadata

### DIFF
--- a/core/shared/src/main/scala/sttp/client/ResponseMetadata.scala
+++ b/core/shared/src/main/scala/sttp/client/ResponseMetadata.scala
@@ -13,6 +13,8 @@ trait ResponseMetadata extends HasHeaders {
   def isRedirect: Boolean = code.isRedirect
   def isClientError: Boolean = code.isClientError
   def isServerError: Boolean = code.isServerError
+
+  override def toString: String = s"ResponseMetadata(code=$code, statusText=$statusText)"
 }
 
 object ResponseMetadata {

--- a/core/shared/src/main/scala/sttp/client/ResponseMetadata.scala
+++ b/core/shared/src/main/scala/sttp/client/ResponseMetadata.scala
@@ -14,7 +14,9 @@ trait ResponseMetadata extends HasHeaders {
   def isClientError: Boolean = code.isClientError
   def isServerError: Boolean = code.isServerError
 
-  override def toString: String = s"ResponseMetadata(code=$code, statusText=$statusText)"
+  override def toString: String = s"ResponseMetadata(code=$code, statusText=$statusText, headers=$headersToStringSafe)"
+
+  private def headersToStringSafe: Seq[String] = headers.map(_.toStringSafe)
 }
 
 object ResponseMetadata {


### PR DESCRIPTION
Added toString to ResponseMetadata, as it hugely improves debugging (by default it's serialised as ResponseMetadata@hashcode).

I decided not to include headers, as I was not sure if they wouldn't contain some auth secrets which shall not be logged (however wasn't sure, can change if you want).