### PR TITLE
Lazy logging (don't construct log messages if specified log level disabled)

### DIFF
--- a/logging/slf4j/src/main/scala/sttp/client/logging/slf4j/Logger.scala
+++ b/logging/slf4j/src/main/scala/sttp/client/logging/slf4j/Logger.scala
@@ -16,9 +16,9 @@ private[sttp] class Logger(private val name: String) {
     if (underlying.isInfoEnabled) underlying.info(message, t) else ()
 
   def warn(message: => String): Unit =
-    if (underlying.isWarnEnabled) underlying.error(message) else ()
+    if (underlying.isWarnEnabled) underlying.warn(message) else ()
   def warn(message: => String, t: Throwable): Unit =
-    if (underlying.isWarnEnabled) underlying.error(message, t) else ()
+    if (underlying.isWarnEnabled) underlying.warn(message, t) else ()
 
   def error(message: => String): Unit =
     if (underlying.isErrorEnabled) underlying.error(message) else ()

--- a/logging/slf4j/src/main/scala/sttp/client/logging/slf4j/Logger.scala
+++ b/logging/slf4j/src/main/scala/sttp/client/logging/slf4j/Logger.scala
@@ -1,0 +1,27 @@
+package sttp.client.logging.slf4j
+
+import org.slf4j.LoggerFactory
+
+private[sttp] class Logger(private val name: String) {
+  private val underlying = LoggerFactory.getLogger(name)
+
+  def debug(message: => String): Unit =
+    if (underlying.isDebugEnabled) underlying.debug(message) else ()
+  def debug(message: => String, t: Throwable): Unit =
+    if (underlying.isDebugEnabled) underlying.debug(message, t) else ()
+
+  def info(message: => String): Unit =
+    if (underlying.isInfoEnabled) underlying.info(message) else ()
+  def info(message: => String, t: Throwable): Unit =
+    if (underlying.isInfoEnabled) underlying.info(message, t) else ()
+
+  def warn(message: => String): Unit =
+    if (underlying.isWarnEnabled) underlying.error(message) else ()
+  def warn(message: => String, t: Throwable): Unit =
+    if (underlying.isWarnEnabled) underlying.error(message, t) else ()
+
+  def error(message: => String): Unit =
+    if (underlying.isErrorEnabled) underlying.error(message) else ()
+  def error(message: => String, t: Throwable): Unit =
+    if (underlying.isErrorEnabled) underlying.error(message, t) else ()
+}

--- a/logging/slf4j/src/main/scala/sttp/client/logging/slf4j/Slf4jCurlBackend.scala
+++ b/logging/slf4j/src/main/scala/sttp/client/logging/slf4j/Slf4jCurlBackend.scala
@@ -1,13 +1,12 @@
 package sttp.client.logging.slf4j
 
-import org.slf4j.{Logger, LoggerFactory}
 import sttp.client.listener.{ListenerBackend, RequestListener}
 import sttp.client.logging.LogMessages
 import sttp.client.ws.WebSocketResponse
 import sttp.client.{Identity, Request, Response, SttpBackend}
 
 object Slf4jCurlBackend {
-  private val logger = LoggerFactory.getLogger("sttp.client.logging.slf4j.Slf4jCurlBackend")
+  private val logger = new Logger("sttp.client.logging.slf4j.Slf4jCurlBackend")
 
   def apply[F[_], S, WS_HANDLER[_]](delegate: SttpBackend[F, S, WS_HANDLER]): SttpBackend[F, S, WS_HANDLER] =
     ListenerBackend.lift(delegate, new Slf4jCurlListener(logger))

--- a/logging/slf4j/src/main/scala/sttp/client/logging/slf4j/Slf4jLoggingBackend.scala
+++ b/logging/slf4j/src/main/scala/sttp/client/logging/slf4j/Slf4jLoggingBackend.scala
@@ -1,13 +1,12 @@
 package sttp.client.logging.slf4j
 
-import org.slf4j.{Logger, LoggerFactory}
 import sttp.client._
 import sttp.client.listener.{ListenerBackend, RequestListener}
 import sttp.client.logging.LogMessages
 import sttp.client.ws.WebSocketResponse
 
 object Slf4jLoggingBackend {
-  private val logger = LoggerFactory.getLogger("sttp.client.logging.slf4j.Slf4jLoggingBackend")
+  private val logger = new Logger("sttp.client.logging.slf4j.Slf4jLoggingBackend")
 
   def apply[F[_], S, WS_HANDLER[_]](delegate: SttpBackend[F, S, WS_HANDLER]): SttpBackend[F, S, WS_HANDLER] =
     ListenerBackend.lift(delegate, new Slf4jLoggingListener(logger))

--- a/logging/slf4j/src/main/scala/sttp/client/logging/slf4j/Slf4jTimingBackend.scala
+++ b/logging/slf4j/src/main/scala/sttp/client/logging/slf4j/Slf4jTimingBackend.scala
@@ -1,13 +1,12 @@
 package sttp.client.logging.slf4j
 
-import org.slf4j.{Logger, LoggerFactory}
 import sttp.client.listener.{ListenerBackend, RequestListener}
 import sttp.client.logging.LogMessages
 import sttp.client.ws.WebSocketResponse
 import sttp.client.{Identity, Request, Response, SttpBackend}
 
 object Slf4jTimingBackend {
-  private val logger = LoggerFactory.getLogger("sttp.client.logging.slf4j.Slf4jTimingBackend")
+  private val logger = new Logger("sttp.client.logging.slf4j.Slf4jTimingBackend")
 
   def apply[F[_], S, WS_HANDLER[_]](delegate: SttpBackend[F, S, WS_HANDLER]): SttpBackend[F, S, WS_HANDLER] =
     ListenerBackend.lift(delegate, new Slf4jTimingListener(logger))


### PR DESCRIPTION
Currently logging backend constructs `curl` request representation even if `DEBUG` logging is disabled.

I created lazy wrapper which checks log level first.