### PR TITLE
Fix handling of utf-8 responses in scala-native

### DIFF
--- a/core/src/main/scalanative/sttp/client/AbstractCurlBackend.scala
+++ b/core/src/main/scalanative/sttp/client/AbstractCurlBackend.scala
@@ -213,7 +213,7 @@ abstract class AbstractCurlBackend[F[_], S](monad: MonadError[F], verbose: Boole
       }
   }
 
-  private def toByteArray(str: String): F[Array[Byte]] = responseMonad.unit(str.toCharArray.map(_.toByte))
+  private def toByteArray(str: String): F[Array[Byte]] = responseMonad.unit(str.getBytes)
 
   private def lift(code: CurlCode): F[CurlCode] = {
     code match {

--- a/core/src/test/scalanative/sttp/client/testing/SyncHttpTest.scala
+++ b/core/src/test/scalanative/sttp/client/testing/SyncHttpTest.scala
@@ -31,9 +31,9 @@ trait SyncHttpTest
   implicit val backend: SttpBackend[Identity, Nothing, NothingT]
 
   protected def postEcho = basicRequest.post(uri"$endpoint/echo")
-  protected val testBody = "this is the body"
+  protected val testBody = "this is the body😀"
   protected val testBodyBytes = testBody.getBytes("UTF-8")
-  protected val expectedPostEchoResponse = "POST /echo this is the body"
+  protected val expectedPostEchoResponse = "POST /echo this is the body😀"
 
   protected val sttpIgnore = sttp.client.ignore
 


### PR DESCRIPTION
#### Problem:
`str.toCharArray.map(_.toByte)`, takes only one byte per
character, thus producing an incorrect `Array[Byte]` for
any string that contains multi-byte characters.

#### Solution:
Use `str.getBytes` instead.

#### Demo:
```scala
val smile = "😀"

smile.toCharArray.map(_.toByte)
// Array[Byte] = Array(61, 0)

smile.getBytes
// Array[Byte] = Array(-16, -97, -104, -128)
```

#### Testing:
This patch also adds an unicode character to the test
string in `SyncHttpTest`. The modified test fails without
the patch, and passes with the patch.

#### Future Work:
Currently `AbstractCurlBackend` calls the `fromCString`
function from scala-native, without the encoding parameter.
Thus, the encoding parameter gets defaulted to UTF-8.
Testing needs to be done in cases where the encoding
of the server response is not UTF-8, which is out of the
scope for this patch.

#### Checklist:
- [x] Check if the project compiles by running `sbt compile`
- [x] Verify docs compilation by running `sbt compileDocs`
- [x] Check if tests pass by running `sbt test`
- [x] Format code by running `sbt scalafmt`
