### PR TITLE
Use ExecutionContext/Scheduler.global when it's not implicit

### DIFF
--- a/akka-http-backend/src/main/scala/sttp/client/akkahttp/AkkaHttpBackend.scala
+++ b/akka-http-backend/src/main/scala/sttp/client/akkahttp/AkkaHttpBackend.scala
@@ -378,7 +378,7 @@ object AkkaHttpBackend {
       customizeRequest: HttpRequest => HttpRequest = identity,
       customizeWebsocketRequest: WebSocketRequest => WebSocketRequest = identity
   )(
-      implicit ec: ExecutionContext = ExecutionContext.Implicits.global
+      implicit ec: ExecutionContext = ExecutionContext.global
   ): SttpBackend[Future, Source[ByteString, Any], Flow[Message, Message, *]] = {
     val actorSystem = ActorSystem("sttp")
 
@@ -410,7 +410,7 @@ object AkkaHttpBackend {
       customizeRequest: HttpRequest => HttpRequest = identity,
       customizeWebsocketRequest: WebSocketRequest => WebSocketRequest = identity
   )(
-      implicit ec: ExecutionContext = ExecutionContext.Implicits.global
+      implicit ec: ExecutionContext = ExecutionContext.global
   ): SttpBackend[Future, Source[ByteString, Any], Flow[Message, Message, *]] = {
     usingClient(
       actorSystem,
@@ -437,7 +437,7 @@ object AkkaHttpBackend {
       customizeRequest: HttpRequest => HttpRequest = identity,
       customizeWebsocketRequest: WebSocketRequest => WebSocketRequest = identity
   )(
-      implicit ec: ExecutionContext = ExecutionContext.Implicits.global
+      implicit ec: ExecutionContext = ExecutionContext.global
   ): SttpBackend[Future, Source[ByteString, Any], Flow[Message, Message, *]] = {
     make(
       actorSystem,
@@ -456,7 +456,7 @@ object AkkaHttpBackend {
     *
     * See [[SttpBackendStub]] for details on how to configure stub responses.
     */
-  def stub(implicit ec: ExecutionContext = ExecutionContext.Implicits.global): SttpBackendStub[Future, Nothing] =
+  def stub(implicit ec: ExecutionContext = ExecutionContext.global): SttpBackendStub[Future, Nothing] =
     SttpBackendStub(new FutureMonad())
 }
 

--- a/akka-http-backend/src/test/scala/sttp/client/akkahttp/AkkaHttpWebsocketTest.scala
+++ b/akka-http-backend/src/test/scala/sttp/client/akkahttp/AkkaHttpWebsocketTest.scala
@@ -24,7 +24,7 @@ class AkkaHttpWebsocketTest
     with TestHttpServer
     with Eventually
     with IntegrationPatience {
-  implicit val ec: ExecutionContext = scala.concurrent.ExecutionContext.Implicits.global
+  implicit val ec: ExecutionContext = scala.concurrent.ExecutionContext.global
   implicit val backend: SttpBackend[Future, Nothing, Flow[Message, Message, *]] = AkkaHttpBackend()
 
   it should "send and receive ten messages" in {

--- a/async-http-client-backend/fs2/src/main/scala/sttp/client/asynchttpclient/fs2/AsyncHttpClientFs2Backend.scala
+++ b/async-http-client-backend/fs2/src/main/scala/sttp/client/asynchttpclient/fs2/AsyncHttpClientFs2Backend.scala
@@ -56,7 +56,7 @@ class AsyncHttpClientFs2Backend[F[_]: ConcurrentEffect: ContextShift] private (
   override protected def publisherToFile(p: Publisher[ByteBuffer], f: File): F[Unit] = {
     p.toStream[F]
       .flatMap(b => Stream.emits(b.array()))
-      .through(fs2.io.file.writeAll(f.toPath, Blocker.liftExecutionContext(ExecutionContext.Implicits.global)))
+      .through(fs2.io.file.writeAll(f.toPath, Blocker.liftExecutionContext(ExecutionContext.global)))
       .compile
       .drain
   }

--- a/async-http-client-backend/fs2/src/test/scala/sttp/client/asynchttpclient/fs2/AsyncHttpClientFs2HttpStreamingTest.scala
+++ b/async-http-client-backend/fs2/src/test/scala/sttp/client/asynchttpclient/fs2/AsyncHttpClientFs2HttpStreamingTest.scala
@@ -10,7 +10,7 @@ import sttp.client.{NothingT, SttpBackend}
 import scala.concurrent.ExecutionContext
 
 class AsyncHttpClientFs2HttpStreamingTest extends Fs2ByteBufferStreamingTest {
-  private implicit val cs: ContextShift[IO] = IO.contextShift(ExecutionContext.Implicits.global)
+  private implicit val cs: ContextShift[IO] = IO.contextShift(ExecutionContext.global)
 
   override implicit val backend: SttpBackend[IO, Stream[IO, ByteBuffer], NothingT] =
     AsyncHttpClientFs2Backend[IO]().unsafeRunSync()

--- a/async-http-client-backend/future/src/main/scala/sttp/client/asynchttpclient/future/AsyncHttpClientFutureBackend.scala
+++ b/async-http-client-backend/future/src/main/scala/sttp/client/asynchttpclient/future/AsyncHttpClientFutureBackend.scala
@@ -52,7 +52,7 @@ object AsyncHttpClientFutureBackend {
   def apply(
       options: SttpBackendOptions = SttpBackendOptions.Default,
       customizeRequest: BoundRequestBuilder => BoundRequestBuilder = identity
-  )(implicit ec: ExecutionContext = ExecutionContext.Implicits.global): SttpBackend[Future, Nothing, WebSocketHandler] =
+  )(implicit ec: ExecutionContext = ExecutionContext.global): SttpBackend[Future, Nothing, WebSocketHandler] =
     AsyncHttpClientFutureBackend(AsyncHttpClientBackend.defaultClient(options), closeClient = true, customizeRequest)
 
   /**
@@ -63,7 +63,7 @@ object AsyncHttpClientFutureBackend {
   def usingConfig(
       cfg: AsyncHttpClientConfig,
       customizeRequest: BoundRequestBuilder => BoundRequestBuilder = identity
-  )(implicit ec: ExecutionContext = ExecutionContext.Implicits.global): SttpBackend[Future, Nothing, WebSocketHandler] =
+  )(implicit ec: ExecutionContext = ExecutionContext.global): SttpBackend[Future, Nothing, WebSocketHandler] =
     AsyncHttpClientFutureBackend(new DefaultAsyncHttpClient(cfg), closeClient = true, customizeRequest)
 
   /**
@@ -76,7 +76,7 @@ object AsyncHttpClientFutureBackend {
       updateConfig: DefaultAsyncHttpClientConfig.Builder => DefaultAsyncHttpClientConfig.Builder,
       options: SttpBackendOptions = SttpBackendOptions.Default,
       customizeRequest: BoundRequestBuilder => BoundRequestBuilder = identity
-  )(implicit ec: ExecutionContext = ExecutionContext.Implicits.global): SttpBackend[Future, Nothing, WebSocketHandler] =
+  )(implicit ec: ExecutionContext = ExecutionContext.global): SttpBackend[Future, Nothing, WebSocketHandler] =
     AsyncHttpClientFutureBackend(
       AsyncHttpClientBackend.clientWithModifiedOptions(options, updateConfig),
       closeClient = true,
@@ -91,7 +91,7 @@ object AsyncHttpClientFutureBackend {
   def usingClient(
       client: AsyncHttpClient,
       customizeRequest: BoundRequestBuilder => BoundRequestBuilder = identity
-  )(implicit ec: ExecutionContext = ExecutionContext.Implicits.global): SttpBackend[Future, Nothing, WebSocketHandler] =
+  )(implicit ec: ExecutionContext = ExecutionContext.global): SttpBackend[Future, Nothing, WebSocketHandler] =
     AsyncHttpClientFutureBackend(client, closeClient = false, customizeRequest)
 
   /**
@@ -99,6 +99,6 @@ object AsyncHttpClientFutureBackend {
     *
     * See [[SttpBackendStub]] for details on how to configure stub responses.
     */
-  def stub(implicit ec: ExecutionContext = ExecutionContext.Implicits.global): SttpBackendStub[Future, Nothing] =
+  def stub(implicit ec: ExecutionContext = ExecutionContext.global): SttpBackendStub[Future, Nothing] =
     SttpBackendStub(new FutureMonad())
 }

--- a/async-http-client-backend/monix/src/main/scala/sttp/client/asynchttpclient/monix/AsyncHttpClientMonixBackend.scala
+++ b/async-http-client-backend/monix/src/main/scala/sttp/client/asynchttpclient/monix/AsyncHttpClientMonixBackend.scala
@@ -70,7 +70,7 @@ object AsyncHttpClientMonixBackend {
       options: SttpBackendOptions = SttpBackendOptions.Default,
       customizeRequest: BoundRequestBuilder => BoundRequestBuilder = identity
   )(
-      implicit s: Scheduler = Scheduler.Implicits.global
+      implicit s: Scheduler = Scheduler.global
   ): Task[SttpBackend[Task, Observable[ByteBuffer], WebSocketHandler]] =
     Task.eval(
       AsyncHttpClientMonixBackend(AsyncHttpClientBackend.defaultClient(options), closeClient = true, customizeRequest)
@@ -83,7 +83,7 @@ object AsyncHttpClientMonixBackend {
       options: SttpBackendOptions = SttpBackendOptions.Default,
       customizeRequest: BoundRequestBuilder => BoundRequestBuilder = identity
   )(
-      implicit s: Scheduler = Scheduler.Implicits.global
+      implicit s: Scheduler = Scheduler.global
   ): Resource[Task, SttpBackend[Task, Observable[ByteBuffer], WebSocketHandler]] =
     Resource.make(apply(options, customizeRequest))(_.close())
 
@@ -95,7 +95,7 @@ object AsyncHttpClientMonixBackend {
       cfg: AsyncHttpClientConfig,
       customizeRequest: BoundRequestBuilder => BoundRequestBuilder = identity
   )(
-      implicit s: Scheduler = Scheduler.Implicits.global
+      implicit s: Scheduler = Scheduler.global
   ): Task[SttpBackend[Task, Observable[ByteBuffer], WebSocketHandler]] =
     Task.eval(AsyncHttpClientMonixBackend(new DefaultAsyncHttpClient(cfg), closeClient = true, customizeRequest))
 
@@ -106,7 +106,7 @@ object AsyncHttpClientMonixBackend {
       cfg: AsyncHttpClientConfig,
       customizeRequest: BoundRequestBuilder => BoundRequestBuilder = identity
   )(
-      implicit s: Scheduler = Scheduler.Implicits.global
+      implicit s: Scheduler = Scheduler.global
   ): Resource[Task, SttpBackend[Task, Observable[ByteBuffer], WebSocketHandler]] =
     Resource.make(usingConfig(cfg, customizeRequest))(_.close())
 
@@ -120,7 +120,7 @@ object AsyncHttpClientMonixBackend {
       options: SttpBackendOptions = SttpBackendOptions.Default,
       customizeRequest: BoundRequestBuilder => BoundRequestBuilder = identity
   )(
-      implicit s: Scheduler = Scheduler.Implicits.global
+      implicit s: Scheduler = Scheduler.global
   ): Task[SttpBackend[Task, Observable[ByteBuffer], WebSocketHandler]] =
     Task.eval(
       AsyncHttpClientMonixBackend(
@@ -141,7 +141,7 @@ object AsyncHttpClientMonixBackend {
       options: SttpBackendOptions = SttpBackendOptions.Default,
       customizeRequest: BoundRequestBuilder => BoundRequestBuilder = identity
   )(
-      implicit s: Scheduler = Scheduler.Implicits.global
+      implicit s: Scheduler = Scheduler.global
   ): Resource[Task, SttpBackend[Task, Observable[ByteBuffer], WebSocketHandler]] =
     Resource.make(usingConfigBuilder(updateConfig, options, customizeRequest))(_.close())
 
@@ -152,7 +152,7 @@ object AsyncHttpClientMonixBackend {
   def usingClient(
       client: AsyncHttpClient,
       customizeRequest: BoundRequestBuilder => BoundRequestBuilder = identity
-  )(implicit s: Scheduler = Scheduler.Implicits.global): SttpBackend[Task, Observable[ByteBuffer], WebSocketHandler] =
+  )(implicit s: Scheduler = Scheduler.global): SttpBackend[Task, Observable[ByteBuffer], WebSocketHandler] =
     AsyncHttpClientMonixBackend(client, closeClient = false, customizeRequest)
 
   /**

--- a/core/js/src/main/scala/sttp/client/FetchBackend.scala
+++ b/core/js/src/main/scala/sttp/client/FetchBackend.scala
@@ -36,7 +36,7 @@ object FetchBackend {
   def apply(
       fetchOptions: FetchOptions = FetchOptions.Default,
       customizeRequest: FetchRequest => FetchRequest = identity
-  )(implicit ec: ExecutionContext = ExecutionContext.Implicits.global): SttpBackend[Future, Nothing, NothingT] =
+  )(implicit ec: ExecutionContext = ExecutionContext.global): SttpBackend[Future, Nothing, NothingT] =
     new FetchBackend(fetchOptions, customizeRequest)
 
   /**
@@ -44,6 +44,6 @@ object FetchBackend {
     *
     * See [[SttpBackendStub]] for details on how to configure stub responses.
     */
-  def stub(implicit ec: ExecutionContext = ExecutionContext.Implicits.global): SttpBackendStub[Future, Nothing] =
+  def stub(implicit ec: ExecutionContext = ExecutionContext.global): SttpBackendStub[Future, Nothing] =
     SttpBackendStub(new FutureMonad())
 }

--- a/core/js/src/test/scala/sttp/client/testing/AsyncExecutionContext.scala
+++ b/core/js/src/test/scala/sttp/client/testing/AsyncExecutionContext.scala
@@ -12,5 +12,5 @@ import scala.concurrent.ExecutionContext
   *   using a wrong ExecutionContext for your task, please double check your Future.
   */
 trait AsyncExecutionContext { self: AsyncTestSuite =>
-  implicit override def executionContext: ExecutionContext = ExecutionContext.Implicits.global
+  implicit override def executionContext: ExecutionContext = ExecutionContext.global
 }

--- a/core/native/src/test/scala/sttp/client/testing/AsyncExecutionContext.scala
+++ b/core/native/src/test/scala/sttp/client/testing/AsyncExecutionContext.scala
@@ -3,5 +3,5 @@ package sttp.client.testing
 import scala.concurrent.ExecutionContext
 
 trait AsyncExecutionContext {
-  implicit def executionContext: ExecutionContext = ExecutionContext.Implicits.global
+  implicit def executionContext: ExecutionContext = ExecutionContext.global
 }

--- a/docs/backends/fs2.md
+++ b/docs/backends/fs2.md
@@ -75,7 +75,7 @@ import java.nio.ByteBuffer
 import cats.effect.{ContextShift, IO}
 import fs2.Stream
 
-implicit val cs: ContextShift[IO] = IO.contextShift(ExecutionContext.Implicits.global)
+implicit val cs: ContextShift[IO] = IO.contextShift(ExecutionContext.global)
 val effect = AsyncHttpClientFs2Backend[IO]().flatMap { implicit backend =>
   val stream: Stream[IO, ByteBuffer] = ...
 
@@ -97,7 +97,7 @@ import cats.effect.{ContextShift, IO}
 import fs2.Stream
 import scala.concurrent.duration.Duration
 
-implicit val cs: ContextShift[IO] = IO.contextShift(ExecutionContext.Implicits.global)
+implicit val cs: ContextShift[IO] = IO.contextShift(ExecutionContext.global)
 val effect = AsyncHttpClientFs2Backend[IO]().flatMap { implicit backend =>
   val response: IO[Response[Either[String, Stream[IO, ByteBuffer]]]] =
     basicRequest

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -292,7 +292,7 @@ import cats.effect.{ContextShift, IO}
 import cats.instances.string._
 import fs2.{Stream, Chunk, text}
 
-implicit val cs: ContextShift[IO] = IO.contextShift(scala.concurrent.ExecutionContext.Implicits.global)
+implicit val cs: ContextShift[IO] = IO.contextShift(scala.concurrent.ExecutionContext.global)
 
 def streamRequestBody(implicit backend: SttpBackend[IO, Stream[IO, ByteBuffer], NothingT]): IO[Unit] = {
   val stream: Stream[IO, ByteBuffer] = Stream.emits(List("Hello, ".getBytes, "world".getBytes)).map(ByteBuffer.wrap)

--- a/examples/src/main/scala/sttp/client/examples/StreamFs2.scala
+++ b/examples/src/main/scala/sttp/client/examples/StreamFs2.scala
@@ -9,7 +9,7 @@ object StreamFs2 extends App {
   import cats.instances.string._
   import fs2.{Stream, Chunk, text}
 
-  implicit val cs: ContextShift[IO] = IO.contextShift(scala.concurrent.ExecutionContext.Implicits.global)
+  implicit val cs: ContextShift[IO] = IO.contextShift(scala.concurrent.ExecutionContext.global)
 
   def streamRequestBody(implicit backend: SttpBackend[IO, Stream[IO, ByteBuffer], NothingT]): IO[Unit] = {
     val stream: Stream[IO, ByteBuffer] = Stream.emits(List("Hello, ".getBytes, "world".getBytes)).map(ByteBuffer.wrap)

--- a/http4s-backend/src/main/scala/sttp/client/http4s/Http4sBackend.scala
+++ b/http4s-backend/src/main/scala/sttp/client/http4s/Http4sBackend.scala
@@ -249,7 +249,7 @@ object Http4sBackend {
   }
 
   def usingDefaultClientBuilder[F[_]: ConcurrentEffect: ContextShift](
-      clientExecutionContext: ExecutionContext = ExecutionContext.Implicits.global,
+      clientExecutionContext: ExecutionContext = ExecutionContext.global,
       blocker: Blocker,
       customizeRequest: Http4sRequest[F] => Http4sRequest[F] = identity[Http4sRequest[F]] _
   ): Resource[F, SttpBackend[F, Stream[F, Byte], NothingT]] =

--- a/httpclient-backend/monix/src/main/scala/sttp/client/httpclient/monix/HttpClientMonixBackend.scala
+++ b/httpclient-backend/monix/src/main/scala/sttp/client/httpclient/monix/HttpClientMonixBackend.scala
@@ -51,7 +51,7 @@ object HttpClientMonixBackend {
       options: SttpBackendOptions = SttpBackendOptions.Default,
       customizeRequest: HttpRequest => HttpRequest = identity
   )(
-      implicit s: Scheduler = Scheduler.Implicits.global
+      implicit s: Scheduler = Scheduler.global
   ): Task[SttpBackend[Task, Observable[ByteBuffer], WebSocketHandler]] =
     Task.eval(
       HttpClientMonixBackend(HttpClientBackend.defaultClient(options), closeClient = true, customizeRequest)(s)
@@ -61,14 +61,14 @@ object HttpClientMonixBackend {
       options: SttpBackendOptions = SttpBackendOptions.Default,
       customizeRequest: HttpRequest => HttpRequest = identity
   )(
-      implicit s: Scheduler = Scheduler.Implicits.global
+      implicit s: Scheduler = Scheduler.global
   ): Resource[Task, SttpBackend[Task, Observable[ByteBuffer], WebSocketHandler]] =
     Resource.make(apply(options, customizeRequest))(_.close())
 
   def usingClient(
       client: HttpClient,
       customizeRequest: HttpRequest => HttpRequest = identity
-  )(implicit s: Scheduler = Scheduler.Implicits.global): SttpBackend[Task, Observable[ByteBuffer], WebSocketHandler] =
+  )(implicit s: Scheduler = Scheduler.global): SttpBackend[Task, Observable[ByteBuffer], WebSocketHandler] =
     HttpClientMonixBackend(client, closeClient = false, customizeRequest)(s)
 
   /**

--- a/httpclient-backend/src/main/scala/sttp/client/httpclient/HttpClientAsyncBackend.scala
+++ b/httpclient-backend/src/main/scala/sttp/client/httpclient/HttpClientAsyncBackend.scala
@@ -96,12 +96,12 @@ object HttpClientFutureBackend {
       options: SttpBackendOptions = SttpBackendOptions.Default,
       customizeRequest: HttpRequest => HttpRequest = identity
   )(
-      implicit ec: ExecutionContext = ExecutionContext.Implicits.global
+      implicit ec: ExecutionContext = ExecutionContext.global
   ): SttpBackend[Future, Nothing, WebSocketHandler] =
     HttpClientFutureBackend(HttpClientBackend.defaultClient(options), closeClient = true, customizeRequest)
 
   def usingClient(client: HttpClient, customizeRequest: HttpRequest => HttpRequest = identity)(
-      implicit ec: ExecutionContext = ExecutionContext.Implicits.global
+      implicit ec: ExecutionContext = ExecutionContext.global
   ): SttpBackend[Future, Nothing, WebSocketHandler] =
     HttpClientFutureBackend(client, closeClient = false, customizeRequest)
 
@@ -110,6 +110,6 @@ object HttpClientFutureBackend {
     *
     * See [[SttpBackendStub]] for details on how to configure stub responses.
     */
-  def stub(implicit ec: ExecutionContext = ExecutionContext.Implicits.global): SttpBackendStub[Future, Nothing] =
+  def stub(implicit ec: ExecutionContext = ExecutionContext.global): SttpBackendStub[Future, Nothing] =
     SttpBackendStub(new FutureMonad())
 }

--- a/okhttp-backend/monix/src/main/scala/sttp/client/okhttp/monix/OkHttpMonixBackend.scala
+++ b/okhttp-backend/monix/src/main/scala/sttp/client/okhttp/monix/OkHttpMonixBackend.scala
@@ -85,7 +85,7 @@ object OkHttpMonixBackend {
   def apply(
       options: SttpBackendOptions = SttpBackendOptions.Default
   )(
-      implicit s: Scheduler = Scheduler.Implicits.global
+      implicit s: Scheduler = Scheduler.global
   ): Task[SttpBackend[Task, Observable[ByteBuffer], WebSocketHandler]] =
     Task.eval(
       OkHttpMonixBackend(OkHttpBackend.defaultClient(DefaultReadTimeout.toMillis, options), closeClient = true)(s)
@@ -94,13 +94,13 @@ object OkHttpMonixBackend {
   def resource(
       options: SttpBackendOptions = SttpBackendOptions.Default
   )(
-      implicit s: Scheduler = Scheduler.Implicits.global
+      implicit s: Scheduler = Scheduler.global
   ): Resource[Task, SttpBackend[Task, Observable[ByteBuffer], WebSocketHandler]] =
     Resource.make(apply(options))(_.close())
 
   def usingClient(
       client: OkHttpClient
-  )(implicit s: Scheduler = Scheduler.Implicits.global): SttpBackend[Task, Observable[ByteBuffer], WebSocketHandler] =
+  )(implicit s: Scheduler = Scheduler.global): SttpBackend[Task, Observable[ByteBuffer], WebSocketHandler] =
     OkHttpMonixBackend(client, closeClient = false)(s)
 
   /**

--- a/okhttp-backend/src/main/scala/sttp/client/okhttp/OkHttpBackend.scala
+++ b/okhttp-backend/src/main/scala/sttp/client/okhttp/OkHttpBackend.scala
@@ -344,12 +344,12 @@ object OkHttpFutureBackend {
 
   def apply(
       options: SttpBackendOptions = SttpBackendOptions.Default
-  )(implicit ec: ExecutionContext = ExecutionContext.Implicits.global): SttpBackend[Future, Nothing, WebSocketHandler] =
+  )(implicit ec: ExecutionContext = ExecutionContext.global): SttpBackend[Future, Nothing, WebSocketHandler] =
     OkHttpFutureBackend(OkHttpBackend.defaultClient(DefaultReadTimeout.toMillis, options), closeClient = true)
 
   def usingClient(
       client: OkHttpClient
-  )(implicit ec: ExecutionContext = ExecutionContext.Implicits.global): SttpBackend[Future, Nothing, WebSocketHandler] =
+  )(implicit ec: ExecutionContext = ExecutionContext.global): SttpBackend[Future, Nothing, WebSocketHandler] =
     OkHttpFutureBackend(client, closeClient = false)
 
   /**
@@ -357,7 +357,7 @@ object OkHttpFutureBackend {
     *
     * See [[SttpBackendStub]] for details on how to configure stub responses.
     */
-  def stub(implicit ec: ExecutionContext = ExecutionContext.Implicits.global): SttpBackendStub[Future, Nothing] =
+  def stub(implicit ec: ExecutionContext = ExecutionContext.global): SttpBackendStub[Future, Nothing] =
     SttpBackendStub(new FutureMonad())
 }
 


### PR DESCRIPTION
`ExecutionContext.Implicits.global` is just an implicit reference to `ExecutionContext.global`, so when it's not imported to be implicit, the direct reference is clearer, in my opinion.

The same holds for Monix' `Scheduler`.