### PR TITLE
Make OkHttpBackend compatible with Java 8 again

### DIFF
--- a/okhttp-backend/src/main/scala/sttp/client/okhttp/OkHttpBackend.scala
+++ b/okhttp-backend/src/main/scala/sttp/client/okhttp/OkHttpBackend.scala
@@ -155,7 +155,7 @@ abstract class OkHttpBackend[F[_], S](
           case IgnoreResponse =>
             Try(responseBody.close())
           case ResponseAsByteArray =>
-            val body = Try(responseBody.readAllBytes())
+            val body = Try(Stream.continually(responseBody.read()).takeWhile(_ != -1).map(_.toByte).toArray)
             responseBody.close()
             body
           case ras @ ResponseAsStream() =>


### PR DESCRIPTION
With the rewrite for using an InputStream the OkHttp backend used the `InputStream.readAllBytes()` which doesn't exist in Java 8.

Unfortunately for many users, Java 8 is still the norm, so this should make the library compatible with them again.