### PR TITLE
Add support for typed http errors

### DIFF
--- a/core/src/main/scala/sttp/client/ResponseAs.scala
+++ b/core/src/main/scala/sttp/client/ResponseAs.scala
@@ -122,7 +122,7 @@ object ResponseAs {
     */
   def deserializeRightWithError[E: ShowError, T](
       doDeserialize: String => Either[E, T]
-  ): (Either[String, String], ResponseMetadata) => Either[ResponseError[E], T] = {
+  ): (Either[String, String], ResponseMetadata) => Either[ResponseErrorTyped[String, E], T] = {
     case (Left(s), meta) => Left(HttpError(s, meta.code))
     case (Right(s), _)   => deserializeWithError(doDeserialize)(implicitly[ShowError[E]])(s)
   }
@@ -162,11 +162,11 @@ object ResponseAs {
     }
 }
 
-sealed abstract class ResponseError[+T](error: String) extends Exception(error)
-case class HttpError(body: String, statusCode: StatusCode)
-    extends ResponseError[Nothing](s"statusCode: $statusCode, response: $body")
-case class DeserializationError[T: ShowError](body: String, error: T)
-    extends ResponseError[T](implicitly[ShowError[T]].show(error))
+sealed abstract class ResponseErrorTyped[+HE, +DE](error: String) extends Exception(error)
+case class HttpError[HE](body: HE, statusCode: StatusCode)
+    extends ResponseErrorTyped[HE, Nothing](s"statusCode: $statusCode, response: $body")
+case class DeserializationError[DE: ShowError](body: String, error: DE)
+    extends ResponseErrorTyped[Nothing, DE](implicitly[ShowError[DE]].show(error))
 
 trait ShowError[-T] {
   def show(t: T): String

--- a/core/src/main/scala/sttp/client/SttpApi.scala
+++ b/core/src/main/scala/sttp/client/SttpApi.scala
@@ -263,7 +263,7 @@ trait SttpApi extends SttpExtensions with UriInterpolator {
       } else {
         onError.map {
           case Left(a)  => Left(a)
-          case Right(b) => Left(HttpError(b))
+          case Right(b) => Left(HttpError(b, meta.code))
         }
       }
     }

--- a/core/src/main/scala/sttp/client/SttpApi.scala
+++ b/core/src/main/scala/sttp/client/SttpApi.scala
@@ -244,4 +244,56 @@ trait SttpApi extends SttpExtensions with UriInterpolator {
     */
   def multipart[B: BodySerializer](name: String, b: B): Part[BasicRequestBody] =
     Part(name, implicitly[BodySerializer[B]].apply(b), contentType = Some(MediaType.ApplicationXWwwFormUrlencoded))
+
+  /**
+    * Allows to provide different mappings for success and error responses
+    * @param onError transformation which will be applied if the response is unsuccessful (non 2xx)
+    * @param onSuccess transformation which will be applied if the response is successful (2xx)
+    * @tparam DE underlying type of deserialization failure
+    * @tparam HE type which represents known error cases
+    * @tparam T type of the successful response
+    */
+  def either[DE, HE, T](
+      onError: ResponseAs[Either[DeserializationError[DE], HE], Nothing],
+      onSuccess: ResponseAs[Either[DeserializationError[DE], T], Nothing]
+  ): ResponseAs[Either[ResponseErrorTyped[HE, DE], T], Nothing] = {
+    fromMetadata { meta =>
+      if (meta.isSuccess) {
+        onSuccess
+      } else {
+        onError.map {
+          case Left(a)  => Left(a)
+          case Right(b) => Left(HttpError(b))
+        }
+      }
+    }
+  }
+
+  def fromStatusCode[DE, T](
+      mapping: StatusCode => ResponseAs[Either[DeserializationError[DE], T], Nothing]
+  ): ResponseAs[Either[DeserializationError[DE], T], Nothing] = {
+    fromMetadata { meta =>
+      mapping(meta.code)
+    }
+  }
+
+  /**
+    * Same as #either but throws deserialization error if either success or error deserialization fails
+    * @param onSuccess transformation which will be applied if the response is successful (2xx)
+    * @param onError transformation which will be applied if the response is unsuccessful (non 2xx)
+    * @tparam E type which represents known error cases
+    * @tparam T type of the successful response
+    * @return
+    */
+  def eitherUnsafe[E, T](
+      onSuccess: ResponseAs[T, Nothing]
+  )(onError: ResponseAs[E, Nothing]): ResponseAs[Either[E, T], Nothing] = {
+    fromMetadata { meta =>
+      if (meta.isSuccess) {
+        onSuccess.map(Right(_))
+      } else {
+        onError.map(Left(_))
+      }
+    }
+  }
 }

