### PR TITLE
Add a ZIO-style Service type for idiomaticity points

### DIFF
--- a/httpclient-backend/zio/src/main/scala/sttp/client/httpclient/zio/package.scala
+++ b/httpclient-backend/zio/src/main/scala/sttp/client/httpclient/zio/package.scala
@@ -13,9 +13,11 @@ package object zio {
   /**
     * ZIO-environment service definition, which is an SttpBackend.
     */
-  type SttpClient = Has[SttpBackend[BlockingTask, ZStream[Blocking, Throwable, Byte], WebSocketHandler]]
+  type SttpClient = Has[SttpClient.Service]
 
   object SttpClient {
+    
+    type Service = SttpBackend[BlockingTask, ZStream[Blocking, Throwable, Byte], WebSocketHandler]
 
     /**
       * Sends the request. Only requests for which the method & URI are specified can be sent.


### PR DESCRIPTION
There's usually (when adhering to the ZIO module pattern) a `Service` trait which defines interface (`send` and `openWebsocket` here).
In lieu of that refactoring, it could be nice to expose a `Service` type alias such that it could be idiomatically accessed when relying upon SttpClient in ones own ZLayers.

Then it would be trivial to refactor from 
```scala
  def live(token: String): ZLayer[Console with SttpClient, Nothing, SlackClient] =
    ZLayer
      .fromServices[Console.Service, SttpBackend[Task, Stream[Throwable, Byte], WebSocketHandler], SlackClient.Service](
        (console: Console.Service, sttp: SttpBackend[Task, Stream[Throwable, Byte], WebSocketHandler]) =>
          LiveSlackClient(console, sttp, token)
      )
```
to
```scala
  def live(token: String): ZLayer[Console with SttpClient, Nothing, SlackClient] =
    ZLayer
      .fromServices[Console.Service, SttpClient.Service, SlackClient.Service](
        (console: Console.Service, sttp: SttpClient.Service) =>
          LiveSlackClient(console, sttp, token)
      )
```

Ahh, much better ;)


I'd also be happy to fully refactor this to use the `trait Service` pattern if that's something you'd be into, my dear sttp-eople.

Take care and thx for all the lovely software!