### PR TITLE
Let HttpUrlConnectionBackend allow custom encodings

### DIFF
--- a/core/src/main/scala/sttp/client/internal/ToCurlConverter.scala
+++ b/core/src/main/scala/sttp/client/internal/ToCurlConverter.scala
@@ -21,7 +21,7 @@ class ToCurlConverter[R <: RequestT[Identity, _, _]] {
 
   private def extractHeaders(r: R): String = {
     r.headers
-    // filtering out compression headers so that the results are human-readable, if possible
+      // filtering out compression headers so that the results are human-readable, if possible
       .filterNot(_.name.equalsIgnoreCase(HeaderNames.AcceptEncoding))
       .collect {
         case Header(k, v) => s"""-H '$k: $v'"""

--- a/core/src/main/scalajvm/sttp/client/HttpURLConnectionBackend.scala
+++ b/core/src/main/scalajvm/sttp/client/HttpURLConnectionBackend.scala
@@ -285,8 +285,7 @@ class HttpURLConnectionBackend private (
       case None            => is
       case Some("gzip")    => new GZIPInputStream(is)
       case Some("deflate") => new InflaterInputStream(is)
-      case Some(ce) =>
-        throw new UnsupportedEncodingException(s"Unsupported encoding: $ce")
+      case _               => is
     }
 
   private def adjustExceptions[T](t: => T): T =

--- a/core/src/main/scalajvm/sttp/client/TryHttpURLConnectionBackend.scala
+++ b/core/src/main/scalajvm/sttp/client/TryHttpURLConnectionBackend.scala
@@ -1,13 +1,20 @@
 package sttp.client
 
-import java.net.HttpURLConnection
+import java.net.{HttpURLConnection, URL, URLConnection}
+
+import sttp.client.HttpURLConnectionBackend.{EncodingHandler, defaultOpenConnection}
 
 import scala.util.Try
 
 object TryHttpURLConnectionBackend {
   def apply(
       options: SttpBackendOptions = SttpBackendOptions.Default,
-      customizeConnection: HttpURLConnection => Unit = _ => ()
+      customizeConnection: HttpURLConnection => Unit = _ => (),
+      createURL: String => URL = new URL(_),
+      openConnection: (URL, Option[java.net.Proxy]) => URLConnection = defaultOpenConnection,
+      customEncodingHandler: EncodingHandler = PartialFunction.empty
   ): SttpBackend[Try, Nothing, NothingT] =
-    new TryBackend[Nothing, NothingT](HttpURLConnectionBackend(options, customizeConnection))
+    new TryBackend[Nothing, NothingT](
+      HttpURLConnectionBackend(options, customizeConnection, createURL, openConnection, customEncodingHandler)
+    )
 }

--- a/core/src/test/scala/sttp/client/testing/HttpTest.scala
+++ b/core/src/test/scala/sttp/client/testing/HttpTest.scala
@@ -34,12 +34,15 @@ trait HttpTest[F[_]]
   protected val testBody = "this is the body"
   protected val testBodyBytes: Array[Byte] = testBody.getBytes("UTF-8")
   protected val expectedPostEchoResponse = "POST /echo this is the body"
+  protected val customEncoding = "custom"
+  protected val customEncodedData = "custom-data"
 
   protected val sttpIgnore: ResponseAs[Unit, Nothing] = sttp.client.ignore
 
   protected def supportsRequestTimeout = true
   protected def supportsSttpExceptions = true
   protected def supportsCustomMultipartContentType = true
+  protected def supportsCustomContentEncoding = false
   protected def throwsExceptionOnUnsupportedEncoding = true
 
   "parse response" - {
@@ -284,6 +287,13 @@ trait HttpTest[F[_]]
     "not attempt to decompress HEAD requests" in {
       val req = basicRequest.head(uri"$endpoint/compress")
       req.send().toFuture().map { resp => resp.code shouldBe StatusCode.Ok }
+    }
+
+    if (supportsCustomContentEncoding) {
+      "decompress using custom content encoding" in {
+        val req = basicRequest.get(uri"$endpoint/compress-custom").acceptEncoding(customEncoding).response(asStringAlways)
+        req.send().toFuture().map { resp => resp.body should be(customEncodedData) }
+      }
     }
 
     if (supportsSttpExceptions && throwsExceptionOnUnsupportedEncoding) {

--- a/core/src/test/scalajvm/sttp/client/HttpURLConnectionBackendHttpTest.scala
+++ b/core/src/test/scalajvm/sttp/client/HttpURLConnectionBackendHttpTest.scala
@@ -1,9 +1,15 @@
 package sttp.client
 
+import java.io.ByteArrayInputStream
+
 import sttp.client.testing.{ConvertToFuture, HttpTest}
 
 class HttpURLConnectionBackendHttpTest extends HttpTest[Identity] {
+  override implicit val backend: SttpBackend[Identity, Nothing, NothingT] = HttpURLConnectionBackend(
+    customEncodingHandler = { case (stream, "custom") => new ByteArrayInputStream(customEncodedData.getBytes()) }
+  )
 
-  override implicit val backend: SttpBackend[Identity, Nothing, NothingT] = HttpURLConnectionBackend()
   override implicit val convertToFuture: ConvertToFuture[Identity] = ConvertToFuture.id
+
+  override def supportsCustomContentEncoding = true
 }

--- a/testing/server/src/main/scala/sttp/client/testing/server/HttpServer.scala
+++ b/testing/server/src/main/scala/sttp/client/testing/server/HttpServer.scala
@@ -2,10 +2,9 @@ package sttp.client.testing.server
 
 import java.io.{ByteArrayOutputStream, InputStream, OutputStream}
 
-import akka.Done
 import akka.actor.ActorSystem
 import akka.http.scaladsl.Http
-import akka.http.scaladsl.coding.{Deflate, Gzip, NoCoding}
+import akka.http.scaladsl.coding._
 import akka.http.scaladsl.model._
 import akka.http.scaladsl.model.headers.CacheDirectives._
 import akka.http.scaladsl.model.headers._
@@ -15,8 +14,9 @@ import akka.http.scaladsl.server.directives.Credentials
 import akka.http.scaladsl.server.directives.RouteDirectives.complete
 import akka.http.scaladsl.server.{RejectionHandler, Route}
 import akka.stream.ActorMaterializer
-import akka.stream.scaladsl.{Flow, Keep, Sink, Source}
+import akka.stream.scaladsl.{Flow, Sink, Source}
 import akka.util.ByteString
+import akka.{Done, NotUsed}
 import ch.megard.akka.http.cors.scaladsl.CorsDirectives
 import ch.megard.akka.http.cors.scaladsl.settings.CorsSettings
 
@@ -220,6 +220,10 @@ private class HttpServer(port: Int, info: String => Unit) extends AutoCloseable 
       }
     } ~ path("compress-unsupported") {
       respondWithHeader(`Content-Encoding`(HttpEncoding("secret-encoding"))) {
+        complete("I'm compressed!")
+      }
+    } ~ path("compress-custom") {
+      respondWithHeader(`Content-Encoding`(HttpEncoding("custom"))) {
         complete("I'm compressed!")
       }
     } ~ path("compress") {

--- a/testing/server/src/main/scala/sttp/client/testing/server/HttpServer.scala
+++ b/testing/server/src/main/scala/sttp/client/testing/server/HttpServer.scala
@@ -224,7 +224,7 @@ private class HttpServer(port: Int, info: String => Unit) extends AutoCloseable 
       }
     } ~ path("compress-custom") {
       respondWithHeader(`Content-Encoding`(HttpEncoding("custom"))) {
-        complete("I'm compressed!")
+        complete("I'm compressed, but who cares! Must be overwritten by client encoder")
       }
     } ~ path("compress") {
       encodeResponseWith(Gzip, Deflate, NoCoding) {


### PR DESCRIPTION
During checking backends for supporting custom encodings found out that we have special logic in HttpUrlConnectionBackend which prevents passing custom encoded bodies back to the client.

For consistency with other backends (every of them just let unsupported encoding pass through) here is the fix for HttpUrlConnectionBackend

-----

Before submitting pull request:
- [ ] Check if the project compiles by running `sbt compile`
- [ ] Verify docs compilation by running `sbt compileDocs`
- [ ] Check if tests pass by running `sbt test`
- [ ] Format code by running `sbt scalafmt`
