### PR TITLE
Fail openWebsocket for JDK HttpClient backends when request fails with 404

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,4 +29,5 @@ before_script:
 - mkdir -p chromedriver && unzip chromedriver_linux64.zip -d chromedriver/
 - export PATH="$PATH:$PWD/chromedriver/"
 script:
+- google-chrome --version
 - sbt test

--- a/httpclient-backend/src/main/scala/sttp/client/httpclient/HttpClientAsyncBackend.scala
+++ b/httpclient-backend/src/main/scala/sttp/client/httpclient/HttpClientAsyncBackend.scala
@@ -64,7 +64,10 @@ abstract class HttpClientAsyncBackend[F[_], S](
       val wsBuilder = client.newWebSocketBuilder()
       client.connectTimeout().map(wsBuilder.connectTimeout(_))
       request.headers.foreach(h => wsBuilder.header(h.name, h.value))
-      val cf = wsBuilder.buildAsync(request.uri.toJavaUri, listener)
+      val cf = wsBuilder
+        .buildAsync(request.uri.toJavaUri, listener)
+        .thenApply(_ => ())
+        .exceptionally(t => cb(Left(t)))
       Canceler(() => cf.cancel(true))
     })
   }


### PR DESCRIPTION
Now it's ready for review.
Problem was that we missed handling exception in CompletableFuture and never used callback, because listener was never called