### PR TITLE
WebSocket stubbing

### DIFF
--- a/akka-http-backend/src/main/scala/sttp/client/akkahttp/AkkaHttpBackend.scala
+++ b/akka-http-backend/src/main/scala/sttp/client/akkahttp/AkkaHttpBackend.scala
@@ -483,7 +483,7 @@ object AkkaHttpBackend {
     *
     * See [[SttpBackendStub]] for details on how to configure stub responses.
     */
-  def stub(implicit ec: ExecutionContext = ExecutionContext.global): SttpBackendStub[Future, Nothing] =
+  def stub(implicit ec: ExecutionContext = ExecutionContext.global): SttpBackendStub[Future, Nothing, Flow[Message, Message, *]] =
     SttpBackendStub(new FutureMonad())
 }
 

--- a/akka-http-backend/src/test/scala/sttp/client/akkahttp/SttpBackendStubAkkaTests.scala
+++ b/akka-http-backend/src/test/scala/sttp/client/akkahttp/SttpBackendStubAkkaTests.scala
@@ -1,0 +1,89 @@
+package sttp.client.akkahttp
+
+import akka.actor.ActorSystem
+import akka.http.scaladsl.model.ws.{Message, TextMessage}
+import akka.stream.OverflowStrategy
+import akka.stream.scaladsl.{Flow, Keep, Sink, Source}
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import sttp.client._
+import sttp.model.Headers
+
+import scala.concurrent.{Await, Future}
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.duration._
+
+class SttpBackendStubAkkaTests extends AnyFlatSpec with Matchers with ScalaFutures with BeforeAndAfterAll {
+
+  implicit val system: ActorSystem = ActorSystem()
+
+  override protected def afterAll(): Unit = {
+    Await.result(system.terminate().map(_ => ()), 5.seconds)
+  }
+
+  "backend stub" should "cycle through responses using a single sent request" in {
+    // given
+    implicit val backend = AkkaHttpBackend.stub
+      .whenRequestMatches(_ => true)
+      .thenRespondCyclic("a", "b", "c")
+
+    // when
+    def r = basicRequest.get(uri"http://example.org/a/b/c").send().futureValue
+
+    // then
+    r.body shouldBe Right("a")
+    r.body shouldBe Right("b")
+    r.body shouldBe Right("c")
+    r.body shouldBe Right("a")
+  }
+
+  it should "use given flow as web socket handler" in {
+    // This test is an example how can we test client flow.
+    // We check behavior of client when connected to echo server.
+    // Client responsibility was to send two messages to the server and collect received messages.
+    val useHandler: Flow[Message, Message, Future[Seq[Message]]] => Future[Seq[Message]] = clientFlow => {
+      val ((outQueue, clientReceivedMessages), inQueue) = Source
+        .queue(1, OverflowStrategy.fail)
+        .viaMat(clientFlow)(Keep.both)
+        .toMat(Sink.queue())(Keep.both)
+        .run()
+
+      def echoMsg(): Future[Unit] =
+        inQueue.pull().flatMap {
+          case None =>
+            echoMsg()
+          case Some(msg) =>
+            outQueue.offer(TextMessage(s"echo: " + msg.asTextMessage.getStrictText)).map(_ => ())
+        }
+
+      (for {
+        _ <- outQueue.offer(TextMessage("Hi!"))
+        _ <- echoMsg()
+        _ <- echoMsg()
+        _ = outQueue.complete()
+        _ <- outQueue.watchCompletion()
+      } yield ()).flatMap(_ => clientReceivedMessages)
+    }
+
+    val clientFlow: Flow[Message, Message, Future[Seq[Message]]] = {
+      Flow.fromSinkAndSourceMat(
+        Sink.seq[Message],
+        Source((1 to 2).map(i => TextMessage(s"test$i")))
+      )(Keep.left)
+    }
+
+    implicit val b = AkkaHttpBackend.stub
+      .whenRequestMatches(_ => true)
+      .thenHandleOpenWebSocket(Headers(List.empty), useHandler)
+
+    val receivedMessages = basicRequest
+      .get(uri"wss://echo.websocket.org")
+      .openWebsocket(clientFlow)
+      .flatMap(_.result)
+      .futureValue.toList
+
+    receivedMessages shouldBe List("Hi!", "echo: test1", "echo: test2").map(TextMessage(_))
+  }
+}

--- a/async-http-client-backend/cats/src/main/scala/sttp/client/asynchttpclient/cats/AsyncHttpClientCatsBackend.scala
+++ b/async-http-client-backend/cats/src/main/scala/sttp/client/asynchttpclient/cats/AsyncHttpClientCatsBackend.scala
@@ -138,5 +138,5 @@ object AsyncHttpClientCatsBackend {
     *
     * See [[SttpBackendStub]] for details on how to configure stub responses.
     */
-  def stub[F[_]: Concurrent]: SttpBackendStub[F, Nothing] = SttpBackendStub(new CatsMonadAsyncError())
+  def stub[F[_]: Concurrent]: SttpBackendStub[F, Nothing, WebSocketHandler] = SttpBackendStub(new CatsMonadAsyncError())
 }

--- a/async-http-client-backend/fs2/src/main/scala/sttp/client/asynchttpclient/fs2/AsyncHttpClientFs2Backend.scala
+++ b/async-http-client-backend/fs2/src/main/scala/sttp/client/asynchttpclient/fs2/AsyncHttpClientFs2Backend.scala
@@ -140,5 +140,5 @@ object AsyncHttpClientFs2Backend {
     *
     * See [[SttpBackendStub]] for details on how to configure stub responses.
     */
-  def stub[F[_]: Concurrent]: SttpBackendStub[F, Stream[F, ByteBuffer]] = SttpBackendStub(new CatsMonadAsyncError())
+  def stub[F[_]: Concurrent]: SttpBackendStub[F, Stream[F, ByteBuffer], WebSocketHandler] = SttpBackendStub(new CatsMonadAsyncError())
 }

