### PR TITLE
Update javascript-fetch backend documentation page

### DIFF
--- a/docs/backends/javascript/fetch.md
+++ b/docs/backends/javascript/fetch.md
@@ -34,7 +34,7 @@ You then need to load the modules into your runtime. This can be done in
 your main method as such :
 
 ```scala
-val g = scalajs.js.Dynamic.global
+val g = scalajs.js.Dynamic.global.globalThis
 g.fetch = g.require("node-fetch")
 g.require("abortcontroller-polyfill/dist/polyfill-patch-fetch")
 g.Headers = g.require("fetch-headers")


### PR DESCRIPTION
Issue: the current [javascript/fetch node-js](https://sttp.softwaremill.com/en/latest/backends/javascript/fetch.html#node-js) documentation is outdated for Scala-js 1.x. 

Error message:
`Loading the global scope as a value (anywhere but as the left-hand-side of a `.`-selection) is not allowed.`

Solution: use the `globalThis` property from `global` [https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/globalThis](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/globalThis)
