### PR TITLE
Let HttpUrlConnectionBackend allow custom encodings

### DIFF
--- a/core/jvm/src/main/scala/sttp/client/HttpURLConnectionBackend.scala
+++ b/core/jvm/src/main/scala/sttp/client/HttpURLConnectionBackend.scala
@@ -278,11 +278,9 @@ class HttpURLConnectionBackend private (
 
   private def wrapInput(contentEncoding: Option[String], is: InputStream): InputStream =
     contentEncoding.map(_.toLowerCase) match {
-      case None            => is
       case Some("gzip")    => new GZIPInputStream(is)
       case Some("deflate") => new InflaterInputStream(is)
-      case Some(ce) =>
-        throw new UnsupportedEncodingException(s"Unsupported encoding: $ce")
+      case _ =>               is
     }
 
   private def adjustExceptions[T](t: => T): T =

--- a/core/jvm/src/main/scala/sttp/client/HttpURLConnectionBackend.scala
+++ b/core/jvm/src/main/scala/sttp/client/HttpURLConnectionBackend.scala
@@ -280,7 +280,7 @@ class HttpURLConnectionBackend private (
     contentEncoding.map(_.toLowerCase) match {
       case Some("gzip")    => new GZIPInputStream(is)
       case Some("deflate") => new InflaterInputStream(is)
-      case _ =>               is
+      case _               => is
     }
 
   private def adjustExceptions[T](t: => T): T =


### PR DESCRIPTION
During checking backends for supporting custom encodings found out that we have special logic in `HttpUrlConnectionBackend` which prevents passing custom encoded bodies back to the client.

For consistency with other backends (every of them just let unsupported encoding pass through) here is the fix for `HttpUrlConnectionBackend`

------

Before submitting pull request:
- [ ] Check if the project compiles by running `sbt compile`
- [ ] Verify docs compilation by running `sbt compileDocs`
- [ ] Check if tests pass by running `sbt test`
- [ ] Format code by running `sbt scalafmt`