--- a/async-http-client-backend/future/src/main/scala/sttp/client/asynchttpclient/future/AsyncHttpClientFutureBackend.scala
+++ b/async-http-client-backend/future/src/main/scala/sttp/client/asynchttpclient/future/AsyncHttpClientFutureBackend.scala
@@ -99,6 +99,6 @@ object AsyncHttpClientFutureBackend {
     *
     * See [[SttpBackendStub]] for details on how to configure stub responses.
     */
-  def stub(implicit ec: ExecutionContext = ExecutionContext.global): SttpBackendStub[Future, Nothing] =
+  def stub(implicit ec: ExecutionContext = ExecutionContext.global): SttpBackendStub[Future, Nothing, WebSocketHandler] =
     SttpBackendStub(new FutureMonad())
 }

--- a/async-http-client-backend/monix/src/main/scala/sttp/client/asynchttpclient/monix/AsyncHttpClientMonixBackend.scala
+++ b/async-http-client-backend/monix/src/main/scala/sttp/client/asynchttpclient/monix/AsyncHttpClientMonixBackend.scala
@@ -161,5 +161,5 @@ object AsyncHttpClientMonixBackend {
     *
     * See [[SttpBackendStub]] for details on how to configure stub responses.
     */
-  def stub: SttpBackendStub[Task, Observable[ByteBuffer]] = SttpBackendStub(TaskMonadAsyncError)
+  def stub: SttpBackendStub[Task, Observable[ByteBuffer], WebSocketHandler] = SttpBackendStub(TaskMonadAsyncError)
 }

--- a/async-http-client-backend/scalaz/src/main/scala/sttp/client/asynchttpclient/scalaz/AsyncHttpClientScalazBackend.scala
+++ b/async-http-client-backend/scalaz/src/main/scala/sttp/client/asynchttpclient/scalaz/AsyncHttpClientScalazBackend.scala
@@ -80,5 +80,5 @@ object AsyncHttpClientScalazBackend {
     *
     * See [[SttpBackendStub]] for details on how to configure stub responses.
     */
-  def stub: SttpBackendStub[Task, Nothing] = SttpBackendStub(TaskMonadAsyncError)
+  def stub: SttpBackendStub[Task, Nothing, WebSocketHandler] = SttpBackendStub(TaskMonadAsyncError)
 }

--- a/async-http-client-backend/zio-streams/src/main/scala/sttp/client/asynchttpclient/ziostreams/AsyncHttpClientZioStreamsBackend.scala
+++ b/async-http-client-backend/zio-streams/src/main/scala/sttp/client/asynchttpclient/ziostreams/AsyncHttpClientZioStreamsBackend.scala
@@ -180,5 +180,5 @@ object AsyncHttpClientZioStreamsBackend {
     *
     * See [[SttpBackendStub]] for details on how to configure stub responses.
     */
-  def stub: SttpBackendStub[Task, Stream[Throwable, ByteBuffer]] = SttpBackendStub(new RIOMonadAsyncError)
+  def stub: SttpBackendStub[Task, Stream[Throwable, ByteBuffer], WebSocketHandler] = SttpBackendStub(new RIOMonadAsyncError)
 }

--- a/async-http-client-backend/zio/src/main/scala/sttp/client/asynchttpclient/zio/AsyncHttpClientZioBackend.scala
+++ b/async-http-client-backend/zio/src/main/scala/sttp/client/asynchttpclient/zio/AsyncHttpClientZioBackend.scala
@@ -124,5 +124,5 @@ object AsyncHttpClientZioBackend {
     *
     * See [[SttpBackendStub]] for details on how to configure stub responses.
     */
-  def stub: SttpBackendStub[Task, Nothing] = SttpBackendStub(new RIOMonadAsyncError)
+  def stub: SttpBackendStub[Task, Nothing, WebSocketHandler] = SttpBackendStub(new RIOMonadAsyncError[Any])
 }

--- a/async-http-client-backend/zio/src/test/scala/sttp/client/asynchttpclient/zio/SttpBackendStubZioTests.scala
+++ b/async-http-client-backend/zio/src/test/scala/sttp/client/asynchttpclient/zio/SttpBackendStubZioTests.scala
@@ -1,19 +1,22 @@
 package sttp.client.asynchttpclient.zio
 
 import org.scalatest.concurrent.ScalaFutures
-import sttp.client._
-import sttp.client.impl.zio.RIOMonadAsyncError
-import sttp.client.testing.SttpBackendStub
-import sttp.client.impl.zio._
-import zio.Task
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
+import sttp.client._
+import sttp.client.testing.SttpBackendStub
+import sttp.client.impl.zio._
+import sttp.client.monad.MonadError
+import sttp.client.ws.{WebSocket, WebSocketEvent}
+import sttp.model.Headers
+import sttp.model.ws._
+import zio._
 
 class SttpBackendStubZioTests extends AnyFlatSpec with Matchers with ScalaFutures {
 
   "backend stub" should "cycle through responses using a single sent request" in {
     // given
-    implicit val b: SttpBackendStub[Task, Nothing] = SttpBackendStub(new RIOMonadAsyncError[Any])
+    implicit val b: SttpBackendStub[Task, Nothing, NothingT] = SttpBackendStub(new RIOMonadAsyncError[Any])
       .whenRequestMatches(_ => true)
       .thenRespondCyclic("a", "b", "c")
 
@@ -25,5 +28,42 @@ class SttpBackendStubZioTests extends AnyFlatSpec with Matchers with ScalaFuture
     runtime.unsafeRun(r).body shouldBe Right("b")
     runtime.unsafeRun(r).body shouldBe Right("c")
     runtime.unsafeRun(r).body shouldBe Right("a")
+  }
+
+  it should "return given web socket response" in {
+    val rioMonad: MonadError[zio.Task] = new RIOMonadAsyncError[Any]
+    val frame1 = WebSocketFrame.text("initial frame")
+    val sentFrame = WebSocketFrame.text("sent frame")
+
+    def webSocket(queue: Queue[WebSocketFrame.Incoming]) =
+      new WebSocket[Task] {
+        override def isOpen: zio.Task[Boolean] = Task.succeed(true)
+        override def monad: MonadError[zio.Task] = rioMonad
+        override def receive: zio.Task[Either[WebSocketEvent.Close, WebSocketFrame.Incoming]] = queue.take.map(Right(_))
+        override def send(f: WebSocketFrame, isContinuation: Boolean): zio.Task[Unit] =
+          f match {
+            case t: WebSocketFrame.Text => queue.offer(t).unit
+            case _                      => Task.unit
+          }
+      }
+
+    def makeBackend(queue: Queue[WebSocketFrame.Incoming]) =
+      AsyncHttpClientZioBackend.stub
+        .whenRequestMatches(_ => true)
+        .thenRespondWebSocket(Headers(List.empty), webSocket(queue))
+
+    val test = for {
+      queue <- Queue.unbounded[WebSocketFrame.Incoming]
+      _ <- queue.offer(frame1)
+      backend = makeBackend(queue)
+      handler <- ZioWebSocketHandler()
+      request = basicRequest.get(uri"http://example.org/a/b/c")
+      ws <- backend.openWebsocket(request, handler).map(_.result)
+      msg1 <- ws.receive
+      _ <- ws.send(sentFrame, false)
+      msg2 <- ws.receive
+    } yield (msg1, msg2)
+
+    runtime.unsafeRun(test) shouldBe ((Right(frame1), Right(sentFrame)))
   }
 }

