### PR TITLE
Removed DefaultFormats from Json4s Package

### DIFF
--- a/json/json4s/src/main/scala/sttp/client/json4s/SttpJson4sApi.scala
+++ b/json/json4s/src/main/scala/sttp/client/json4s/SttpJson4sApi.scala
@@ -2,13 +2,13 @@ package sttp.client.json4s
 
 import sttp.client._
 import sttp.client.internal.Utf8
-import org.json4s.{DefaultFormats, Formats, Serialization}
+import org.json4s.{Formats, Serialization}
 import sttp.model._
 import sttp.client.{ResponseAs, ResponseError}
 
 trait SttpJson4sApi {
   implicit def json4sBodySerializer[B <: AnyRef](
-      implicit formats: Formats = DefaultFormats,
+      implicit formats: Formats,
       serialization: Serialization
   ): BodySerializer[B] =
     b => StringBody(serialization.write(b), Utf8, Some(MediaType.ApplicationJson))
@@ -20,7 +20,7 @@ trait SttpJson4sApi {
     * - `Left(DeserializationError)` if there's an error during deserialization
     */
   def asJson[B: Manifest](
-      implicit formats: Formats = DefaultFormats,
+      implicit formats: Formats,
       serialization: Serialization
   ): ResponseAs[Either[ResponseError[Exception], B], Nothing] =
     asString.map(ResponseAs.deserializeRightCatchingExceptions(deserializeJson[B]))
@@ -31,7 +31,7 @@ trait SttpJson4sApi {
     * - `Left(DeserializationError)` if there's an error during deserialization
     */
   def asJsonAlways[B: Manifest](
-      implicit formats: Formats = DefaultFormats,
+      implicit formats: Formats,
       serialization: Serialization
   ): ResponseAs[Either[DeserializationError[Exception], B], Nothing] =
     asStringAlways.map(ResponseAs.deserializeCatchingExceptions(deserializeJson[B]))
@@ -41,13 +41,13 @@ trait SttpJson4sApi {
     * result, or throws an exception is there's an error during deserialization
     */
   def asJsonAlwaysUnsafe[B: Manifest](
-      implicit formats: Formats = DefaultFormats,
+      implicit formats: Formats,
       serialization: Serialization
   ): ResponseAs[B, Nothing] =
     asStringAlways.map(deserializeJson)
 
   def deserializeJson[B: Manifest](
-      implicit formats: Formats = DefaultFormats,
+      implicit formats: Formats,
       serialization: Serialization
   ): String => B =
     JsonInput.sanitize[B].andThen(serialization.read[B])

--- a/json/json4s/src/test/scala/sttp/client/Json4sTests.scala
+++ b/json/json4s/src/test/scala/sttp/client/Json4sTests.scala
@@ -1,7 +1,7 @@
 package sttp.client
 
 import org.json4s.ParserUtil.ParseException
-import org.json4s.{MappingException, native}
+import org.json4s.{DefaultFormats, MappingException, native}
 import org.scalatest._
 import sttp.client.internal._
 import sttp.model._
@@ -12,6 +12,8 @@ import org.scalatest.matchers.should.Matchers
 
 class Json4sTests extends AnyFlatSpec with Matchers with EitherValues {
   implicit val serialization = native.Serialization
+  implicit val formats = DefaultFormats
+
   import Json4sTests._
   import json4s._
 


### PR DESCRIPTION
Address #515 by removing the default parameter for `formats` in the `SttpJson4sApi` functions.