--- a/core/src/main/scala/sttp/client/package.scala
+++ b/core/src/main/scala/sttp/client/package.scala
@@ -14,6 +14,8 @@ package object client extends SttpApi {
     */
   type Request[T, -R] = RequestT[Identity, T, R]
 
+  type ResponseError[DE] = ResponseErrorTyped[String, DE]
+
   /**
     * Provide an implicit value of this type to serialize arbitrary classes into a request body.
     * Backends might also provide special logic for serializer instances which they define (e.g. to handle streaming).

--- a/docs/responses/body.md
+++ b/docs/responses/body.md
@@ -107,7 +107,7 @@ basicRequest
 
 A number of JSON libraries are supported out-of-the-box, see [json support](../json.md).
 
-Sometimes it might be useful to model some http error responses right away. We can do that by using `either` combine with `fromStatusCodes`:
+Sometimes it might be useful to model some http error responses right away. We can do that by using `either` combined with `fromStatusCodes`:
 ```scala mdoc:compile-only
 import sttp.client._
 import sttp.model._

--- a/docs/responses/body.md
+++ b/docs/responses/body.md
@@ -107,6 +107,31 @@ basicRequest
 
 A number of JSON libraries are supported out-of-the-box, see [json support](../json.md).
 
+Sometimes it might be useful to model some http error responses right away. We can do that by using `either` combine with `fromStatusCodes`:
+```scala mdoc:compile-only
+import sttp.client._
+import sttp.model._
+import sttp.client.circe._
+import io.circe._
+import io.circe.generic.auto._
+
+case class MyModel(p1: Int)
+sealed trait MyErrorModel
+case class Conflict(message: String) extends MyErrorModel
+case class BadRequest(message: String) extends MyErrorModel
+case class GenericError(message: String) extends MyErrorModel
+
+basicRequest
+  .get(uri"https://example.com")
+  .response(either(fromStatusCode{
+    case StatusCode.Conflict => asJsonAlways[Conflict]
+    case StatusCode.BadRequest => asJsonAlways[BadRequest]
+    case _ => asStringAlways.map(s=>Right(GenericError(s)))
+  }, asJsonAlways[MyModel]))
+```
+
+There is also an unsafe variant of above method (`eitherUnsafe`) which in case of deserialization error or any unspecified http error throws related exception.
+
 Using the `fromMetadata` combinator, it's possible to dynamically specify how the response should be deserialized, basing on the response status code and response headers. The default `asString`, `asByteArray` response descriptions use this method to return a `Left` in case of non-2xx responses, and a `Right` otherwise. 
 
 A more complex case, which uses Circe for deserializing JSON, choosing to which model to deserialize to depending on the status code, can look as following:
@@ -116,13 +141,11 @@ import sttp.client._
 import sttp.model._
 import sttp.client.circe._
 import io.circe._
-import io.circe.generic.semiauto._
+import io.circe.generic.auto._
 
 sealed trait MyModel
 case class SuccessModel(name: String, age: Int) extends MyModel
 case class ErrorModel(message: String) extends MyModel
-implicit val successModelDecoder: Decoder[SuccessModel] = deriveDecoder[SuccessModel]
-implicit val errorModelDecoder: Decoder[ErrorModel] = deriveDecoder[ErrorModel]
 
 val myRequest: Request[Either[ResponseError[io.circe.Error], MyModel], Nothing] =
   basicRequest

--- a/generated-docs/out/responses/body.md
+++ b/generated-docs/out/responses/body.md
@@ -107,6 +107,24 @@ basicRequest
 
 A number of JSON libraries are supported out-of-the-box, see [json support](../json.md).
 
+Sometimes it might be useful to model some http error responses right away. We can do that using `asTypedErrors` method:
+```scala
+case class SuccessModel(...)
+sealed trait MyErrorModel
+case class Conflict(...) extends MyErrorModel
+case class ServerError(...) extends MyErrorModel
+
+val myRequest: Request[Either[ResponseErrorTyped[MyErrorModel, io.circe.Error], MyModel], Nothing] =
+  basicRequest
+    .get(uri"https://example.com")
+    .response(asTypedError(asJsonAlways[SuccessModel]){
+      case StatusCode.Conflict => asJsonAlways[Conflict]
+      case StatusCode.ServerError => asJsonAlways[ServerError]
+    })
+```
+
+There is also an unsafe variant of above method which in case of deserialization error or any unspecified http error throws related exception.
+
 Using the `fromMetadata` combinator, it's possible to dynamically specify how the response should be deserialized, basing on the response status code and response headers. The default `asString`, `asByteArray` response descriptions use this method to return a `Left` in case of non-2xx responses, and a `Right` otherwise. 
 
 A more complex case, which uses Circe for deserializing JSON, choosing to which model to deserialize to depending on the status code, can look as following:

--- a/generated-docs/out/responses/body.md
+++ b/generated-docs/out/responses/body.md
@@ -107,24 +107,6 @@ basicRequest
 
 A number of JSON libraries are supported out-of-the-box, see [json support](../json.md).
 
-Sometimes it might be useful to model some http error responses right away. We can do that using `asTypedErrors` method:
-```scala
-case class SuccessModel(...)
-sealed trait MyErrorModel
-case class Conflict(...) extends MyErrorModel
-case class ServerError(...) extends MyErrorModel
-
-val myRequest: Request[Either[ResponseErrorTyped[MyErrorModel, io.circe.Error], MyModel], Nothing] =
-  basicRequest
-    .get(uri"https://example.com")
-    .response(asTypedError(asJsonAlways[SuccessModel]){
-      case StatusCode.Conflict => asJsonAlways[Conflict]
-      case StatusCode.ServerError => asJsonAlways[ServerError]
-    })
-```
-
-There is also an unsafe variant of above method which in case of deserialization error or any unspecified http error throws related exception.
-
 Using the `fromMetadata` combinator, it's possible to dynamically specify how the response should be deserialized, basing on the response status code and response headers. The default `asString`, `asByteArray` response descriptions use this method to return a `Left` in case of non-2xx responses, and a `Right` otherwise. 
 
 A more complex case, which uses Circe for deserializing JSON, choosing to which model to deserialize to depending on the status code, can look as following:

--- a/json/circe/src/main/scala/sttp/client/circe/SttpCirceApi.scala
+++ b/json/circe/src/main/scala/sttp/client/circe/SttpCirceApi.scala
@@ -1,9 +1,9 @@
 package sttp.client.circe
 
+import sttp.client._
 import io.circe.parser.decode
 import io.circe.{Decoder, Encoder, Printer}
 import sttp.client.internal.Utf8
-import sttp.client.{IsOption, ResponseAs, ResponseError, _}
 import sttp.model.MediaType
 
 trait SttpCirceApi {

--- a/json/json4s/src/main/scala/sttp/client/json4s/SttpJson4sApi.scala
+++ b/json/json4s/src/main/scala/sttp/client/json4s/SttpJson4sApi.scala
@@ -1,10 +1,9 @@
 package sttp.client.json4s
 
-import sttp.client._
-import sttp.client.internal.Utf8
 import org.json4s.{Formats, Serialization}
+import sttp.client.{ResponseAs, _}
+import sttp.client.internal.Utf8
 import sttp.model._
-import sttp.client.{ResponseAs, ResponseError}
 
 trait SttpJson4sApi {
   implicit def json4sBodySerializer[B <: AnyRef](implicit

--- a/json/play-json/src/main/scala/sttp/client/playJson/SttpPlayJsonApi.scala
+++ b/json/play-json/src/main/scala/sttp/client/playJson/SttpPlayJsonApi.scala
@@ -1,10 +1,8 @@
 package sttp.client.playJson
 
-import sttp.client._
-import sttp.model._
-import sttp.client.internal.Utf8
 import play.api.libs.json.{JsError, Json, Reads, Writes}
-import sttp.client.{IsOption, JsonInput, ResponseAs, ResponseError}
+import sttp.client.internal.Utf8
+import sttp.client.{IsOption, JsonInput, ResponseAs, _}
 import sttp.model.MediaType
 
 import scala.util.{Failure, Success, Try}

--- a/json/spray-json/src/main/scala/sttp/client/sprayJson/SttpSprayJsonApi.scala
+++ b/json/spray-json/src/main/scala/sttp/client/sprayJson/SttpSprayJsonApi.scala
@@ -1,10 +1,9 @@
 package sttp.client.sprayJson
 
-import sttp.client._
-import sttp.client.internal.Utf8
-import sttp.model._
 import spray.json._
-import sttp.client.{IsOption, ResponseAs, ResponseError}
+import sttp.client.internal.Utf8
+import sttp.client.{IsOption, ResponseAs, _}
+import sttp.model._
 
 trait SttpSprayJsonApi {
   implicit def sprayBodySerializer[B: JsonWriter](implicit printer: JsonPrinter = CompactPrinter): BodySerializer[B] =


### PR DESCRIPTION
This relates to #618 

Before submitting pull request:
- [x] Check if the project compiles by running `sbt compile`
- [x] Verify docs compilation by running `sbt compileDocs`
- [x] Check if tests pass by running `sbt test`
- [x] Format code by running `sbt scalafmt`