--- a/async-http-client-backend/zio/src/test/scala/sttp/client/asynchttpclient/zio/WebSocketStubZioTests.scala
+++ b/async-http-client-backend/zio/src/test/scala/sttp/client/asynchttpclient/zio/WebSocketStubZioTests.scala
@@ -1,0 +1,137 @@
+package sttp.client.asynchttpclient.zio
+
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import sttp.client._
+import sttp.client.testing.WebSocketStub
+import sttp.client.impl.zio._
+import sttp.client.ws.WebSocketEvent
+import sttp.model.Headers
+import sttp.model.ws.WebSocketFrame
+
+import scala.util.{Failure, Success}
+
+class WebSocketStubZioTests extends AnyFlatSpec with Matchers with ScalaFutures {
+
+  def mkBackend(webSocketStub: WebSocketStub[_]) =
+    AsyncHttpClientZioBackend.stub
+      .whenRequestMatches(_ => true)
+      .thenRespondWebSocket(Headers(List.empty), webSocketStub)
+
+  "web socket stub" should "return initial Incoming frames on 'receive'" in {
+    val frames = List("a", "b", "c").map(WebSocketFrame.text(_))
+    val webSocketStub = WebSocketStub.withInitialIncoming(frames)
+    implicit val b = mkBackend(webSocketStub)
+    val test = for {
+      handler <- ZioWebSocketHandler()
+      ws <- basicRequest.get(uri"http://example.org/a/b/c").openWebsocket(handler).map(_.result)
+      msg1 <- ws.receive
+      msg2 <- ws.receive
+      msg3 <- ws.receive
+    } yield List(msg1, msg2, msg3)
+
+    runtime.unsafeRun(test) shouldBe frames.map(Right(_))
+  }
+
+  it should "return initial responses on 'receive'" in {
+    val okFrame = WebSocketFrame.text("abc")
+    val exception = new Exception("boom")
+    val webSocketStub = WebSocketStub.withInitialResponses(List(Success(Right(okFrame)), Failure(exception)))
+    implicit val b = mkBackend(webSocketStub)
+    val test = for {
+      handler <- ZioWebSocketHandler()
+      ws <- basicRequest.get(uri"http://example.org/a/b/c").openWebsocket(handler).map(_.result)
+      msg <- ws.receive
+      err <- ws.receive.either
+    } yield (msg, err)
+
+    runtime.unsafeRun(test) shouldBe ((Right(okFrame), Left(exception)))
+  }
+
+  it should "add next Incoming frames as reaction to send" in {
+    val firstFrame = WebSocketFrame.text("No. 1")
+    val secondFrame = WebSocketFrame.text("Second")
+    val thirdFrame = WebSocketFrame.text("3")
+    val expectedFrame = WebSocketFrame.text("give me more!")
+    val webSocketStub = WebSocketStub
+      .withInitialIncoming(List(firstFrame))
+      .thenRespond {
+        case `expectedFrame` => List(secondFrame, thirdFrame)
+        case _               => List.empty
+      }
+    implicit val b = mkBackend(webSocketStub)
+    val test = for {
+      handler <- ZioWebSocketHandler()
+      ws <- basicRequest.get(uri"http://example.org/a/b/c").openWebsocket(handler).map(_.result)
+      msg1 <- ws.receive
+      err1 <- ws.receive.either
+      _ <- ws.send(WebSocketFrame.text("not expected"))
+      err2 <- ws.receive.either
+      _ <- ws.send(expectedFrame)
+      msg2 <- ws.receive
+      msg3 <- ws.receive
+    } yield (msg1, err1.isLeft, err2.isLeft, msg2, msg3)
+
+    runtime.unsafeRun(test) shouldBe ((Right(firstFrame), true, true, Right(secondFrame), Right(thirdFrame)))
+  }
+
+  it should "add next responses as reaction to send" in {
+    val ok = WebSocketFrame.text("ok")
+    val exception = new Exception("some error")
+
+    val webSocketStub = WebSocketStub.withNoInitialResponses
+      .thenRespondWith {
+        case _ => List(Success(Right(ok)), Failure(exception))
+      }
+    implicit val b = mkBackend(webSocketStub)
+    val test = for {
+      handler <- ZioWebSocketHandler()
+      ws <- basicRequest.get(uri"http://example.org/a/b/c").openWebsocket(handler).map(_.result)
+      _ <- ws.send(WebSocketFrame.text("let's add responses"))
+      msg <- ws.receive
+      err1 <- ws.receive.either
+      err2 <- ws.receive.either
+    } yield (msg, err1, err2.isLeft)
+
+    runtime.unsafeRun(test) shouldBe ((Right(ok), Left(exception), true))
+  }
+
+  it should "be closed after sending Close event" in {
+    val ok = WebSocketFrame.text("ok")
+    val closeEvent = WebSocketEvent.Close(500, "internal error")
+    val webSocketStub = WebSocketStub.withInitialResponses(List(Success(Left(closeEvent)), Success(Right(ok))))
+
+    implicit val b = mkBackend(webSocketStub)
+    val test = for {
+      handler <- ZioWebSocketHandler()
+      ws <- basicRequest.get(uri"http://example.org/a/b/c").openWebsocket(handler).map(_.result)
+      _ <- ws.send(WebSocketFrame.text("let's add responses"))
+      close <- ws.receive
+      isOpen <- ws.isOpen
+      err <- ws.receive.either
+    } yield (close, isOpen, err.isLeft)
+
+    runtime.unsafeRun(test) shouldBe ((Left(closeEvent), false, true))
+  }
+
+  it should "use state to add next responses" in {
+    val webSocketStub = WebSocketStub.withNoInitialResponses
+      .thenRespondWithS(0) {
+        case (counter, _) => (counter + 1, List(Success(Right(WebSocketFrame.text(s"No. $counter")))))
+      }
+    implicit val b = mkBackend(webSocketStub)
+    val test = for {
+      handler <- ZioWebSocketHandler()
+      ws <- basicRequest.get(uri"http://example.org/a/b/c").openWebsocket(handler).map(_.result)
+      _ <- ws.send(WebSocketFrame.text("a"))
+      _ <- ws.send(WebSocketFrame.text("b"))
+      _ <- ws.send(WebSocketFrame.text("c"))
+      msg1 <- ws.receive
+      msg2 <- ws.receive
+      msg3 <- ws.receive
+    } yield List(msg1, msg2, msg3)
+
+    runtime.unsafeRun(test) shouldBe List("No. 0", "No. 1", "No. 2").map(s => Right(WebSocketFrame.text(s)))
+  }
+}

