### PR TITLE
Make vals in ops classes private

### DIFF
--- a/core/shared/src/main/scala/sttp/client/monad/MonadError.scala
+++ b/core/shared/src/main/scala/sttp/client/monad/MonadError.scala
@@ -38,14 +38,14 @@ trait MonadAsyncError[F[_]] extends MonadError[F] {
 case class Canceler(cancel: () => Unit)
 
 object syntax {
-  implicit final class MonadErrorOps[F[_], A](val r: F[A]) extends AnyVal {
+  implicit final class MonadErrorOps[F[_], A](private val r: F[A]) extends AnyVal {
     def map[B](f: A => B)(implicit ME: MonadError[F]): F[B] = ME.map(r)(f)
     def flatMap[B](f: A => F[B])(implicit ME: MonadError[F]): F[B] = ME.flatMap(r)(f)
     def >>[B](r2: F[B])(implicit ME: MonadError[F]): F[B] = ME.flatMap(r)(_ => r2)
     def handleError[T](h: PartialFunction[Throwable, F[A]])(implicit ME: MonadError[F]): F[A] = ME.handleError(r)(h)
   }
 
-  implicit final class MonadErrorValueOps[F[_], A](val v: A) extends AnyVal {
+  implicit final class MonadErrorValueOps[F[_], A](private val v: A) extends AnyVal {
     def unit(implicit ME: MonadError[F]): F[A] = ME.unit(v)
   }
 }

--- a/implementations/cats/src/main/scala/sttp/client/impl/cats/implicits.scala
+++ b/implementations/cats/src/main/scala/sttp/client/impl/cats/implicits.scala
@@ -11,19 +11,21 @@ import scala.language.higherKinds
 object implicits extends CatsImplicits
 
 trait CatsImplicits extends LowLevelCatsImplicits {
-  implicit def sttpBackendToCatsMappableSttpBackend[R[_], S, WS_HANDLER[_]](
+  implicit final def sttpBackendToCatsMappableSttpBackend[R[_], S, WS_HANDLER[_]](
       sttpBackend: SttpBackend[R, S, WS_HANDLER]
   ): MappableSttpBackend[R, S, WS_HANDLER] = new MappableSttpBackend(sttpBackend)
 
-  implicit def asyncMonadError[F[_]: Concurrent]: MonadAsyncError[F] = new CatsMonadAsyncError[F]
+  implicit final def asyncMonadError[F[_]: Concurrent]: MonadAsyncError[F] = new CatsMonadAsyncError[F]
 }
 
 trait LowLevelCatsImplicits {
-  implicit def catsMonadError[F[_]](implicit E: cats.MonadError[F, Throwable]): MonadError[F] = new CatsMonadError[F]
+  implicit final def catsMonadError[F[_]](implicit E: cats.MonadError[F, Throwable]): MonadError[F] =
+    new CatsMonadError[F]
 }
 
-class MappableSttpBackend[F[_], S, WS_HANDLER[_]] private[cats] (val sttpBackend: SttpBackend[F, S, WS_HANDLER])
-    extends AnyVal {
+final class MappableSttpBackend[F[_], S, WS_HANDLER[_]] private[cats] (
+    private val sttpBackend: SttpBackend[F, S, WS_HANDLER]
+) extends AnyVal {
   def mapK[G[_]: MonadError](f: F ~> G): SttpBackend[G, S, WS_HANDLER] =
     new MappedKSttpBackend(sttpBackend, f, implicitly)
 }

--- a/implementations/scalaz/src/main/scala/sttp/client/impl/scalaz/implicits.scala
+++ b/implementations/scalaz/src/main/scala/sttp/client/impl/scalaz/implicits.scala
@@ -10,13 +10,14 @@ import scala.language.higherKinds
 object implicits extends ScalazImplicits
 
 trait ScalazImplicits {
-  implicit def sttpBackendToScalazMappableSttpBackend[F[_], S, WS_HANDLER[_]](
+  implicit final def sttpBackendToScalazMappableSttpBackend[F[_], S, WS_HANDLER[_]](
       sttpBackend: SttpBackend[F, S, WS_HANDLER]
   ): MappableSttpBackend[F, S, WS_HANDLER] = new MappableSttpBackend(sttpBackend)
 }
 
-class MappableSttpBackend[F[_], S, WS_HANDLER[_]] private[scalaz] (val sttpBackend: SttpBackend[F, S, WS_HANDLER])
-    extends AnyVal {
+final class MappableSttpBackend[F[_], S, WS_HANDLER[_]] private[scalaz] (
+    private val sttpBackend: SttpBackend[F, S, WS_HANDLER]
+) extends AnyVal {
   def mapK[G[_]: MonadError](f: F ~> G): SttpBackend[G, S, WS_HANDLER] =
     new MappedKSttpBackend(sttpBackend, f, implicitly)
 }


### PR DESCRIPTION
This vals pollute auto-complete scope in IDE. So when you type, this useless vals always pop-up, stealing space from some useful methods.

Also finalize classes for better inlining chances 