### PR TITLE
Add cats/fs2 backend for JRE11 Http Client

### DIFF
--- a/async-http-client-backend/cats/src/test/scala/sttp/client/asynchttpclient/cats/AsyncHttpClientCatsHttpTest.scala
+++ b/async-http-client-backend/cats/src/test/scala/sttp/client/asynchttpclient/cats/AsyncHttpClientCatsHttpTest.scala
@@ -2,19 +2,15 @@ package sttp.client.asynchttpclient.cats
 
 import java.util.concurrent.TimeoutException
 
-import cats.effect.{ContextShift, IO, Timer}
+import cats.effect.IO
 import sttp.client._
-import sttp.client.impl.cats.convertCatsIOToFuture
-import sttp.client.testing.{CancelTest, ConvertToFuture, HttpTest}
+import sttp.client.impl.cats.CatsTestBase
+import sttp.client.testing.{CancelTest, HttpTest}
 
 import scala.concurrent.duration._
 
-class AsyncHttpClientCatsHttpTest extends HttpTest[IO] with CancelTest[IO, Nothing] {
-
-  implicit val cs: ContextShift[IO] = IO.contextShift(scala.concurrent.ExecutionContext.global)
-  implicit val timer: Timer[IO] = IO.timer(scala.concurrent.ExecutionContext.global)
+class AsyncHttpClientCatsHttpTest extends HttpTest[IO] with CancelTest[IO, Nothing] with CatsTestBase {
   override implicit val backend: SttpBackend[IO, Nothing, NothingT] = AsyncHttpClientCatsBackend[IO]().unsafeRunSync()
-  override implicit val convertToFuture: ConvertToFuture[IO] = convertCatsIOToFuture
 
   "illegal url exceptions" - {
     "should be wrapped in the effect wrapper" in {

--- a/async-http-client-backend/fs2/src/test/scala/sttp/client/asynchttpclient/fs2/AsyncHttpClientFs2HttpStreamingTest.scala
+++ b/async-http-client-backend/fs2/src/test/scala/sttp/client/asynchttpclient/fs2/AsyncHttpClientFs2HttpStreamingTest.scala
@@ -3,35 +3,15 @@ package sttp.client.asynchttpclient.fs2
 import java.nio.ByteBuffer
 
 import cats.effect.{ContextShift, IO}
-import cats.instances.string._
-import fs2.{Chunk, Stream, text}
+import fs2.Stream
 import sttp.client.{NothingT, SttpBackend}
-import sttp.client.testing.ConvertToFuture
-import sttp.client.testing.streaming.StreamingTest
 
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.ExecutionContext
+import sttp.client.impl.fs2.Fs2StreamingTest
 
-class AsyncHttpClientFs2HttpStreamingTest extends StreamingTest[IO, Stream[IO, ByteBuffer]] {
-
+class AsyncHttpClientFs2HttpStreamingTest extends Fs2StreamingTest {
   private implicit val cs: ContextShift[IO] = IO.contextShift(ExecutionContext.Implicits.global)
 
   override implicit val backend: SttpBackend[IO, Stream[IO, ByteBuffer], NothingT] =
     AsyncHttpClientFs2Backend[IO]().unsafeRunSync()
-
-  override implicit val convertToFuture: ConvertToFuture[IO] =
-    new ConvertToFuture[IO] {
-      override def toFuture[T](value: IO[T]): Future[T] =
-        value.unsafeToFuture()
-    }
-
-  override def bodyProducer(chunks: Iterable[Array[Byte]]): Stream[IO, ByteBuffer] =
-    Stream.emits(chunks.toSeq).map(ByteBuffer.wrap)
-
-  override def bodyConsumer(stream: Stream[IO, ByteBuffer]): IO[String] =
-    stream
-      .map(bb => Chunk.array(bb.array))
-      .through(text.utf8DecodeC)
-      .compile
-      .foldMonoid
-
 }

--- a/async-http-client-backend/fs2/src/test/scala/sttp/client/asynchttpclient/fs2/AsyncHttpClientFs2HttpStreamingTest.scala
+++ b/async-http-client-backend/fs2/src/test/scala/sttp/client/asynchttpclient/fs2/AsyncHttpClientFs2HttpStreamingTest.scala
@@ -4,12 +4,12 @@ import java.nio.ByteBuffer
 
 import cats.effect.{ContextShift, IO}
 import fs2.Stream
+import sttp.client.impl.fs2.Fs2ByteBufferStreamingTest
 import sttp.client.{NothingT, SttpBackend}
 
 import scala.concurrent.ExecutionContext
-import sttp.client.impl.fs2.Fs2StreamingTest
 
-class AsyncHttpClientFs2HttpStreamingTest extends Fs2StreamingTest {
+class AsyncHttpClientFs2HttpStreamingTest extends Fs2ByteBufferStreamingTest {
   private implicit val cs: ContextShift[IO] = IO.contextShift(ExecutionContext.Implicits.global)
 
   override implicit val backend: SttpBackend[IO, Stream[IO, ByteBuffer], NothingT] =

--- a/async-http-client-backend/fs2/src/test/scala/sttp/client/asynchttpclient/fs2/AsyncHttpClientFs2HttpTest.scala
+++ b/async-http-client-backend/fs2/src/test/scala/sttp/client/asynchttpclient/fs2/AsyncHttpClientFs2HttpTest.scala
@@ -1,17 +1,10 @@
 package sttp.client.asynchttpclient.fs2
 
-import cats.effect.{ContextShift, IO}
+import cats.effect.IO
 import sttp.client.{NothingT, SttpBackend}
-import sttp.client.testing.{ConvertToFuture, HttpTest}
+import sttp.client.impl.cats.CatsTestBase
+import sttp.client.testing.HttpTest
 
-import scala.concurrent.{ExecutionContext, Future}
-
-class AsyncHttpClientFs2HttpTest extends HttpTest[IO] {
-
-  private implicit val cs: ContextShift[IO] = IO.contextShift(ExecutionContext.Implicits.global)
-
+class AsyncHttpClientFs2HttpTest extends HttpTest[IO] with CatsTestBase {
   override implicit val backend: SttpBackend[IO, Nothing, NothingT] = AsyncHttpClientFs2Backend[IO]().unsafeRunSync()
-  override implicit val convertToFuture: ConvertToFuture[IO] = new ConvertToFuture[IO] {
-    override def toFuture[T](value: IO[T]): Future[T] = value.unsafeToFuture()
-  }
 }

--- a/async-http-client-backend/fs2/src/test/scala/sttp/client/asynchttpclient/fs2/AsyncHttpClientHighLevelFs2WebsocketTest.scala
+++ b/async-http-client-backend/fs2/src/test/scala/sttp/client/asynchttpclient/fs2/AsyncHttpClientHighLevelFs2WebsocketTest.scala
@@ -1,25 +1,16 @@
 package sttp.client.asynchttpclient.fs2
 
-import cats.effect.{ContextShift, IO, Timer}
+import cats.effect.IO
 import sttp.client._
 import sttp.client.asynchttpclient.{AsyncHttpClientHighLevelWebsocketTest, WebSocketHandler}
-import sttp.client.impl.cats.CatsMonadAsyncError
-import sttp.client.monad.MonadError
-import sttp.client.testing.ConvertToFuture
+import sttp.client.impl.cats.CatsTestBase
 import sttp.client.ws.WebSocket
 
-import scala.concurrent.Future
 import scala.concurrent.duration._
 import cats.implicits._
 
-class AsyncHttpClientHighLevelFs2WebsocketTest extends AsyncHttpClientHighLevelWebsocketTest[IO] {
+class AsyncHttpClientHighLevelFs2WebsocketTest extends AsyncHttpClientHighLevelWebsocketTest[IO] with CatsTestBase {
   implicit val backend: SttpBackend[IO, Nothing, WebSocketHandler] = AsyncHttpClientFs2Backend[IO]().unsafeRunSync()
-  implicit val convertToFuture: ConvertToFuture[IO] = new ConvertToFuture[IO] {
-    override def toFuture[T](value: IO[T]): Future[T] = value.unsafeToFuture()
-  }
-  override implicit val monad: MonadError[IO] = new CatsMonadAsyncError[IO]
-  implicit lazy val contextShift: ContextShift[IO] = IO.contextShift(implicitly)
-  implicit lazy val timer: Timer[IO] = IO.timer(implicitly)
 
   override def createHandler: Option[Int] => IO[WebSocketHandler[WebSocket[IO]]] = Fs2WebSocketHandler[IO](_)
 

--- a/async-http-client-backend/fs2/src/test/scala/sttp/client/asynchttpclient/fs2/AsyncHttpClientLowLevelFs2WebsocketTest.scala
+++ b/async-http-client-backend/fs2/src/test/scala/sttp/client/asynchttpclient/fs2/AsyncHttpClientLowLevelFs2WebsocketTest.scala
@@ -1,22 +1,17 @@
 package sttp.client.asynchttpclient.fs2
 
-import cats.effect.{ContextShift, IO}
+import cats.effect.IO
 import com.github.ghik.silencer.silent
 import org.asynchttpclient.ws.{WebSocketListener, WebSocket => AHCWebSocket}
 import sttp.client._
 import sttp.client.asynchttpclient.WebSocketHandler
-import sttp.client.testing.ConvertToFuture
+import sttp.client.impl.cats.CatsTestBase
 import sttp.client.testing.websocket.LowLevelListenerWebSocketTest
 
-import scala.concurrent.Future
-
 class AsyncHttpClientLowLevelFs2WebsocketTest
-    extends LowLevelListenerWebSocketTest[IO, AHCWebSocket, WebSocketHandler] {
-  implicit val cs: ContextShift[IO] = IO.contextShift(implicitly)
+    extends LowLevelListenerWebSocketTest[IO, AHCWebSocket, WebSocketHandler]
+    with CatsTestBase {
   implicit val backend: SttpBackend[IO, Nothing, WebSocketHandler] = AsyncHttpClientFs2Backend[IO]().unsafeRunSync()
-  implicit val convertToFuture: ConvertToFuture[IO] = new ConvertToFuture[IO] {
-    override def toFuture[T](value: IO[T]): Future[T] = value.unsafeToFuture()
-  }
 
   override def createHandler(_onTextFrame: String => Unit): WebSocketHandler[AHCWebSocket] =
     WebSocketHandler.fromListener(new WebSocketListener {

--- a/async-http-client-backend/fs2/src/test/scala/sttp/client/asynchttpclient/fs2/AsyncHttpClientPipedFs2WebsocketsTest.scala
+++ b/async-http-client-backend/fs2/src/test/scala/sttp/client/asynchttpclient/fs2/AsyncHttpClientPipedFs2WebsocketsTest.scala
@@ -7,13 +7,13 @@ import fs2._
 import sttp.client._
 import sttp.client.asynchttpclient.WebSocketHandler
 import sttp.client.impl.cats.CatsMonadAsyncError
+import sttp.client.impl.fs2.Fs2WebSockets
 import sttp.client.monad.MonadError
 import sttp.client.testing.{ConvertToFuture, TestHttpServer, ToFutureWrapper}
 import sttp.client.ws.WebSocket
 import sttp.model.ws.WebSocketFrame
 
 import scala.collection.immutable.Queue
-import scala.concurrent.duration._
 import scala.concurrent.Future
 import org.scalatest.flatspec.AsyncFlatSpec
 import org.scalatest.matchers.should.Matchers

--- a/async-http-client-backend/fs2/src/test/scala/sttp/client/asynchttpclient/fs2/AsyncHttpClientPipedFs2WebsocketsTest.scala
+++ b/async-http-client-backend/fs2/src/test/scala/sttp/client/asynchttpclient/fs2/AsyncHttpClientPipedFs2WebsocketsTest.scala
@@ -1,20 +1,18 @@
 package sttp.client.asynchttpclient.fs2
 
 import cats.effect.concurrent.Ref
-import cats.effect.{ContextShift, IO, Timer}
+import cats.effect.IO
 import cats.implicits._
 import fs2._
 import sttp.client._
 import sttp.client.asynchttpclient.WebSocketHandler
-import sttp.client.impl.cats.CatsMonadAsyncError
+import sttp.client.impl.cats.CatsTestBase
 import sttp.client.impl.fs2.Fs2WebSockets
-import sttp.client.monad.MonadError
-import sttp.client.testing.{ConvertToFuture, TestHttpServer, ToFutureWrapper}
+import sttp.client.testing.{TestHttpServer, ToFutureWrapper}
 import sttp.client.ws.WebSocket
 import sttp.model.ws.WebSocketFrame
 
 import scala.collection.immutable.Queue
-import scala.concurrent.Future
 import org.scalatest.flatspec.AsyncFlatSpec
 import org.scalatest.matchers.should.Matchers
 
@@ -22,14 +20,9 @@ class AsyncHttpClientPipedFs2WebsocketsTest
     extends AsyncFlatSpec
     with Matchers
     with TestHttpServer
-    with ToFutureWrapper {
+    with ToFutureWrapper
+    with CatsTestBase {
   implicit val backend: SttpBackend[IO, Nothing, WebSocketHandler] = AsyncHttpClientFs2Backend[IO]().unsafeRunSync()
-  implicit val convertToFuture: ConvertToFuture[IO] = new ConvertToFuture[IO] {
-    override def toFuture[T](value: IO[T]): Future[T] = value.unsafeToFuture()
-  }
-  implicit val monad: MonadError[IO] = new CatsMonadAsyncError[IO]
-  implicit lazy val contextShift: ContextShift[IO] = IO.contextShift(implicitly)
-  implicit lazy val timer: Timer[IO] = IO.timer(implicitly)
 
   def createHandler: Option[Int] => IO[WebSocketHandler[WebSocket[IO]]] = Fs2WebSocketHandler[IO](_)
 

--- a/build.sbt
+++ b/build.sbt
@@ -345,7 +345,7 @@ lazy val fs2 = crossProject(JSPlatform, JVMPlatform)
     )
   )
 lazy val fs2JS = fs2.js.dependsOn(coreJS % compileAndTest)
-lazy val fs2JVM = fs2.jvm.dependsOn(coreJVM % compileAndTest)
+lazy val fs2JVM = fs2.jvm.dependsOn(coreJVM % compileAndTest, catsJVM % compileAndTest)
 
 lazy val monix = crossProject(JSPlatform, JVMPlatform)
   .withoutSuffixFor(JVMPlatform)

--- a/build.sbt
+++ b/build.sbt
@@ -242,6 +242,7 @@ lazy val rootJVM = project
     prometheusBackend,
     httpClientBackend,
     httpClientMonixBackend,
+    httpClientFs2Backend,
     finagleBackend,
     slf4jBackend,
     examples
@@ -516,6 +517,16 @@ def httpClientBackendProject(proj: String): Project = {
 lazy val httpClientMonixBackend: Project =
   httpClientBackendProject("monix")
     .dependsOn(monixJVM % compileAndTest)
+
+lazy val httpClientFs2Backend: Project =
+  httpClientBackendProject("fs2")
+    .settings(
+      libraryDependencies ++= dependenciesFor(scalaVersion.value)(
+        "co.fs2" %% "fs2-reactive-streams" % fs2Version(_),
+        "co.fs2" %% "fs2-io" % fs2Version(_)
+      )
+    )
+    .dependsOn(fs2JVM % compileAndTest)
 
 //-- finagle backend
 lazy val finagleBackend: Project = (project in file("finagle-backend"))

--- a/build.sbt
+++ b/build.sbt
@@ -494,7 +494,7 @@ lazy val http4sBackend: Project = (project in file("http4s-backend"))
     )
   )
   .settings(only2_12_and_2_13_settings)
-  .dependsOn(catsJVM, coreJVM % compileAndTest)
+  .dependsOn(catsJVM % compileAndTest, coreJVM % compileAndTest)
 
 //-- httpclient-java11
 lazy val httpClientBackend: Project = (project in file("httpclient-backend"))

--- a/build.sbt
+++ b/build.sbt
@@ -494,7 +494,7 @@ lazy val http4sBackend: Project = (project in file("http4s-backend"))
     )
   )
   .settings(only2_12_and_2_13_settings)
-  .dependsOn(catsJVM % compileAndTest, coreJVM % compileAndTest)
+  .dependsOn(catsJVM % compileAndTest, coreJVM % compileAndTest, fs2JVM % "test->test")
 
 //-- httpclient-java11
 lazy val httpClientBackend: Project = (project in file("httpclient-backend"))

--- a/build.sbt
+++ b/build.sbt
@@ -345,7 +345,7 @@ lazy val fs2 = crossProject(JSPlatform, JVMPlatform)
       "co.fs2" %%% "fs2-core" % fs2Version(_)
     )
   )
-lazy val fs2JS = fs2.js.dependsOn(coreJS % compileAndTest)
+lazy val fs2JS = fs2.js.dependsOn(coreJS % compileAndTest, catsJS % compileAndTest)
 lazy val fs2JVM = fs2.jvm.dependsOn(coreJVM % compileAndTest, catsJVM % compileAndTest)
 
 lazy val monix = crossProject(JSPlatform, JVMPlatform)

--- a/http4s-backend/src/test/scala/sttp/client/http4s/Http4sHttpStreamingTest.scala
+++ b/http4s-backend/src/test/scala/sttp/client/http4s/Http4sHttpStreamingTest.scala
@@ -1,26 +1,21 @@
 package sttp.client.http4s
 
-import cats.effect.{ContextShift, IO}
+import cats.effect.IO
 import cats.instances.string._
 import fs2.{Chunk, Stream, text}
 import sttp.client.{NothingT, SttpBackend}
-import sttp.client.testing.ConvertToFuture
+import sttp.client.impl.cats.CatsTestBase
 import sttp.client.testing.streaming.StreamingTest
 
-import scala.concurrent.ExecutionContext.global
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.ExecutionContext
 
 import org.http4s.client.blaze.BlazeClientBuilder
 
-class Http4sHttpStreamingTest extends StreamingTest[IO, Stream[IO, Byte]] {
+class Http4sHttpStreamingTest extends StreamingTest[IO, Stream[IO, Byte]] with CatsTestBase {
 
-  implicit val contextShift: ContextShift[IO] = IO.contextShift(global)
   private val blazeClientBuilder = BlazeClientBuilder[IO](ExecutionContext.Implicits.global)
   override implicit val backend: SttpBackend[IO, Stream[IO, Byte], NothingT] =
     Http4sBackend.usingClientBuilder(blazeClientBuilder).allocated.unsafeRunSync()._1
-  override implicit val convertToFuture: ConvertToFuture[IO] = new ConvertToFuture[IO] {
-    override def toFuture[T](value: IO[T]): Future[T] = value.unsafeToFuture()
-  }
 
   override def bodyProducer(chunks: Iterable[Array[Byte]]): Stream[IO, Byte] =
     Stream.chunk(Chunk.concatBytes(chunks.toSeq.map(Chunk.array)))

--- a/http4s-backend/src/test/scala/sttp/client/http4s/Http4sHttpStreamingTest.scala
+++ b/http4s-backend/src/test/scala/sttp/client/http4s/Http4sHttpStreamingTest.scala
@@ -1,28 +1,18 @@
 package sttp.client.http4s
 
 import cats.effect.IO
-import cats.instances.string._
-import fs2.{Chunk, Stream, text}
+import fs2.Stream
 import sttp.client.{NothingT, SttpBackend}
-import sttp.client.impl.cats.CatsTestBase
-import sttp.client.testing.streaming.StreamingTest
+import sttp.client.impl.fs2.Fs2StreamingTest
 
 import scala.concurrent.ExecutionContext
 
 import org.http4s.client.blaze.BlazeClientBuilder
 
-class Http4sHttpStreamingTest extends StreamingTest[IO, Stream[IO, Byte]] with CatsTestBase {
+class Http4sHttpStreamingTest extends Fs2StreamingTest {
 
-  private val blazeClientBuilder = BlazeClientBuilder[IO](ExecutionContext.Implicits.global)
+  private val blazeClientBuilder = BlazeClientBuilder[IO](ExecutionContext.global)
   override implicit val backend: SttpBackend[IO, Stream[IO, Byte], NothingT] =
     Http4sBackend.usingClientBuilder(blazeClientBuilder).allocated.unsafeRunSync()._1
 
-  override def bodyProducer(chunks: Iterable[Array[Byte]]): Stream[IO, Byte] =
-    Stream.chunk(Chunk.concatBytes(chunks.toSeq.map(Chunk.array)))
-
-  override def bodyConsumer(stream: Stream[IO, Byte]): IO[String] =
-    stream
-      .through(text.utf8Decode)
-      .compile
-      .foldMonoid
 }

--- a/http4s-backend/src/test/scala/sttp/client/http4s/Http4sHttpTest.scala
+++ b/http4s-backend/src/test/scala/sttp/client/http4s/Http4sHttpTest.scala
@@ -1,27 +1,18 @@
 package sttp.client.http4s
 
-import cats.effect.{ContextShift, IO}
-import sttp.client.{NothingT, SttpBackend}
-import sttp.client.testing.{ConvertToFuture, HttpTest}
-
-import scala.concurrent.ExecutionContext.global
-import scala.concurrent.{ExecutionContext, Future}
-
+import cats.effect.IO
 import org.http4s.client.blaze.BlazeClientBuilder
+import sttp.client.{NothingT, SttpBackend}
+import sttp.client.impl.cats.CatsTestBase
+import sttp.client.testing.HttpTest
 
-class Http4sHttpTest extends HttpTest[IO] {
+import scala.concurrent.ExecutionContext
 
-  implicit val contextShift: ContextShift[IO] = IO.contextShift(global)
-
-  private val blazeClientBuilder = BlazeClientBuilder[IO](ExecutionContext.Implicits.global)
+class Http4sHttpTest extends HttpTest[IO] with CatsTestBase {
+  private val blazeClientBuilder = BlazeClientBuilder[IO](ExecutionContext.global)
 
   override implicit val backend: SttpBackend[IO, Nothing, NothingT] =
     Http4sBackend.usingClientBuilder(blazeClientBuilder).allocated.unsafeRunSync()._1
-  override implicit val convertToFuture: ConvertToFuture[IO] = new ConvertToFuture[IO] {
-    override def toFuture[T](value: IO[T]): Future[T] = value.unsafeToFuture()
-  }
 
   override protected def supportsRequestTimeout = false
-
-  //override protected def supportsSttpExceptions = false
 }

--- a/httpclient-backend/fs2/src/main/scala/sttp/client/httpclient/fs2/Fs2WebSocketHandler.scala
+++ b/httpclient-backend/fs2/src/main/scala/sttp/client/httpclient/fs2/Fs2WebSocketHandler.scala
@@ -1,0 +1,52 @@
+package sttp.client.httpclient.fs2
+
+import cats.effect.{ConcurrentEffect, Sync}
+import fs2.concurrent.InspectableQueue
+import sttp.client.httpclient.WebSocketHandler
+import sttp.client.httpclient.internal.NativeWebSocketHandler
+import sttp.client.impl.cats.CatsMonadAsyncError
+import sttp.client.impl.cats.implicits._
+import sttp.client.impl.fs2.Fs2AsyncQueue
+import sttp.client.monad.syntax._
+import sttp.client.ws.{WebSocket, WebSocketEvent}
+
+object Fs2WebSocketHandler {
+
+  /**
+    * Returns an effect, which creates a new [[WebSocketHandler]]. The handler should be used *once* to send and
+    * receive from a single websocket.
+    *
+    * The handler will internally buffer incoming messages, and expose an instance of the [[WebSocket]] interface for
+    * sending/receiving messages.
+    *
+    * @param incomingBufferCapacity Should the buffer of incoming websocket events be bounded. If yes, unreceived
+    *                               events will some point cause the websocket to error and close. If no, unreceived
+    *                               messages will eventually take up all available memory.
+    */
+  def apply[F[_]: ConcurrentEffect](
+      incomingBufferCapacity: Option[Int] = None
+  ): F[WebSocketHandler[WebSocket[F]]] =
+    apply(incomingBufferCapacity.fold(InspectableQueue.unbounded[F, WebSocketEvent])(InspectableQueue.bounded))
+
+  /**
+    * Returns an effect, which creates a new [[WebSocketHandler]]. The handler should be used *once* to send and
+    * receive from a single websocket.
+    *
+    * The handler will internally buffer incoming messages, and expose an instance of the [[WebSocket]] interface for
+    * sending/receiving messages.
+    *
+    * @param createQueue Effect to create an [[InspectableQueue]] which is used to buffer incoming messages.
+    */
+  def apply[F[_]: ConcurrentEffect](
+      createQueue: F[InspectableQueue[F, WebSocketEvent]]
+  ): F[WebSocketHandler[WebSocket[F]]] =
+    createQueue.flatMap { queue =>
+      Sync[F].delay {
+        NativeWebSocketHandler[F](
+          new Fs2AsyncQueue[F, WebSocketEvent](queue),
+          new CatsMonadAsyncError
+        )
+      }
+    }
+
+}

--- a/httpclient-backend/fs2/src/main/scala/sttp/client/httpclient/fs2/HttpClientFs2Backend.scala
+++ b/httpclient-backend/fs2/src/main/scala/sttp/client/httpclient/fs2/HttpClientFs2Backend.scala
@@ -1,0 +1,94 @@
+package sttp.client.httpclient.fs2
+
+import java.io.InputStream
+import java.net.http.{HttpClient, HttpRequest}
+import java.net.http.HttpRequest.BodyPublishers
+import java.nio.ByteBuffer
+
+import cats.effect._
+import cats.effect.implicits._
+import cats.implicits._
+import fs2.Stream
+import fs2.interop.reactivestreams._
+import org.reactivestreams.FlowAdapters
+import sttp.client.{FollowRedirectsBackend, SttpBackend, SttpBackendOptions}
+import sttp.client.httpclient.{HttpClientAsyncBackend, HttpClientBackend, WebSocketHandler}
+import sttp.client.impl.cats.implicits._
+import sttp.client.testing.SttpBackendStub
+
+import scala.util.{Success, Try}
+import sttp.client.ws.WebSocketResponse
+
+class HttpClientFs2Backend[F[_]: ConcurrentEffect: ContextShift] private (
+    client: HttpClient,
+    blocker: Blocker,
+    chunkSize: Int,
+    closeClient: Boolean,
+    customizeRequest: HttpRequest => HttpRequest
+) extends HttpClientAsyncBackend[F, Stream[F, ByteBuffer]](client, implicitly, closeClient, customizeRequest) {
+
+  override def openWebsocket[T, WS_RESULT](
+      request: sttp.client.Request[T, Stream[F, ByteBuffer]],
+      handler: WebSocketHandler[WS_RESULT]
+  ): F[WebSocketResponse[WS_RESULT]] =
+    super.openWebsocket(request, handler).guarantee(ContextShift[F].shift)
+
+  override def streamToRequestBody(stream: Stream[F, ByteBuffer]): HttpRequest.BodyPublisher =
+    BodyPublishers.fromPublisher(FlowAdapters.toFlowPublisher(stream.toUnicastPublisher()))
+
+  override def responseBodyToStream(responseBody: InputStream): Try[Stream[F, ByteBuffer]] =
+    Success(fs2.io.readInputStream(responseBody.pure[F], chunkSize, blocker).chunks.map(_.toByteBuffer))
+}
+
+object HttpClientFs2Backend {
+  private val defaultChunkSize: Int = 4096
+
+  private def apply[F[_]: ConcurrentEffect: ContextShift](
+      client: HttpClient,
+      blocker: Blocker,
+      chunkSize: Int,
+      closeClient: Boolean,
+      customizeRequest: HttpRequest => HttpRequest
+  ): SttpBackend[F, Stream[F, ByteBuffer], WebSocketHandler] =
+    new FollowRedirectsBackend(new HttpClientFs2Backend(client, blocker, chunkSize, closeClient, customizeRequest))
+
+  def apply[F[_]: ConcurrentEffect: ContextShift](
+      blocker: Blocker,
+      chunkSize: Int = defaultChunkSize,
+      options: SttpBackendOptions = SttpBackendOptions.Default,
+      customizeRequest: HttpRequest => HttpRequest = identity
+  ): F[SttpBackend[F, Stream[F, ByteBuffer], WebSocketHandler]] =
+    Sync[F].delay(
+      HttpClientFs2Backend(
+        HttpClientBackend.defaultClient(options),
+        blocker,
+        chunkSize,
+        closeClient = true,
+        customizeRequest
+      )
+    )
+
+  def resource[F[_]: ConcurrentEffect: ContextShift](
+      blocker: Blocker,
+      chunkSize: Int = defaultChunkSize,
+      options: SttpBackendOptions = SttpBackendOptions.Default,
+      customizeRequest: HttpRequest => HttpRequest = identity
+  ): Resource[F, SttpBackend[F, Stream[F, ByteBuffer], WebSocketHandler]] =
+    Resource.make(apply(blocker, chunkSize, options, customizeRequest))(_.close())
+
+  def usingClient[F[_]: ConcurrentEffect: ContextShift](
+      client: HttpClient,
+      blocker: Blocker,
+      chunkSize: Int = defaultChunkSize,
+      customizeRequest: HttpRequest => HttpRequest = identity
+  ): SttpBackend[F, Stream[F, ByteBuffer], WebSocketHandler] =
+    HttpClientFs2Backend(client, blocker, chunkSize, closeClient = false, customizeRequest)
+
+  /**
+    * Create a stub backend for testing, which uses the [[F]] response wrapper, and supports `Stream[F, ByteBuffer]`
+    * streaming.
+    *
+    * See [[SttpBackendStub]] for details on how to configure stub responses.
+    */
+  def stub[F[_]: Concurrent]: SttpBackendStub[F, Stream[F, ByteBuffer]] = SttpBackendStub(implicitly)
+}

--- a/httpclient-backend/fs2/src/test/scala/sttp/client/httpclient/fs2/HttpClientFs2HttpTest.scala
+++ b/httpclient-backend/fs2/src/test/scala/sttp/client/httpclient/fs2/HttpClientFs2HttpTest.scala
@@ -1,0 +1,6 @@
+package sttp.client.httpclient.fs2
+
+import cats.effect.IO
+import sttp.client.testing.HttpTest
+
+class HttpClientFs2HttpTest extends HttpTest[IO] with HttpClientFs2TestBase

--- a/httpclient-backend/fs2/src/test/scala/sttp/client/httpclient/fs2/HttpClientFs2LowLevelListenerWebSocketTest.scala
+++ b/httpclient-backend/fs2/src/test/scala/sttp/client/httpclient/fs2/HttpClientFs2LowLevelListenerWebSocketTest.scala
@@ -1,0 +1,8 @@
+package sttp.client.httpclient.fs2
+
+import cats.effect.IO
+import sttp.client.httpclient.HttpClientLowLevelListenerWebSocketTest
+
+class HttpClientFs2LowLevelListenerWebSocketTest
+    extends HttpClientLowLevelListenerWebSocketTest[IO]
+    with HttpClientFs2TestBase

--- a/httpclient-backend/fs2/src/test/scala/sttp/client/httpclient/fs2/HttpClientFs2StreamingTest.scala
+++ b/httpclient-backend/fs2/src/test/scala/sttp/client/httpclient/fs2/HttpClientFs2StreamingTest.scala
@@ -1,0 +1,5 @@
+package sttp.client.httpclient.fs2
+
+import sttp.client.impl.fs2.Fs2StreamingTest
+
+class HttpClientFs2StreamingTest extends Fs2StreamingTest with HttpClientFs2TestBase

--- a/httpclient-backend/fs2/src/test/scala/sttp/client/httpclient/fs2/HttpClientFs2TestBase.scala
+++ b/httpclient-backend/fs2/src/test/scala/sttp/client/httpclient/fs2/HttpClientFs2TestBase.scala
@@ -1,7 +1,5 @@
 package sttp.client.httpclient.fs2
 
-import java.nio.ByteBuffer
-
 import cats.effect.IO
 import fs2.Stream
 import sttp.client._
@@ -9,6 +7,6 @@ import sttp.client.httpclient.WebSocketHandler
 import sttp.client.impl.cats.CatsTestBase
 
 trait HttpClientFs2TestBase extends CatsTestBase {
-  implicit val backend: SttpBackend[IO, Stream[IO, ByteBuffer], WebSocketHandler] =
+  implicit val backend: SttpBackend[IO, Stream[IO, Byte], WebSocketHandler] =
     HttpClientFs2Backend[IO](blocker).unsafeRunSync()
 }

--- a/httpclient-backend/fs2/src/test/scala/sttp/client/httpclient/fs2/HttpClientFs2TestBase.scala
+++ b/httpclient-backend/fs2/src/test/scala/sttp/client/httpclient/fs2/HttpClientFs2TestBase.scala
@@ -1,0 +1,14 @@
+package sttp.client.httpclient.fs2
+
+import java.nio.ByteBuffer
+
+import cats.effect.IO
+import fs2.Stream
+import sttp.client._
+import sttp.client.httpclient.WebSocketHandler
+import sttp.client.impl.cats.CatsTestBase
+
+trait HttpClientFs2TestBase extends CatsTestBase {
+  implicit val backend: SttpBackend[IO, Stream[IO, ByteBuffer], WebSocketHandler] =
+    HttpClientFs2Backend[IO](blocker).unsafeRunSync()
+}

--- a/httpclient-backend/fs2/src/test/scala/sttp/client/httpclient/fs2/HttpClientHighLevelFs2WebsocketTest.scala
+++ b/httpclient-backend/fs2/src/test/scala/sttp/client/httpclient/fs2/HttpClientHighLevelFs2WebsocketTest.scala
@@ -14,8 +14,6 @@ import scala.concurrent.duration._
 class HttpClientHighLevelFs2WebsocketTest
     extends HighLevelWebsocketTest[IO, WebSocketHandler]
     with HttpClientFs2TestBase {
-  private implicit val timer: Timer[IO] = IO.timer(implicitly)
-  override val monad: MonadError[IO] = new CatsMonadError[IO]
 
   override def createHandler: Option[Int] => IO[WebSocketHandler[WebSocket[IO]]] =
     Fs2WebSocketHandler[IO](_)

--- a/httpclient-backend/fs2/src/test/scala/sttp/client/httpclient/fs2/HttpClientHighLevelFs2WebsocketTest.scala
+++ b/httpclient-backend/fs2/src/test/scala/sttp/client/httpclient/fs2/HttpClientHighLevelFs2WebsocketTest.scala
@@ -1,11 +1,9 @@
 package sttp.client.httpclient.fs2
 
-import cats.effect.{IO, Timer}
+import cats.effect.IO
 import cats.implicits._
 import sttp.client._
 import sttp.client.httpclient.WebSocketHandler
-import sttp.client.impl.cats.CatsMonadError
-import sttp.client.monad.MonadError
 import sttp.client.testing.websocket.HighLevelWebsocketTest
 import sttp.client.ws.WebSocket
 

--- a/httpclient-backend/fs2/src/test/scala/sttp/client/httpclient/fs2/HttpClientHighLevelFs2WebsocketTest.scala
+++ b/httpclient-backend/fs2/src/test/scala/sttp/client/httpclient/fs2/HttpClientHighLevelFs2WebsocketTest.scala
@@ -1,0 +1,43 @@
+package sttp.client.httpclient.fs2
+
+import cats.effect.{IO, Timer}
+import cats.implicits._
+import sttp.client._
+import sttp.client.httpclient.WebSocketHandler
+import sttp.client.impl.cats.CatsMonadError
+import sttp.client.monad.MonadError
+import sttp.client.testing.websocket.HighLevelWebsocketTest
+import sttp.client.ws.WebSocket
+
+import scala.concurrent.duration._
+
+class HttpClientHighLevelFs2WebsocketTest
+    extends HighLevelWebsocketTest[IO, WebSocketHandler]
+    with HttpClientFs2TestBase {
+  private implicit val timer: Timer[IO] = IO.timer(implicitly)
+  override val monad: MonadError[IO] = new CatsMonadError[IO]
+
+  override def createHandler: Option[Int] => IO[WebSocketHandler[WebSocket[IO]]] =
+    Fs2WebSocketHandler[IO](_)
+
+  it should "handle backpressure correctly" in {
+    basicRequest
+      .get(uri"$wsEndpoint/ws/echo")
+      .openWebsocketF(createHandler(Some(3)))
+      .flatMap { response =>
+        val ws = response.result
+        send(ws, 1000) >> eventually(10.millis, 500) { ws.isOpen.map(_ shouldBe true) }
+      }
+      .toFuture()
+  }
+
+  override def eventually[T](interval: FiniteDuration, attempts: Int)(f: => IO[T]): IO[T] = {
+    def tryWithCounter(i: Int): IO[T] = {
+      (IO.sleep(interval) >> f).recoverWith {
+        case _: Exception if i < attempts => tryWithCounter(i + 1)
+      }
+    }
+    tryWithCounter(0)
+  }
+
+}

--- a/httpclient-backend/monix/src/main/scala/sttp/client/httpclient/monix/HttpClientMonixBackend.scala
+++ b/httpclient-backend/monix/src/main/scala/sttp/client/httpclient/monix/HttpClientMonixBackend.scala
@@ -12,7 +12,7 @@ import monix.reactive.Observable
 import sttp.client.httpclient.{HttpClientAsyncBackend, HttpClientBackend, WebSocketHandler}
 import sttp.client.impl.monix.TaskMonadAsyncError
 import sttp.client.testing.SttpBackendStub
-import sttp.client.{SttpBackend, _}
+import sttp.client.{FollowRedirectsBackend, SttpBackend, SttpBackendOptions}
 
 import scala.util.{Success, Try}
 

--- a/httpclient-backend/src/main/scala/sttp/client/httpclient/internal/NativeWebsocketHandler.scala
+++ b/httpclient-backend/src/main/scala/sttp/client/httpclient/internal/NativeWebsocketHandler.scala
@@ -1,0 +1,138 @@
+package sttp.client.httpclient.internal
+
+import sttp.client.ws.internal.AsyncQueue
+import java.util.concurrent.atomic.AtomicBoolean
+import java.net.http.WebSocket.Listener
+import java.net.http.{WebSocket => JWebSocket}
+import sttp.client.ws.WebSocketEvent
+import sttp.model.ws.WebSocketFrame
+import sttp.client.monad.syntax._
+import java.util.concurrent.CompletionStage
+import java.nio.ByteBuffer
+import sttp.client.httpclient.WebSocketHandler
+import sttp.client.monad.MonadAsyncError
+import sttp.client.ws.WebSocket
+import sttp.model.ws.{WebSocketClosed, WebSocketFrame}
+import sttp.client.monad.MonadError
+import java.util.concurrent.CompletableFuture
+import java.util.function.BiConsumer
+import sttp.client.monad.Canceler
+
+private[httpclient] object NativeWebSocketHandler {
+
+  /**
+    * Returns an effect, which creates a new [[WebSocketHandler]]. The handler should be used *once* to send and
+    * receive from a single websocket.
+    */
+  def apply[F[_]](queue: AsyncQueue[F, WebSocketEvent], monad: MonadAsyncError[F]): WebSocketHandler[WebSocket[F]] = {
+    val isOpen: AtomicBoolean = new AtomicBoolean(false)
+    WebSocketHandler(
+      new AddToQueueListener(queue, isOpen),
+      httpClientWebSocketToWebSocket(_, queue, isOpen, monad)
+    )
+  }
+
+  private def httpClientWebSocketToWebSocket[F[_]](
+      ws: JWebSocket,
+      queue: AsyncQueue[F, WebSocketEvent],
+      _isOpen: AtomicBoolean,
+      _monad: MonadAsyncError[F]
+  ): WebSocket[F] = new WebSocket[F] {
+    override def receive: F[Either[WebSocketEvent.Close, WebSocketFrame.Incoming]] = {
+      queue.poll.flatMap {
+        case WebSocketEvent.Open() => receive
+        case c: WebSocketEvent.Close =>
+          queue.offer(WebSocketEvent.Error(new WebSocketClosed))
+          monad.unit(Left(c))
+        case e @ WebSocketEvent.Error(t: Exception) =>
+          // putting back the error so that subsequent invocations end in an error as well, instead of hanging
+          queue.offer(e)
+          monad.error(t)
+        case WebSocketEvent.Error(t) => throw t
+        case WebSocketEvent.Frame(f) =>
+          monad.eval {
+            ws.request(1)
+            Right(f)
+          }
+      }
+    }
+
+    override def send(f: WebSocketFrame, isContinuation: Boolean = false): F[Unit] =
+      monad.flatten(monad.eval(fromCompletableFuture(f match {
+        case WebSocketFrame.Text(payload, finalFragment, _) =>
+          ws.sendText(payload, finalFragment)
+        case WebSocketFrame.Binary(payload, finalFragment, _) =>
+          ws.sendBinary(ByteBuffer.wrap(payload), finalFragment)
+        case WebSocketFrame.Ping(payload)                 => ws.sendPing(ByteBuffer.wrap(payload))
+        case WebSocketFrame.Pong(payload)                 => ws.sendPong(ByteBuffer.wrap(payload))
+        case WebSocketFrame.Close(statusCode, reasonText) => ws.sendClose(statusCode, reasonText)
+      })))
+
+    override def isOpen: F[Boolean] = monad.eval(_isOpen.get())
+
+    override implicit def monad: MonadError[F] = _monad
+
+    private def fromCompletableFuture(cf: CompletableFuture[JWebSocket]): F[Unit] = {
+      _monad.async { cb =>
+        cf.whenComplete(new BiConsumer[JWebSocket, Throwable] {
+          override def accept(t: JWebSocket, error: Throwable): Unit = {
+            if (error != null) {
+              cb(Left(error))
+            } else {
+              cb(Right(()))
+            }
+          }
+        })
+        Canceler { () =>
+          cf.cancel(true)
+          ()
+        }
+      }
+    }
+  }
+}
+
+private[httpclient] class AddToQueueListener[F[_]](
+    queue: AsyncQueue[F, WebSocketEvent],
+    isOpen: AtomicBoolean
+) extends Listener {
+  override def onOpen(webSocket: JWebSocket): Unit = {
+    isOpen.set(true)
+    queue.offer(WebSocketEvent.Open())
+    webSocket.request(1)
+  }
+
+  override def onText(webSocket: JWebSocket, data: CharSequence, last: Boolean): CompletionStage[_] = {
+    onFrame(WebSocketFrame.Text(data.toString, last, None))
+    null
+  }
+
+  override def onBinary(webSocket: JWebSocket, data: ByteBuffer, last: Boolean): CompletionStage[_] = {
+    onFrame(WebSocketFrame.Binary(data.array(), last, None))
+    null
+  }
+
+  override def onPing(webSocket: JWebSocket, message: ByteBuffer): CompletionStage[_] = {
+    onFrame(WebSocketFrame.Ping(message.array()))
+    null
+  }
+
+  override def onPong(webSocket: JWebSocket, message: ByteBuffer): CompletionStage[_] = {
+    onFrame(WebSocketFrame.Pong(message.array()))
+    null
+  }
+
+  override def onClose(webSocket: JWebSocket, statusCode: Int, reason: String): CompletionStage[_] = {
+    isOpen.set(false)
+    queue.offer(WebSocketEvent.Close(statusCode, reason))
+    super.onClose(webSocket, statusCode, reason)
+  }
+
+  override def onError(webSocket: JWebSocket, error: Throwable): Unit = {
+    isOpen.set(false)
+    queue.offer(WebSocketEvent.Error(error))
+    super.onError(webSocket, error)
+  }
+
+  private def onFrame(f: WebSocketFrame.Incoming): Unit = queue.offer(WebSocketEvent.Frame(f))
+}

--- a/httpclient-backend/src/test/scala/sttp/client/httpclient/HttpClientLowLevelListenerWebSocketTest.scala
+++ b/httpclient-backend/src/test/scala/sttp/client/httpclient/HttpClientLowLevelListenerWebSocketTest.scala
@@ -16,7 +16,6 @@ abstract class HttpClientLowLevelListenerWebSocketTest[F[_]]
     WebSocketHandler.fromListener(new Listener {
       var accumulator: String = ""
       override def onText(webSocket: WebSocket, data: CharSequence, last: Boolean): CompletionStage[_] = {
-        println(data)
         if (last) {
           _onTextFrame(accumulator + data.toString)
           accumulator = ""

--- a/httpclient-backend/src/test/scala/sttp/client/httpclient/HttpClientLowLevelListenerWebSocketTest.scala
+++ b/httpclient-backend/src/test/scala/sttp/client/httpclient/HttpClientLowLevelListenerWebSocketTest.scala
@@ -16,6 +16,7 @@ abstract class HttpClientLowLevelListenerWebSocketTest[F[_]]
     WebSocketHandler.fromListener(new Listener {
       var accumulator: String = ""
       override def onText(webSocket: WebSocket, data: CharSequence, last: Boolean): CompletionStage[_] = {
+        println(data)
         if (last) {
           _onTextFrame(accumulator + data.toString)
           accumulator = ""
@@ -30,5 +31,5 @@ abstract class HttpClientLowLevelListenerWebSocketTest[F[_]]
   override def sendText(ws: WebSocket, t: String): Unit = ws.sendText(t.toString, true).get()
 
   @silent("discarded")
-  override def sendCloseFrame(ws: WebSocket): Unit = ws.sendClose(1000, "").get()
+  override def sendCloseFrame(ws: WebSocket): Unit = ws.sendClose(WebSocket.NORMAL_CLOSURE, "").get()
 }

--- a/implementations/cats/src/test/scala/sttp/client/impl/cats/CatsTestBase.scala
+++ b/implementations/cats/src/test/scala/sttp/client/impl/cats/CatsTestBase.scala
@@ -1,0 +1,14 @@
+package sttp.client.impl.cats
+
+import cats.effect.{Blocker, ContextShift, IO}
+import sttp.client.testing.ConvertToFuture
+
+import scala.concurrent.ExecutionContext
+
+trait CatsTestBase {
+  implicit def executionContext: ExecutionContext
+  implicit val contextShift: ContextShift[IO] = IO.contextShift(implicitly)
+  lazy val blocker: Blocker = Blocker.liftExecutionContext(implicitly)
+
+  implicit val convertToFuture: ConvertToFuture[IO] = convertCatsIOToFuture
+}

--- a/implementations/cats/src/test/scala/sttp/client/impl/cats/CatsTestBase.scala
+++ b/implementations/cats/src/test/scala/sttp/client/impl/cats/CatsTestBase.scala
@@ -1,13 +1,17 @@
 package sttp.client.impl.cats
 
-import cats.effect.{Blocker, ContextShift, IO}
+import cats.effect.{Blocker, ContextShift, IO, Timer}
 import sttp.client.testing.ConvertToFuture
 
 import scala.concurrent.ExecutionContext
+import sttp.client.monad.MonadError
 
 trait CatsTestBase {
   implicit def executionContext: ExecutionContext
+
+  implicit lazy val monad: MonadError[IO] = new CatsMonadAsyncError[IO]
   implicit val contextShift: ContextShift[IO] = IO.contextShift(implicitly)
+  implicit lazy val timer: Timer[IO] = IO.timer(scala.concurrent.ExecutionContext.global)
   lazy val blocker: Blocker = Blocker.liftExecutionContext(implicitly)
 
   implicit val convertToFuture: ConvertToFuture[IO] = convertCatsIOToFuture

--- a/implementations/fs2/src/main/scala/sttp/client/impl/fs2/Fs2WebSockets.scala
+++ b/implementations/fs2/src/main/scala/sttp/client/impl/fs2/Fs2WebSockets.scala
@@ -1,4 +1,4 @@
-package sttp.client.asynchttpclient.fs2
+package sttp.client.impl.fs2
 
 import cats.effect.ConcurrentEffect
 import cats.effect.concurrent.Ref

--- a/implementations/fs2/src/test/scala/sttp/client/impl/fs2/Fs2ByteBufferStreamingTest.scala
+++ b/implementations/fs2/src/test/scala/sttp/client/impl/fs2/Fs2ByteBufferStreamingTest.scala
@@ -1,0 +1,22 @@
+package sttp.client.impl.fs2
+
+import java.nio.ByteBuffer
+
+import cats.effect.IO
+import cats.implicits._
+import fs2.{Chunk, Stream, text}
+import sttp.client.impl.cats.CatsTestBase
+import sttp.client.testing.streaming.StreamingTest
+
+trait Fs2ByteBufferStreamingTest extends StreamingTest[IO, Stream[IO, ByteBuffer]] with CatsTestBase {
+
+  override def bodyProducer(chunks: Iterable[Array[Byte]]): Stream[IO, ByteBuffer] =
+    Stream.emits(chunks.toSeq).map(ByteBuffer.wrap)
+
+  override def bodyConsumer(stream: Stream[IO, ByteBuffer]): IO[String] =
+    stream
+      .map(Chunk.ByteBuffer(_))
+      .through(text.utf8DecodeC)
+      .compile
+      .foldMonoid
+}

--- a/implementations/fs2/src/test/scala/sttp/client/impl/fs2/Fs2StreamingTest.scala
+++ b/implementations/fs2/src/test/scala/sttp/client/impl/fs2/Fs2StreamingTest.scala
@@ -1,0 +1,22 @@
+package sttp.client.impl.fs2
+
+import java.nio.ByteBuffer
+
+import cats.effect.IO
+import cats.implicits._
+import fs2.{Chunk, Stream, text}
+import sttp.client.impl.cats.CatsTestBase
+import sttp.client.testing.streaming.StreamingTest
+
+trait Fs2StreamingTest extends StreamingTest[IO, Stream[IO, ByteBuffer]] with CatsTestBase {
+
+  override def bodyProducer(chunks: Iterable[Array[Byte]]): Stream[IO, ByteBuffer] =
+    Stream.emits(chunks.toSeq).map(ByteBuffer.wrap)
+
+  override def bodyConsumer(stream: Stream[IO, ByteBuffer]): IO[String] =
+    stream
+      .map(Chunk.ByteBuffer(_))
+      .through(text.utf8DecodeC)
+      .compile
+      .foldMonoid
+}


### PR DESCRIPTION
This PR adds a cats/fs2 backend for the JRE11 Http Client.

The actual code is mostly a combination of the fs2 AHC backend and the Monix Http Client backend.

While making these changes, I moved some common things around, to avoid duplicating code.