### PR TITLE
Fixed missing constructor parameter for CollectorConfig

### DIFF
--- a/metrics/prometheus-backend/src/main/scala/sttp/client/prometheus/PrometheusBackend.scala
+++ b/metrics/prometheus-backend/src/main/scala/sttp/client/prometheus/PrometheusBackend.scala
@@ -196,7 +196,7 @@ class BaseCollectorConfig(collectorName: String, labels: List[(String, String)] 
   * Represents the name of a collector, together with label names and values.
   * The same labels must be always returned, and in the same order.
   */
-case class CollectorConfig(collectorName: String) extends BaseCollectorConfig(collectorName)
+case class CollectorConfig(collectorName: String, labels: List[(String, String)] = Nil) extends BaseCollectorConfig(collectorName)
 
 /**
   * Represents the name of a collector with configurable histogram buckets.


### PR DESCRIPTION
Hey @adamw, this is a follow-up PR for the Prometheus backend.

Unfortunately my last PR left out an important commit that prevents creating a `CollectorConfig` with custom labels.

This PR's fixes that problem.