--- a/core/src/main/scala/sttp/client/testing/SttpBackendStub.scala
+++ b/core/src/main/scala/sttp/client/testing/SttpBackendStub.scala
@@ -4,12 +4,15 @@ import java.io.InputStream
 
 import sttp.client._
 import sttp.client.internal._
+
 import sttp.client.monad.{FutureMonad, IdMonad, MonadError}
 import sttp.client.testing.SttpBackendStub._
 import sttp.client.internal.SttpFile
-import sttp.client.ws.WebSocketResponse
+import sttp.client.ws.{WebSocket, WebSocketEvent, WebSocketResponse}
 import sttp.client.{IgnoreResponse, ResponseAs, ResponseAsByteArray, SttpBackend}
-import sttp.model.StatusCode
+import sttp.client.SttpClientException.ReadException
+import sttp.model.{Headers, StatusCode}
+import sttp.model.ws.WebSocketFrame
 
 import scala.concurrent.Future
 import scala.language.higherKinds
@@ -32,11 +35,12 @@ import scala.util.{Failure, Success, Try}
   * or headers. A [[ClassCastException]] might occur if for a given request,
   * a response is specified with the incorrect or inconvertible body type.
   */
-class SttpBackendStub[F[_], S](
+class SttpBackendStub[F[_], S, WS_HANDLER[_]](
     monad: MonadError[F],
     matchers: PartialFunction[Request[_, _], F[Response[_]]],
-    fallback: Option[SttpBackend[F, S, NothingT]]
-) extends SttpBackend[F, S, NothingT] { // TODO
+    wsMatchers: PartialFunction[Request[_, _], WhenOpenWebsocket[F, WS_HANDLER]],
+    fallback: Option[SttpBackend[F, S, WS_HANDLER]]
+) extends SttpBackend[F, S, WS_HANDLER] {
 
   /**
     * Specify how the stub backend should respond to requests matching the
@@ -63,10 +67,36 @@ class SttpBackendStub[F[_], S](
     * Note that the stubs are immutable, and each new
     * specification that is added yields a new stub instance.
     */
-  def whenRequestMatchesPartial(partial: PartialFunction[Request[_, _], Response[_]]): SttpBackendStub[F, S] = {
+  def whenRequestMatchesPartial(
+      partial: PartialFunction[Request[_, _], Response[_]]
+  ): SttpBackendStub[F, S, WS_HANDLER] = {
     val wrappedPartial: PartialFunction[Request[_, _], F[Response[_]]] =
       partial.andThen((r: Response[_]) => monad.unit(r))
-    new SttpBackendStub(monad, matchers.orElse(wrappedPartial), fallback)
+    new SttpBackendStub[F, S, WS_HANDLER](monad, matchers.orElse(wrappedPartial), wsMatchers, fallback)
+  }
+
+  /**
+    * Specify how the stub backend should respond to open websocket requests
+    * using the given partial function.
+    */
+  def whenRequestMatchesPartialReturnWebSocketResponse[WS_RESULT](
+      partial: PartialFunction[Request[_, _], (Headers, WS_RESULT)]
+  ): SttpBackendStub[F, S, WS_HANDLER] = {
+    val wrappedPartial: PartialFunction[Request[_, _], WhenOpenWebsocket[F, WS_HANDLER]] =
+      partial.andThen((r) => ReturnWebsocketResponse(r._1, () => monad.unit(r._2)))
+    new SttpBackendStub[F, S, WS_HANDLER](monad, matchers, wsMatchers.orElse(wrappedPartial), fallback)
+  }
+
+  /**
+    * Specify how the stub backend should use web socket handler using the given partial function.
+    * Meant mainly for akka backend or cases when implementing a custom WS_HANDLER.
+    */
+  def whenRequestMatchesPartialHandleOpenWebsocket[WS_RESULT](
+      partial: PartialFunction[Request[_, _], (Headers, WS_HANDLER[WS_RESULT] => WS_RESULT)]
+  ): SttpBackendStub[F, S, WS_HANDLER] = {
+    val wrappedPartial: PartialFunction[Request[_, _], WhenOpenWebsocket[F, WS_HANDLER]] =
+      partial.andThen((r) => UseHandler(r._1, r._2.asInstanceOf[Any => WS_RESULT]))
+    new SttpBackendStub[F, S, WS_HANDLER](monad, matchers, wsMatchers.orElse(wrappedPartial), fallback)
   }
 
   override def send[T](request: Request[T, S]): F[Response[T]] = {
@@ -86,8 +116,21 @@ class SttpBackendStub[F[_], S](
     }
   }
 
-  override def openWebsocket[T, WR](request: Request[T, S], handler: NothingT[WR]): F[WebSocketResponse[WR]] =
-    handler // nothing is everything
+  override def openWebsocket[T, WR](request: Request[T, S], handler: WS_HANDLER[WR]): F[WebSocketResponse[WR]] = {
+    Try(wsMatchers.lift(request)) match {
+      case Success(Some(UseHandler(headers, useHandler))) =>
+        val use = useHandler.asInstanceOf[WS_HANDLER[WR] => WR]
+        monad.unit(WebSocketResponse(headers, use(handler)))
+      case Success(Some(ReturnWebsocketResponse(headers, response))) =>
+        monad.map(response())(r => WebSocketResponse(headers, r.asInstanceOf[WR]))
+      case Success(None) =>
+        fallback match {
+          case None     => monad.error(new ReadException(new Exception("request didn't match any stub path")))
+          case Some(fb) => fb.openWebsocket(request, handler)
+        }
+      case Failure(e) => monad.error(e)
+    }
+  }
 
   private def wrapResponse[T](r: Response[_]): F[Response[T]] =
     monad.unit(r.asInstanceOf[Response[T]])
@@ -97,49 +140,88 @@ class SttpBackendStub[F[_], S](
   override def responseMonad: MonadError[F] = monad
 
   class WhenRequest(p: Request[_, _] => Boolean) {
-    def thenRespondOk(): SttpBackendStub[F, S] =
+    def thenRespondOk(): SttpBackendStub[F, S, WS_HANDLER] =
       thenRespondWithCode(StatusCode.Ok)
-    def thenRespondNotFound(): SttpBackendStub[F, S] =
+    def thenRespondNotFound(): SttpBackendStub[F, S, WS_HANDLER] =
       thenRespondWithCode(StatusCode.NotFound, "Not found")
-    def thenRespondServerError(): SttpBackendStub[F, S] =
+    def thenRespondServerError(): SttpBackendStub[F, S, WS_HANDLER] =
       thenRespondWithCode(StatusCode.InternalServerError, "Internal server error")
-    def thenRespondWithCode(status: StatusCode, msg: String = ""): SttpBackendStub[F, S] = {
+    def thenRespondWithCode(status: StatusCode, msg: String = ""): SttpBackendStub[F, S, WS_HANDLER] = {
       thenRespond(Response(msg, status, msg))
     }
-    def thenRespond[T](body: T): SttpBackendStub[F, S] =
+    def thenRespond[T](body: T): SttpBackendStub[F, S, WS_HANDLER] =
       thenRespond(Response[T](body, StatusCode.Ok, "OK"))
-    def thenRespond[T](resp: => Response[T]): SttpBackendStub[F, S] = {
+    def thenRespond[T](resp: => Response[T]): SttpBackendStub[F, S, WS_HANDLER] = {
       val m: PartialFunction[Request[_, _], F[Response[_]]] = {
         case r if p(r) => monad.eval(resp)
       }
-      new SttpBackendStub(monad, matchers.orElse(m), fallback)
+      new SttpBackendStub[F, S, WS_HANDLER](monad, matchers.orElse(m), wsMatchers, fallback)
+    }
+
+    /**
+      * When [[openWebsocket()]] is called, it will ignore handler and return given result.
+      * This method is intended to be used when [[openWebsocket()]] is called with sttp supplied handlers
+      * that return wrapped WebSocket as WS_RESULT.
+      * */
+    def thenRespondWebSocket[WS_RESULT](headers: Headers, result: WS_RESULT): SttpBackendStub[F, S, WS_HANDLER] = {
+      val m: PartialFunction[Request[_, _], WhenOpenWebsocket[F, WS_HANDLER]] = {
+        case r if p(r) =>
+          ReturnWebsocketResponse(headers, () => monad.unit(result))
+      }
+      new SttpBackendStub[F, S, WS_HANDLER](monad, matchers, wsMatchers.orElse(m), fallback)
+    }
+
+    /**
+      * When [[openWebsocket()]] is called, it will ignore handler and return given result.
+      * It is intended to be used when [[openWebsocket()]] is called with sttp supplied handlers
+      * It returns [[WebSocket]] built by [[WebSocketStub]] wrapped as WS_RESULT.
+      * */
+    def thenRespondWebSocket(headers: Headers, wsStub: WebSocketStub[_]): SttpBackendStub[F, S, WS_HANDLER] = {
+      val m: PartialFunction[Request[_, _], WhenOpenWebsocket[F, WS_HANDLER]] = {
+        case r if p(r) =>
+          ReturnWebsocketResponse(headers, () => monad.unit(wsStub.build(monad)))
+      }
+      new SttpBackendStub[F, S, WS_HANDLER](monad, matchers, wsMatchers.orElse(m), fallback)
+    }
+
+    /**
+      * When [[openWebsocket()]] is called it uses given headers and handler to create result.
+      * It is intended to be used when [[openWebsocket()]] is called with user supplied handler that
+      * doesn't return WebSocket object to act on.
+      * */
+    def thenHandleOpenWebSocket[WS_RESULT](headers: Headers, useHandler: WS_HANDLER[WS_RESULT] => WS_RESULT) = {
+      val m: PartialFunction[Request[_, _], WhenOpenWebsocket[F, WS_HANDLER]] = {
+        case r if p(r) =>
+          UseHandler(headers, useHandler.asInstanceOf[Any => WS_RESULT])
+      }
+      new SttpBackendStub[F, S, WS_HANDLER](monad, matchers, wsMatchers.orElse(m), fallback)
     }
 
     /**
       * Not thread-safe!
       */
-    def thenRespondCyclic[T](bodies: T*): SttpBackendStub[F, S] = {
+    def thenRespondCyclic[T](bodies: T*): SttpBackendStub[F, S, WS_HANDLER] = {
       thenRespondCyclicResponses(bodies.map(body => Response[T](body, StatusCode.Ok, "OK")): _*)
     }
 
     /**
       * Not thread-safe!
       */
-    def thenRespondCyclicResponses[T](responses: Response[T]*): SttpBackendStub[F, S] = {
+    def thenRespondCyclicResponses[T](responses: Response[T]*): SttpBackendStub[F, S, WS_HANDLER] = {
       val iterator = Iterator.continually(responses).flatten
       thenRespond(iterator.next)
     }
-    def thenRespondWrapped(resp: => F[Response[_]]): SttpBackendStub[F, S] = {
+    def thenRespondWrapped(resp: => F[Response[_]]): SttpBackendStub[F, S, WS_HANDLER] = {
       val m: PartialFunction[Request[_, _], F[Response[_]]] = {
         case r if p(r) => resp
       }
-      new SttpBackendStub(monad, matchers.orElse(m), fallback)
+      new SttpBackendStub[F, S, WS_HANDLER](monad, matchers.orElse(m), wsMatchers, fallback)
     }
-    def thenRespondWrapped(resp: Request[_, _] => F[Response[_]]): SttpBackendStub[F, S] = {
+    def thenRespondWrapped(resp: Request[_, _] => F[Response[_]]): SttpBackendStub[F, S, WS_HANDLER] = {
       val m: PartialFunction[Request[_, _], F[Response[_]]] = {
         case r if p(r) => resp(r)
       }
-      new SttpBackendStub(monad, matchers.orElse(m), fallback)
+      new SttpBackendStub[F, S, WS_HANDLER](monad, matchers.orElse(m), wsMatchers, fallback)
     }
   }
 }
@@ -150,31 +232,53 @@ object SttpBackendStub {
     * Create a stub synchronous backend (which doesn't wrap results in any
     * container), without streaming support.
     */
-  def synchronous: SttpBackendStub[Identity, Nothing] =
-    new SttpBackendStub[Identity, Nothing](IdMonad, PartialFunction.empty, None)
+  def synchronous[WS_HANDLER[_]]: SttpBackendStub[Identity, Nothing, WS_HANDLER] =
+    new SttpBackendStub[Identity, Nothing, WS_HANDLER](
+      IdMonad,
+      PartialFunction.empty,
+      PartialFunction.empty,
+      None
+    )
 
   /**
     * Create a stub asynchronous backend (which wraps results in Scala's
     * built-in `Future`), without streaming support.
     */
-  def asynchronousFuture: SttpBackendStub[Future, Nothing] = {
+  def asynchronousFuture[WS_HANDLER[_]]: SttpBackendStub[Future, Nothing, WS_HANDLER] = {
     import scala.concurrent.ExecutionContext.Implicits.global
-    new SttpBackendStub[Future, Nothing](new FutureMonad(), PartialFunction.empty, None)
+    new SttpBackendStub[Future, Nothing, WS_HANDLER](
+      new FutureMonad(),
+      PartialFunction.empty,
+      PartialFunction.empty,
+      None
+    )
   }
 
   /**
     * Create a stub backend using the given response monad (which determines
-    * how requests are wrapped), and any stream type.
+    * how requests are wrapped), any stream type and any web sockets handler.
     */
-  def apply[F[_], S](responseMonad: MonadError[F]): SttpBackendStub[F, S] =
-    new SttpBackendStub[F, S](responseMonad, PartialFunction.empty, None)
+  def apply[F[_], S, WS_RESPONSE[_]](responseMonad: MonadError[F]): SttpBackendStub[F, S, WS_RESPONSE] =
+    new SttpBackendStub[F, S, WS_RESPONSE](
+      responseMonad,
+      PartialFunction.empty,
+      PartialFunction.empty,
+      None
+    )
 
   /**
     * Create a stub backend which delegates send requests to the given fallback
     * backend, if the request doesn't match any of the specified predicates.
     */
-  def withFallback[F[_], S, S2 <: S](fallback: SttpBackend[F, S, NothingT]): SttpBackendStub[F, S2] =
-    new SttpBackendStub[F, S2](fallback.responseMonad, PartialFunction.empty, Some(fallback))
+  def withFallback[F[_], S, S2 <: S, WS_HANDLER[_]](
+      fallback: SttpBackend[F, S, WS_HANDLER]
+  ): SttpBackendStub[F, S2, WS_HANDLER] =
+    new SttpBackendStub[F, S2, WS_HANDLER](
+      fallback.responseMonad,
+      PartialFunction.empty,
+      PartialFunction.empty,
+      Some(fallback)
+    )
 
   private[client] def tryAdjustResponseType[DesiredRType, RType, M[_]](
       monad: MonadError[M],
@@ -210,4 +314,131 @@ object SttpBackendStub {
         tryAdjustResponseBody(f(meta), b, meta)
     }
   }
+}
+
+/**
+  * Websockets use can differ, for akka backend the crucial part is the handler.
+  * For other backends sttp provides handlers that return [[WebSocket]]
+  * instance to send and receive messages.
+  */
+private[testing] sealed trait WhenOpenWebsocket[F[_], +WS_HANDLER[_]]
+
+private[testing] case class UseHandler[F[_], WS_RESULT, WS_HANDLER[_]](
+    headers: Headers,
+    useHandler: Any => WS_RESULT
+) extends WhenOpenWebsocket[F, WS_HANDLER]
+
+private[testing] case class ReturnWebsocketResponse[F[_], WS_RESULT](headers: Headers, response: () => F[WS_RESULT])
+    extends WhenOpenWebsocket[F, NothingT]
+
+/**
+  * A simple stub for web sockets that uses a queue of events for receive.
+  * New messages can be added to queue when `send` is invoked.
+  * For more complex cases, please provide your own implementation of [[WebSocket]].
+  */
+class WebSocketStub[S](
+    initialResponses: List[Try[Either[WebSocketEvent.Close, WebSocketFrame.Incoming]]],
+    initialState: S,
+    makeNewResponses: (S, WebSocketFrame) => (S, List[Try[Either[WebSocketEvent.Close, WebSocketFrame.Incoming]]])
+) {
+
+  /** Returns a stub that has the same initial messages but replaces the function that adds messages to receive when `sent` is called. */
+  def thenRespond(addReceived: WebSocketFrame => List[WebSocketFrame.Incoming]): WebSocketStub[Unit] =
+    thenRespondWith(
+      addReceived.andThen(_.map(m => Success(Right(m): Either[WebSocketEvent.Close, WebSocketFrame.Incoming])))
+    )
+
+  /** More powerful version of [[thenRespond()]]. Allows to use function that calls WebSocket to close or fails. */
+  def thenRespondWith(
+      addReceived: WebSocketFrame => List[Try[Either[WebSocketEvent.Close, WebSocketFrame.Incoming]]]
+  ): WebSocketStub[Unit] =
+    new WebSocketStub(
+      initialResponses,
+      (),
+      (_, frame) => ((), addReceived(frame))
+    )
+
+  /** Allows to implement simple stateful logic for adding messages when `sent` is invoked. */
+  def thenRespondS[S2](initial: S2)(
+      onSend: (S2, WebSocketFrame) => (S2, List[WebSocketFrame.Incoming])
+  ): WebSocketStub[S2] =
+    thenRespondWithS(initial)((state, frame) => {
+      val (newState, messages) = onSend(state, frame)
+      (newState, messages.map(m => Success(Right(m): Either[WebSocketEvent.Close, WebSocketFrame.Incoming])))
+    })
+
+  /** Allows to implement simple stateful logic for adding messages when `sent` is invoked
+    * with the possibility of signalling WebSocket closed or failure. */
+  def thenRespondWithS[S2](initial: S2)(
+      onSend: (S2, WebSocketFrame) => (S2, List[Try[Either[WebSocketEvent.Close, WebSocketFrame.Incoming]]])
+  ): WebSocketStub[S2] = new WebSocketStub(initialResponses, initial, onSend)
+
+  private[testing] def build[F[_]](implicit m: MonadError[F]): WebSocket[F] =
+    new WebSocket[F] {
+
+      private var state: S = initialState
+      private var _isOpen: Boolean = true
+      private var responses = initialResponses.toList
+
+      override def monad = m
+      override def isOpen: F[Boolean] = monad.unit(_isOpen)
+
+      override def receive: F[Either[WebSocketEvent.Close, WebSocketFrame.Incoming]] =
+        synchronized {
+          if (_isOpen) {
+            responses.headOption match {
+              case Some(Success(Right(response))) =>
+                responses = responses.tail
+                monad.unit(Right(response))
+              case Some(Success(Left(close))) =>
+                _isOpen = false
+                monad.unit(Left(close))
+              case Some(Failure(e)) =>
+                _isOpen = false
+                monad.error(e)
+              case None =>
+                monad.error(new Exception("Unexpected 'receive', no more prepared responses."))
+            }
+          } else {
+            monad.error(new Exception("WebSocket is closed."))
+          }
+        }
+
+      override def send(frame: WebSocketFrame, isContinuation: Boolean): F[Unit] =
+        monad.flatten(monad.eval {
+          synchronized {
+            if (_isOpen) {
+              val (newState, newResponses) = makeNewResponses(state, frame)
+              responses = responses ++ newResponses
+              state = newState
+              monad.unit(())
+            } else {
+              monad.error(new Exception("WebSocket is closed."))
+            }
+          }
+        })
+    }
+}
+
+object WebSocketStub {
+
+  /** Creates a stub that has given responses prepared for 'receive' and doesn't add messages on 'send'. */
+  def withInitialResponses(
+      events: List[Try[Either[WebSocketEvent.Close, WebSocketFrame.Incoming]]]
+  ): WebSocketStub[Unit] = {
+    new WebSocketStub(events, (), (_, _) => ((), List.empty))
+  }
+
+  /** Creates a stub that has given incoming frames prepared for 'receive' and doesn't add messages on 'send'.
+    * There is a more powerful version [[withInitialResponses()]] that takes a list of effects to return.
+    */
+  def withInitialIncoming(
+      messages: List[WebSocketFrame.Incoming]
+  ): WebSocketStub[Unit] = {
+    withInitialResponses(messages.map(m => Success(Right(m): Either[WebSocketEvent.Close, WebSocketFrame.Incoming])))
+  }
+
+  /** Creates a stub without any messages prepared for 'receive'. */
+  def withNoInitialResponses: WebSocketStub[Unit] = withInitialResponses(List.empty)
+
 }

--- a/core/src/main/scalajs/sttp/client/FetchBackend.scala
+++ b/core/src/main/scalajs/sttp/client/FetchBackend.scala
@@ -44,6 +44,6 @@ object FetchBackend {
     *
     * See [[SttpBackendStub]] for details on how to configure stub responses.
     */
-  def stub(implicit ec: ExecutionContext = ExecutionContext.global): SttpBackendStub[Future, Nothing] =
+  def stub(implicit ec: ExecutionContext = ExecutionContext.global): SttpBackendStub[Future, Nothing, NothingT] =
     SttpBackendStub(new FutureMonad())
 }

--- a/core/src/main/scalajvm/sttp/client/HttpURLConnectionBackend.scala
+++ b/core/src/main/scalajvm/sttp/client/HttpURLConnectionBackend.scala
@@ -308,5 +308,5 @@ object HttpURLConnectionBackend {
     *
     * See [[SttpBackendStub]] for details on how to configure stub responses.
     */
-  def stub: SttpBackendStub[Identity, Nothing] = SttpBackendStub.synchronous
+  def stub: SttpBackendStub[Identity, Nothing, NothingT] = SttpBackendStub.synchronous
 }

--- a/docs/websockets.md
+++ b/docs/websockets.md
@@ -26,7 +26,7 @@ The type of the handler is determined by the third type parameter of `SttpBacken
 The following backends support streaming websockets:
 
 * [Akka](../backends/akka.html#websockets)
-* [fs2](../backends/fs2.html#streaming-websockets)
+* [fs2](../backends/fs2.html#websockets)
 
 ## Using the high-level websocket interface
 

--- a/finagle-backend/src/main/scala/sttp/client/finagle/FinagleBackend.scala
+++ b/finagle-backend/src/main/scala/sttp/client/finagle/FinagleBackend.scala
@@ -7,7 +7,6 @@ import com.twitter.util.{Future => TFuture}
 import sttp.client.monad.MonadError
 import sttp.client.ws.WebSocketResponse
 import com.twitter.finagle.http.{FileElement, FormElement, RequestBuilder, SimpleElement, Method => FMethod, Response => FResponse}
-import com.twitter.finagle.loadbalancer.Balancers
 import com.twitter.io.Buf
 import com.twitter.io.Buf.{ByteArray, ByteBuffer}
 import com.twitter.util
@@ -208,5 +207,5 @@ object FinagleBackend {
     *
     * See [[SttpBackendStub]] for details on how to configure stub responses.
     */
-  def stub: SttpBackendStub[TFuture, Nothing] = SttpBackendStub(TFutureMonadError)
+  def stub: SttpBackendStub[TFuture, Nothing, NothingT] = SttpBackendStub(TFutureMonadError)
 }

--- a/http4s-backend/src/main/scala/sttp/client/http4s/Http4sBackend.scala
+++ b/http4s-backend/src/main/scala/sttp/client/http4s/Http4sBackend.scala
@@ -279,5 +279,5 @@ object Http4sBackend {
     *
     * See [[SttpBackendStub]] for details on how to configure stub responses.
     */
-  def stub[F[_]: Concurrent]: SttpBackendStub[F, Stream[F, Byte]] = SttpBackendStub(new CatsMonadAsyncError)
+  def stub[F[_]: Concurrent]: SttpBackendStub[F, Stream[F, Byte], NothingT] = SttpBackendStub(new CatsMonadAsyncError)
 }

--- a/httpclient-backend/fs2/src/main/scala/sttp/client/httpclient/fs2/HttpClientFs2Backend.scala
+++ b/httpclient-backend/fs2/src/main/scala/sttp/client/httpclient/fs2/HttpClientFs2Backend.scala
@@ -104,5 +104,5 @@ object HttpClientFs2Backend {
     *
     * See [[SttpBackendStub]] for details on how to configure stub responses.
     */
-  def stub[F[_]: Concurrent]: SttpBackendStub[F, Stream[F, Byte]] = SttpBackendStub(implicitly)
+  def stub[F[_]: Concurrent]: SttpBackendStub[F, Stream[F, Byte], WebSocketHandler] = SttpBackendStub(implicitly)
 }

--- a/httpclient-backend/monix/src/main/scala/sttp/client/httpclient/monix/HttpClientMonixBackend.scala
+++ b/httpclient-backend/monix/src/main/scala/sttp/client/httpclient/monix/HttpClientMonixBackend.scala
@@ -95,5 +95,5 @@ object HttpClientMonixBackend {
     *
     * See [[SttpBackendStub]] for details on how to configure stub responses.
     */
-  def stub: SttpBackendStub[Task, Observable[ByteBuffer]] = SttpBackendStub(TaskMonadAsyncError)
+  def stub: SttpBackendStub[Task, Observable[ByteBuffer], WebSocketHandler] = SttpBackendStub(TaskMonadAsyncError)
 }

--- a/httpclient-backend/src/main/scala/sttp/client/httpclient/HttpClientAsyncBackend.scala
+++ b/httpclient-backend/src/main/scala/sttp/client/httpclient/HttpClientAsyncBackend.scala
@@ -135,6 +135,6 @@ object HttpClientFutureBackend {
     *
     * See [[SttpBackendStub]] for details on how to configure stub responses.
     */
-  def stub(implicit ec: ExecutionContext = ExecutionContext.global): SttpBackendStub[Future, Nothing] =
+  def stub(implicit ec: ExecutionContext = ExecutionContext.global): SttpBackendStub[Future, Nothing, WebSocketHandler] =
     SttpBackendStub(new FutureMonad())
 }

--- a/httpclient-backend/src/main/scala/sttp/client/httpclient/HttpClientSyncBackend.scala
+++ b/httpclient-backend/src/main/scala/sttp/client/httpclient/HttpClientSyncBackend.scala
@@ -95,5 +95,5 @@ object HttpClientSyncBackend {
     *
     * See [[SttpBackendStub]] for details on how to configure stub responses.
     */
-  def stub: SttpBackendStub[Identity, Nothing] = SttpBackendStub.synchronous
+  def stub: SttpBackendStub[Identity, Nothing, WebSocketHandler] = SttpBackendStub.synchronous
 }

--- a/implementations/monix/src/main/scalajs/sttp/client/impl/monix/FetchMonixBackend.scala
+++ b/implementations/monix/src/main/scalajs/sttp/client/impl/monix/FetchMonixBackend.scala
@@ -77,5 +77,5 @@ object FetchMonixBackend {
     *
     * See [[SttpBackendStub]] for details on how to configure stub responses.
     */
-  def stub: SttpBackendStub[Task, Observable[ByteBuffer]] = SttpBackendStub(TaskMonadAsyncError)
+  def stub: SttpBackendStub[Task, Observable[ByteBuffer], NothingT] = SttpBackendStub(TaskMonadAsyncError)
 }

--- a/okhttp-backend/monix/src/main/scala/sttp/client/okhttp/monix/OkHttpMonixBackend.scala
+++ b/okhttp-backend/monix/src/main/scala/sttp/client/okhttp/monix/OkHttpMonixBackend.scala
@@ -125,5 +125,5 @@ object OkHttpMonixBackend {
     *
     * See [[SttpBackendStub]] for details on how to configure stub responses.
     */
-  def stub: SttpBackendStub[Task, Observable[ByteBuffer]] = SttpBackendStub(TaskMonadAsyncError)
+  def stub: SttpBackendStub[Task, Observable[ByteBuffer], WebSocketHandler] = SttpBackendStub(TaskMonadAsyncError)
 }

--- a/okhttp-backend/src/main/scala/sttp/client/okhttp/OkHttpBackend.scala
+++ b/okhttp-backend/src/main/scala/sttp/client/okhttp/OkHttpBackend.scala
@@ -308,7 +308,7 @@ object OkHttpSyncBackend {
     *
     * See [[SttpBackendStub]] for details on how to configure stub responses.
     */
-  def stub: SttpBackendStub[Identity, Nothing] = SttpBackendStub.synchronous
+  def stub: SttpBackendStub[Identity, Nothing, WebSocketHandler] = SttpBackendStub.synchronous
 }
 
 abstract class OkHttpAsyncBackend[F[_], S](
@@ -416,7 +416,7 @@ object OkHttpFutureBackend {
     *
     * See [[SttpBackendStub]] for details on how to configure stub responses.
     */
-  def stub(implicit ec: ExecutionContext = ExecutionContext.global): SttpBackendStub[Future, Nothing] =
+  def stub(implicit ec: ExecutionContext = ExecutionContext.global): SttpBackendStub[Future, Nothing, WebSocketHandler] =
     SttpBackendStub(new FutureMonad())
 }
 


### PR DESCRIPTION
Proposal for API (and implementation) of adding web socket support.

I don't really like combination of mutable and immutable in WebSocketStub.

Also there are two methods of stubbing `openWebsocket`, one meant for cases when supplied  `WebSocketHandler`s are used and return `WebSocket` and the other one where user specifies his handler - basically Akka.
