### PR TITLE
Add more ergonomic zio stubbing

### DIFF
--- a/async-http-client-backend/zio/src/main/scala/sttp/client/asynchttpclient/zio/AsyncHttpClientZioBackend.scala
+++ b/async-http-client-backend/zio/src/main/scala/sttp/client/asynchttpclient/zio/AsyncHttpClientZioBackend.scala
@@ -73,16 +73,16 @@ object AsyncHttpClientZioBackend {
   ): Task[SttpBackend[Task, Stream[Throwable, Byte], WebSocketHandler]] =
     ZIO
       .runtime[Any]
-      .flatMap(
-        runtime =>
-          Task.effect(
-            AsyncHttpClientZioBackend(
-              runtime,
-              AsyncHttpClientBackend.defaultClient(options),
-              closeClient = true,
-              customizeRequest
-            )
-        ))
+      .flatMap(runtime =>
+        Task.effect(
+          AsyncHttpClientZioBackend(
+            runtime,
+            AsyncHttpClientBackend.defaultClient(options),
+            closeClient = true,
+            customizeRequest
+          )
+        )
+      )
 
   def managed(
       options: SttpBackendOptions = SttpBackendOptions.Default,
@@ -102,16 +102,16 @@ object AsyncHttpClientZioBackend {
   ): Task[SttpBackend[Task, Stream[Throwable, Byte], WebSocketHandler]] =
     ZIO
       .runtime[Any]
-      .flatMap(
-        runtime =>
-          Task.effect(
-            AsyncHttpClientZioBackend(
-              runtime,
-              new DefaultAsyncHttpClient(cfg),
-              closeClient = true,
-              customizeRequest
-            )
-        ))
+      .flatMap(runtime =>
+        Task.effect(
+          AsyncHttpClientZioBackend(
+            runtime,
+            new DefaultAsyncHttpClient(cfg),
+            closeClient = true,
+            customizeRequest
+          )
+        )
+      )
 
   def managedUsingConfig(
       cfg: AsyncHttpClientConfig,
@@ -135,16 +135,16 @@ object AsyncHttpClientZioBackend {
   ): Task[SttpBackend[Task, Stream[Throwable, Byte], WebSocketHandler]] =
     ZIO
       .runtime[Any]
-      .flatMap(
-        runtime =>
-          Task.effect(
-            AsyncHttpClientZioBackend(
-              runtime,
-              AsyncHttpClientBackend.clientWithModifiedOptions(options, updateConfig),
-              closeClient = true,
-              customizeRequest
-            )
-        ))
+      .flatMap(runtime =>
+        Task.effect(
+          AsyncHttpClientZioBackend(
+            runtime,
+            AsyncHttpClientBackend.clientWithModifiedOptions(options, updateConfig),
+            closeClient = true,
+            customizeRequest
+          )
+        )
+      )
 
   /**
     * @param updateConfig A function which updates the default configuration (created basing on `options`).

--- a/async-http-client-backend/zio/src/main/scala/sttp/client/asynchttpclient/zio/AsyncHttpClientZioBackend.scala
+++ b/async-http-client-backend/zio/src/main/scala/sttp/client/asynchttpclient/zio/AsyncHttpClientZioBackend.scala
@@ -2,14 +2,9 @@ package sttp.client.asynchttpclient.zio
 
 import java.io.{File, FileOutputStream}
 import java.nio.ByteBuffer
+
 import io.netty.buffer.{ByteBuf, Unpooled}
-import org.asynchttpclient.{
-  AsyncHttpClient,
-  AsyncHttpClientConfig,
-  BoundRequestBuilder,
-  DefaultAsyncHttpClient,
-  DefaultAsyncHttpClientConfig
-}
+import org.asynchttpclient.{AsyncHttpClient, AsyncHttpClientConfig, BoundRequestBuilder, DefaultAsyncHttpClient, DefaultAsyncHttpClientConfig}
 import org.reactivestreams.Publisher
 import sttp.client.asynchttpclient.{AsyncHttpClientBackend, WebSocketHandler}
 import sttp.client.impl.zio.RIOMonadAsyncError
@@ -188,4 +183,7 @@ object AsyncHttpClientZioBackend {
     */
   def stub: SttpBackendStub[Task, Stream[Throwable, Byte], WebSocketHandler] =
     SttpBackendStub(new RIOMonadAsyncError[Any])
+
+  val stubLayer: Layer[Throwable, SttpClient with SttpClientStubbing] =
+    SttpClientStubbing.layer
 }

--- a/async-http-client-backend/zio/src/main/scala/sttp/client/asynchttpclient/zio/AsyncHttpClientZioBackend.scala
+++ b/async-http-client-backend/zio/src/main/scala/sttp/client/asynchttpclient/zio/AsyncHttpClientZioBackend.scala
@@ -4,7 +4,13 @@ import java.io.{File, FileOutputStream}
 import java.nio.ByteBuffer
 
 import io.netty.buffer.{ByteBuf, Unpooled}
-import org.asynchttpclient.{AsyncHttpClient, AsyncHttpClientConfig, BoundRequestBuilder, DefaultAsyncHttpClient, DefaultAsyncHttpClientConfig}
+import org.asynchttpclient.{
+  AsyncHttpClient,
+  AsyncHttpClientConfig,
+  BoundRequestBuilder,
+  DefaultAsyncHttpClient,
+  DefaultAsyncHttpClientConfig
+}
 import org.reactivestreams.Publisher
 import sttp.client.asynchttpclient.{AsyncHttpClientBackend, WebSocketHandler}
 import sttp.client.impl.zio.RIOMonadAsyncError
@@ -67,16 +73,16 @@ object AsyncHttpClientZioBackend {
   ): Task[SttpBackend[Task, Stream[Throwable, Byte], WebSocketHandler]] =
     ZIO
       .runtime[Any]
-      .flatMap(runtime =>
-        Task.effect(
-          AsyncHttpClientZioBackend(
-            runtime,
-            AsyncHttpClientBackend.defaultClient(options),
-            closeClient = true,
-            customizeRequest
-          )
-        )
-      )
+      .flatMap(
+        runtime =>
+          Task.effect(
+            AsyncHttpClientZioBackend(
+              runtime,
+              AsyncHttpClientBackend.defaultClient(options),
+              closeClient = true,
+              customizeRequest
+            )
+        ))
 
   def managed(
       options: SttpBackendOptions = SttpBackendOptions.Default,
@@ -96,16 +102,16 @@ object AsyncHttpClientZioBackend {
   ): Task[SttpBackend[Task, Stream[Throwable, Byte], WebSocketHandler]] =
     ZIO
       .runtime[Any]
-      .flatMap(runtime =>
-        Task.effect(
-          AsyncHttpClientZioBackend(
-            runtime,
-            new DefaultAsyncHttpClient(cfg),
-            closeClient = true,
-            customizeRequest
-          )
-        )
-      )
+      .flatMap(
+        runtime =>
+          Task.effect(
+            AsyncHttpClientZioBackend(
+              runtime,
+              new DefaultAsyncHttpClient(cfg),
+              closeClient = true,
+              customizeRequest
+            )
+        ))
 
   def managedUsingConfig(
       cfg: AsyncHttpClientConfig,
@@ -129,16 +135,16 @@ object AsyncHttpClientZioBackend {
   ): Task[SttpBackend[Task, Stream[Throwable, Byte], WebSocketHandler]] =
     ZIO
       .runtime[Any]
-      .flatMap(runtime =>
-        Task.effect(
-          AsyncHttpClientZioBackend(
-            runtime,
-            AsyncHttpClientBackend.clientWithModifiedOptions(options, updateConfig),
-            closeClient = true,
-            customizeRequest
-          )
-        )
-      )
+      .flatMap(
+        runtime =>
+          Task.effect(
+            AsyncHttpClientZioBackend(
+              runtime,
+              AsyncHttpClientBackend.clientWithModifiedOptions(options, updateConfig),
+              closeClient = true,
+              customizeRequest
+            )
+        ))
 
   /**
     * @param updateConfig A function which updates the default configuration (created basing on `options`).

--- a/async-http-client-backend/zio/src/main/scala/sttp/client/asynchttpclient/zio/package.scala
+++ b/async-http-client-backend/zio/src/main/scala/sttp/client/asynchttpclient/zio/package.scala
@@ -4,11 +4,8 @@ import _root_.zio._
 import _root_.zio.stream._
 import sttp.client._
 import sttp.client.asynchttpclient.zio.SttpClientStubbing.StubbingWhenRequest
-import sttp.client.impl.zio.RIOMonadAsyncError
-import sttp.client.monad.MonadError
-import sttp.client.testing.{SttpBackendStub, WebSocketStub}
+import sttp.client.impl.zio.SttpClientStubbingBase
 import sttp.client.ws.{WebSocket, WebSocketResponse}
-import sttp.model.{Headers, StatusCode}
 
 package object zio {
 
@@ -55,130 +52,9 @@ package object zio {
       ZioWebSocketHandler().flatMap(handler => ZIO.accessM(env => env.get[Service].openWebsocket(request, handler)))
   }
 
-  object SttpClientStubbing {
-
-    trait Service {
-      def whenRequestMatchesPartial(
-          partial: PartialFunction[Request[_, _], Response[_]]
-      ): URIO[SttpClientStubbing, Unit]
-
-      private[zio] def update(
-          stub: SttpBackendStub[Task, Stream[Throwable, Byte], WebSocketHandler] => SttpBackendStub[
-            Task,
-            Stream[Throwable, Byte],
-            WebSocketHandler
-          ]
-      ): UIO[Unit]
-    }
-
-    private class StubWrapper(stub: Ref[SttpBackendStub[Task, Stream[Throwable, Byte], WebSocketHandler]])
-        extends Service {
-      override def whenRequestMatchesPartial(
-          partial: PartialFunction[Request[_, _], Response[_]]
-      ): URIO[SttpClientStubbing, Unit] =
-        update(_.whenRequestMatchesPartial(partial))
-
-      override private[zio] def update(
-          f: SttpBackendStub[Task, Stream[Throwable, Byte], WebSocketHandler] => SttpBackendStub[
-            Task,
-            Stream[Throwable, Byte],
-            WebSocketHandler
-          ]
-      ) = stub.update(f)
-    }
-
-    final case class StubbingWhenRequest private[zio] (p: Request[_, _] => Boolean) {
-      val thenRespondOk: URIO[SttpClientStubbing, Unit] =
-        thenRespondWithCode(StatusCode.Ok)
-
-      def thenRespondNotFound(): URIO[SttpClientStubbing, Unit] =
-        thenRespondWithCode(StatusCode.NotFound, "Not found")
-
-      def thenRespondServerError(): URIO[SttpClientStubbing, Unit] =
-        thenRespondWithCode(StatusCode.InternalServerError, "Internal server error")
-
-      def thenRespondWithCode(status: StatusCode, msg: String = ""): URIO[SttpClientStubbing, Unit] = {
-        thenRespond(Response(msg, status, msg))
-      }
-
-      def thenRespond[T](body: T): URIO[SttpClientStubbing, Unit] =
-        thenRespond(Response[T](body, StatusCode.Ok, "OK"))
-
-      def thenRespond[T](resp: => Response[T]): URIO[SttpClientStubbing, Unit] =
-        URIO.accessM(_.get.update(_.whenRequestMatches(p).thenRespond(resp)))
-
-      def thenRespondCyclic[T](bodies: T*): URIO[SttpClientStubbing, Unit] = {
-        thenRespondCyclicResponses(bodies.map(body => Response[T](body, StatusCode.Ok, "OK")): _*)
-      }
-
-      def thenRespondCyclicResponses[T](responses: Response[T]*): URIO[SttpClientStubbing, Unit] = {
-        for {
-          q <- Queue.bounded[Response[T]](responses.length)
-          _ <- q.offerAll(responses)
-          _ <- thenRespondWrapped(q.take.flatMap(t => q.offer(t) as t))
-        } yield ()
-      }
-
-      def thenRespondWrapped(resp: => Task[Response[_]]): URIO[SttpClientStubbing, Unit] = {
-        val m: PartialFunction[Request[_, _], Task[Response[_]]] = {
-          case r if p(r) => resp
-        }
-        URIO.accessM(_.get.update(_.whenRequestMatches(p).thenRespondWrapped(m)))
-      }
-
-      def thenRespondWrapped(resp: Request[_, _] => Task[Response[_]]): URIO[SttpClientStubbing, Unit] = {
-        val m: PartialFunction[Request[_, _], Task[Response[_]]] = {
-          case r if p(r) => resp(r)
-        }
-        URIO.accessM(_.get.update(_.whenRequestMatches(p).thenRespondWrapped(m)))
-      }
-
-      def thenRespondWebSocket[WS_RESULT](result: WS_RESULT): URIO[SttpClientStubbing, Unit] =
-        thenRespondWebSocket(Headers(List.empty), result)
-
-      def thenRespondWebSocket[WS_RESULT](headers: Headers, result: WS_RESULT): URIO[SttpClientStubbing, Unit] =
-        URIO.accessM(_.get.update(_.whenRequestMatches(p).thenRespondWebSocket(headers, result)))
-
-      def thenRespondWebSocket(wsStub: WebSocketStub[_]): URIO[SttpClientStubbing, Unit] =
-        thenRespondWebSocket(Headers(List.empty), wsStub)
-
-      def thenRespondWebSocket(headers: Headers, wsStub: WebSocketStub[_]): URIO[SttpClientStubbing, Unit] =
-        URIO.accessM(_.get.update(_.whenRequestMatches(p).thenRespondWebSocket(headers, wsStub)))
-
-      def thenHandleOpenWebSocket[WS_RESULT](
-          useHandler: WebSocketHandler[WS_RESULT] => WS_RESULT
-      ): URIO[SttpClientStubbing, Unit] =
-        thenHandleOpenWebSocket(Headers(List.empty), useHandler)
-
-      def thenHandleOpenWebSocket[WS_RESULT](
-          headers: Headers,
-          useHandler: WebSocketHandler[WS_RESULT] => WS_RESULT
-      ): URIO[SttpClientStubbing, Unit] = {
-        URIO.accessM(_.get.update(_.whenRequestMatches(p).thenHandleOpenWebSocket(headers, useHandler)))
-      }
-
-    }
-
-    val layer: ZLayer[Any, Nothing, SttpClientStubbing with SttpClient] =
-      ZLayer.fromEffectMany(for {
-        stub <- Ref.make(AsyncHttpClientZioBackend.stub)
-        stubber = new StubWrapper(stub)
-        proxy = new SttpClient.Service {
-          override def send[T](request: Request[T, Stream[Throwable, Byte]]): Task[Response[T]] =
-            stub.get >>= (_.send(request))
-
-          override def openWebsocket[T, WS_RESULT](
-              request: Request[T, Stream[Throwable, Byte]],
-              handler: WebSocketHandler[WS_RESULT]
-          ): Task[WebSocketResponse[WS_RESULT]] =
-            stub.get >>= (_.openWebsocket(request, handler))
-
-          override def close(): Task[Unit] =
-            stub.get >>= (_.close())
-
-          override def responseMonad: MonadError[Task] = new RIOMonadAsyncError[Any]()
-        }
-      } yield Has.allOf[SttpClientStubbing.Service, SttpClient.Service](stubber, proxy))
+  object SttpClientStubbing extends SttpClientStubbingBase[Any, Stream[Throwable, Byte], WebSocketHandler] {
+    override private[sttp] def serviceTag: Tag[SttpClientStubbing.Service] = implicitly
+    override private[sttp] def sttpBackendTag: Tag[SttpClient.Service] = implicitly
   }
 
   object stubbing {
@@ -193,5 +69,4 @@ package object zio {
     ): URIO[SttpClientStubbing, Unit] =
       ZIO.accessM(_.get.whenRequestMatchesPartial(partial))
   }
-
 }

--- a/async-http-client-backend/zio/src/main/scala/sttp/client/asynchttpclient/zio/package.scala
+++ b/async-http-client-backend/zio/src/main/scala/sttp/client/asynchttpclient/zio/package.scala
@@ -1,9 +1,14 @@
 package sttp.client.asynchttpclient
 
-import sttp.client._
-import sttp.client.ws.{WebSocket, WebSocketResponse}
 import _root_.zio._
 import _root_.zio.stream._
+import sttp.client._
+import sttp.client.asynchttpclient.zio.SttpClientStubbing.StubbingWhenRequest
+import sttp.client.impl.zio.RIOMonadAsyncError
+import sttp.client.monad.MonadError
+import sttp.client.testing.{SttpBackendStub, WebSocketStub}
+import sttp.client.ws.{WebSocket, WebSocketResponse}
+import sttp.model.{Headers, StatusCode}
 
 package object zio {
 
@@ -11,6 +16,7 @@ package object zio {
     * ZIO-environment service definition, which is an SttpBackend.
     */
   type SttpClient = Has[SttpClient.Service]
+  type SttpClientStubbing = Has[SttpClientStubbing.Service]
 
   object SttpClient {
 
@@ -48,4 +54,135 @@ package object zio {
     ): ZIO[SttpClient, Throwable, WebSocketResponse[WebSocket[Task]]] =
       ZioWebSocketHandler().flatMap(handler => ZIO.accessM(env => env.get[Service].openWebsocket(request, handler)))
   }
+
+  object SttpClientStubbing {
+
+    trait Service {
+      def whenRequestMatchesPartial(
+          partial: PartialFunction[Request[_, _], Response[_]]): URIO[SttpClient with SttpClientStubbing, Unit]
+
+      private[zio] def update(
+          stub: SttpBackendStub[Task, Stream[Throwable, Byte], WebSocketHandler] => SttpBackendStub[
+            Task,
+            Stream[Throwable, Byte],
+            WebSocketHandler]): UIO[Unit]
+    }
+
+    final case class StubbingWhenRequest private (p: Request[_, _] => Boolean) {
+      def thenRespondOk(): URIO[SttpClient with SttpClientStubbing, Unit] =
+        thenRespondWithCode(StatusCode.Ok)
+
+      def thenRespondNotFound(): URIO[SttpClient with SttpClientStubbing, Unit] =
+        thenRespondWithCode(StatusCode.NotFound, "Not found")
+
+      def thenRespondServerError(): URIO[SttpClient with SttpClientStubbing, Unit] =
+        thenRespondWithCode(StatusCode.InternalServerError, "Internal server error")
+
+      def thenRespondWithCode(status: StatusCode, msg: String = ""): URIO[SttpClient with SttpClientStubbing, Unit] = {
+        thenRespond(Response(msg, status, msg))
+      }
+
+      def thenRespond[T](body: T): URIO[SttpClient with SttpClientStubbing, Unit] =
+        thenRespond(Response[T](body, StatusCode.Ok, "OK"))
+
+      def thenRespond[T](resp: => Response[T]): URIO[SttpClientStubbing with SttpClient, Unit] =
+        URIO.accessM(_.get.update(_.whenRequestMatches(p).thenRespond(resp)))
+
+      def thenRespondCyclic[T](bodies: T*): URIO[SttpClientStubbing with SttpClient, Unit] = {
+        thenRespondCyclicResponses(bodies.map(body => Response[T](body, StatusCode.Ok, "OK")): _*)
+      }
+
+      def thenRespondCyclicResponses[T](responses: Response[T]*): URIO[SttpClientStubbing with SttpClient, Unit] = {
+        for {
+          q <- Queue.bounded[Response[T]](responses.length)
+          _ <- q.offerAll(responses)
+          _ <- thenRespondWrapped(q.take.flatMap(t => q.offer(t) as t))
+        } yield ()
+      }
+
+      def thenRespondWrapped(resp: => Task[Response[_]]): URIO[SttpClientStubbing with SttpClient, Unit] = {
+        val m: PartialFunction[Request[_, _], Task[Response[_]]] = {
+          case r if p(r) => resp
+        }
+        URIO.accessM(_.get.update(_.whenRequestMatches(p).thenRespondWrapped(m)))
+      }
+
+      def thenRespondWrapped(
+          resp: Request[_, _] => Task[Response[_]]): URIO[SttpClientStubbing with SttpClient, Unit] = {
+        val m: PartialFunction[Request[_, _], Task[Response[_]]] = {
+          case r if p(r) => resp(r)
+        }
+        URIO.accessM(_.get.update(_.whenRequestMatches(p).thenRespondWrapped(m)))
+      }
+
+      def thenRespondWebSocket[WS_RESULT](result: WS_RESULT): URIO[SttpClientStubbing with SttpClient, Unit] =
+        thenRespondWebSocket(Headers(List.empty), result)
+
+      def thenRespondWebSocket[WS_RESULT](headers: Headers,
+                                          result: WS_RESULT): URIO[SttpClientStubbing with SttpClient, Unit] =
+        URIO.accessM(_.get.update(_.whenRequestMatches(p).thenRespondWebSocket(headers, result)))
+
+      def thenRespondWebSocket(wsStub: WebSocketStub[_]): URIO[SttpClientStubbing with SttpClient, Unit] =
+        thenRespondWebSocket(Headers(List.empty), wsStub)
+
+      def thenRespondWebSocket(headers: Headers,
+                               wsStub: WebSocketStub[_]): URIO[SttpClientStubbing with SttpClient, Unit] =
+        URIO.accessM(_.get.update(_.whenRequestMatches(p).thenRespondWebSocket(headers, wsStub)))
+
+      def thenHandleOpenWebSocket[WS_RESULT](
+          useHandler: WebSocketHandler[WS_RESULT] => WS_RESULT): URIO[SttpClientStubbing with SttpClient, Unit] =
+        thenHandleOpenWebSocket(Headers(List.empty), useHandler)
+
+      def thenHandleOpenWebSocket[WS_RESULT](
+          headers: Headers,
+          useHandler: WebSocketHandler[WS_RESULT] => WS_RESULT
+      ): URIO[SttpClientStubbing with SttpClient, Unit] = {
+        URIO.accessM(_.get.update(_.whenRequestMatches(p).thenHandleOpenWebSocket(headers, useHandler)))
+      }
+
+    }
+
+    val layer = ZLayer.fromEffectMany(for {
+      stub <- Ref.make(AsyncHttpClientZioBackend.stub)
+      stubber = new Service {
+        override def whenRequestMatchesPartial(
+            partial: PartialFunction[Request[_, _], Response[_]]): URIO[SttpClient with SttpClientStubbing, Unit] =
+          update(_.whenRequestMatchesPartial(partial))
+
+        override protected[zio] def update(
+            f: SttpBackendStub[Task, Stream[Throwable, Byte], WebSocketHandler] => SttpBackendStub[
+              Task,
+              Stream[Throwable, Byte],
+              WebSocketHandler]): UIO[Unit] =
+          stub.update(f)
+      }
+      proxy = new SttpClient.Service {
+        override def send[T](request: Request[T, Stream[Throwable, Byte]]): Task[Response[T]] =
+          stub.get >>= (_.send(request))
+
+        override def openWebsocket[T, WS_RESULT](
+            request: Request[T, Stream[Throwable, Byte]],
+            handler: WebSocketHandler[WS_RESULT]): Task[WebSocketResponse[WS_RESULT]] =
+          stub.get >>= (_.openWebsocket(request, handler))
+
+        override def close(): Task[Unit] =
+          stub.get >>= (_.close())
+
+        override def responseMonad: MonadError[Task] = new RIOMonadAsyncError[Any]()
+      }
+    } yield Has.allOf[SttpClientStubbing.Service, SttpClient.Service](stubber, proxy))
+  }
+
+  object stubbing {
+    def whenRequestMatches(p: Request[_, _] => Boolean): StubbingWhenRequest =
+      StubbingWhenRequest(p)
+
+    val whenAnyRequest: StubbingWhenRequest =
+      StubbingWhenRequest(_ => true)
+
+    def whenRequestMatchesPartial(
+        partial: PartialFunction[Request[_, _], Response[_]]): URIO[SttpClientStubbing with SttpClient, Unit] =
+      ZIO.accessM(_.get.whenRequestMatchesPartial(partial))
+  }
+
 }

--- a/async-http-client-backend/zio/src/test/scala/sttp/client/asynchttpclient/zio/SttpBackendStubZioTests.scala
+++ b/async-http-client-backend/zio/src/test/scala/sttp/client/asynchttpclient/zio/SttpBackendStubZioTests.scala
@@ -8,9 +8,10 @@ import sttp.client.testing.SttpBackendStub
 import sttp.client.impl.zio._
 import sttp.client.monad.MonadError
 import sttp.client.ws.{WebSocket, WebSocketEvent}
-import sttp.model.Headers
+import sttp.model.{Headers, Method}
 import sttp.model.ws._
 import zio._
+import zio.stream.ZStream
 
 class SttpBackendStubZioTests extends AnyFlatSpec with Matchers with ScalaFutures {
 
@@ -65,5 +66,34 @@ class SttpBackendStubZioTests extends AnyFlatSpec with Matchers with ScalaFuture
     } yield (msg1, msg2)
 
     runtime.unsafeRun(test) shouldBe ((Right(frame1), Right(sentFrame)))
+  }
+
+  it should "allow effectful stubbing" in {
+    import stubbing._
+    val r1 = SttpClient.send(basicRequest.get(uri"http://example.org/a")).map(_.body)
+    val r2 = SttpClient.send(basicRequest.post(uri"http://example.org/a/b")).map(_.body)
+    val r3 = SttpClient.send(basicRequest.get(uri"http://example.org/a/b/c")).map(_.body)
+
+    val effect = for {
+      _ <- whenRequestMatches(_.uri.toString.endsWith("c")).thenRespond("c")
+      _ <- whenRequestMatchesPartial { case r if r.method == Method.POST => Response.ok("b") }
+      _ <- whenAnyRequest.thenRespond("a")
+      resp <- r1 <&> r2 <&> r3
+    } yield resp
+
+    runtime.unsafeRun(effect.provideLayer(AsyncHttpClientZioBackend.stubLayer)) shouldBe
+      (((Right("a"), Right("b")), Right("c")))
+  }
+
+  it should "allow effectful cyclical stubbing" in {
+    import stubbing._
+    val r = basicRequest.get(uri"http://example.org/a/b/c")
+
+    val effect = (for {
+      _ <- whenAnyRequest.thenRespondCyclic("a", "b", "c")
+      resp <- ZStream.repeatEffect(SttpClient.send(r)).take(4).runCollect
+    } yield resp).provideLayer(AsyncHttpClientZioBackend.stubLayer)
+
+    runtime.unsafeRun(effect).map(_.body).toList shouldBe List(Right("a"), Right("b"), Right("c"), Right("a"))
   }
 }

--- a/docs/backends/zio.md
+++ b/docs/backends/zio.md
@@ -171,27 +171,15 @@ use the high-level interface.
 
 ## Testing
 
-The ZIO backends also support a ZIO-familiar way of configuring stubs as well. While you may get a stub normally by using
-
-```scala mdoc:compile-only
-import zio.{RIO, Task}
-import zio.stream.{ZStream, Stream}
-import sttp.client.testing._
-
-import sttp.client.asynchttpclient.WebSocketHandler
-import sttp.client.asynchttpclient.zio.AsyncHttpClientZioBackend
-
-val stub: SttpBackendStub[Task, Stream[Throwable, Byte], WebSocketHandler] = AsyncHttpClientZioBackend.stub 
-```
-
-You can also define your stubs as effects instead
+The ZIO backends also support a ZIO-familiar way of configuring [stubs](../testing.md) as well. In addition to the
+usual way of creating a stand-alone stub, you can also define your stubs as effects instead:
 
 ```scala mdoc:compile-only
 import sttp.client._
 import sttp.model._
 import sttp.client.asynchttpclient._
 import sttp.client.asynchttpclient.zio._
-import stubbing._
+import sttp.client.asynchttpclient.zio.stubbing._
 
 val stubEffect = for {
   _ <- whenRequestMatches(_.uri.toString.endsWith("c")).thenRespond("c")
@@ -202,5 +190,10 @@ val stubEffect = for {
 val responseEffect = stubEffect *> SttpClient.send(basicRequest.get(uri"http://example.org/a")).map(_.body)
 
 responseEffect.provideLayer(AsyncHttpClientZioBackend.stubLayer) // Task[Either[String, String]]
-
 ```
+
+The `whenRequestMatches`, `whenRequestMatchesPartial`, `whenAnyRequest` are effects which require the `SttpClientStubbing`
+dependency. They enrich the stub with the given behavior.
+
+Then, the `stubLayer` provides both an implementation of the `SttpClientStubbing` dependency, as well as a `SttpClient`
+which is backed by the stub.

--- a/generated-docs/out/backends/zio.md
+++ b/generated-docs/out/backends/zio.md
@@ -168,3 +168,32 @@ The ZIO backend supports:
 See [websockets](../websockets.md) for details on how to use the high-level and low-level interfaces. Websockets
 opened using the `SttpClient.openWebsocket` and `SttpStreamsClient.openWebsocket` (leveraging ZIO environment) always
 use the high-level interface.
+
+## Testing
+
+The ZIO backends also support a ZIO-familiar way of configuring [stubs](../testing.md) as well. In addition to the
+usual way of creating a stand-alone stub, you can also define your stubs as effects instead:
+
+```scala
+import sttp.client._
+import sttp.model._
+import sttp.client.asynchttpclient._
+import sttp.client.asynchttpclient.zio._
+import sttp.client.asynchttpclient.zio.stubbing._
+
+val stubEffect = for {
+  _ <- whenRequestMatches(_.uri.toString.endsWith("c")).thenRespond("c")
+  _ <- whenRequestMatchesPartial { case r if r.method == Method.POST => Response.ok("b") }
+  _ <- whenAnyRequest.thenRespond("a")
+} yield ()
+
+val responseEffect = stubEffect *> SttpClient.send(basicRequest.get(uri"http://example.org/a")).map(_.body)
+
+responseEffect.provideLayer(AsyncHttpClientZioBackend.stubLayer) // Task[Either[String, String]]
+```
+
+The `whenRequestMatches`, `whenRequestMatchesPartial`, `whenAnyRequest` are effects which require the `SttpClientStubbing`
+dependency. They enrich the stub with the given behavior.
+
+Then, the `stubLayer` provides both an implementation of the `SttpClientStubbing` dependency, as well as a `SttpClient`
+which is backed by the stub.

--- a/httpclient-backend/zio/src/main/scala/sttp/client/httpclient/zio/HttpClientZioBackend.scala
+++ b/httpclient-backend/zio/src/main/scala/sttp/client/httpclient/zio/HttpClientZioBackend.scala
@@ -153,10 +153,5 @@ object HttpClientZioBackend {
   def stub: SttpBackendStub[BlockingTask, ZStream[Blocking, Throwable, Byte], WebSocketHandler] =
     SttpBackendStub(new RIOMonadAsyncError[Blocking])
 
-  val stubLayer: ZLayer[Any,
-                        Nothing,
-                        Has[zio.SttpClientStubbing.Service] with Has[
-                          SttpBackend[BlockingTask, ZStream[Blocking, Throwable, Byte], WebSocketHandler]
-                        ]] =
-    SttpClientStubbing.layer
+  val stubLayer: ZLayer[Any, Nothing, SttpClientStubbing with SttpClient] = SttpClientStubbing.layer
 }

--- a/httpclient-backend/zio/src/main/scala/sttp/client/httpclient/zio/HttpClientZioBackend.scala
+++ b/httpclient-backend/zio/src/main/scala/sttp/client/httpclient/zio/HttpClientZioBackend.scala
@@ -6,16 +6,15 @@ import java.net.http.{HttpClient, HttpRequest}
 import java.nio.ByteBuffer
 
 import org.reactivestreams.FlowAdapters
-import sttp.client.NothingT
 import sttp.client.httpclient.HttpClientBackend.EncodingHandler
-import sttp.client.httpclient.{HttpClientAsyncBackend, HttpClientBackend, WebSocketHandler}
+import sttp.client.httpclient.{HttpClientAsyncBackend, HttpClientBackend, WebSocketHandler, zio}
 import sttp.client.impl.zio.RIOMonadAsyncError
 import sttp.client.testing.SttpBackendStub
 import sttp.client.{FollowRedirectsBackend, SttpBackend, SttpBackendOptions}
-import zio._
-import zio.blocking.Blocking
-import zio.interop.reactivestreams._
-import zio.stream.{Stream, ZStream}
+import _root_.zio._
+import _root_.zio.blocking.Blocking
+import _root_.zio.interop.reactivestreams._
+import _root_.zio.stream.{Stream, ZStream}
 
 import scala.util.{Success, Try}
 
@@ -151,6 +150,13 @@ object HttpClientZioBackend {
     *
     * See [[SttpBackendStub]] for details on how to configure stub responses.
     */
-  def stub: SttpBackendStub[BlockingTask, ZStream[Blocking, Throwable, Byte], NothingT] =
+  def stub: SttpBackendStub[BlockingTask, ZStream[Blocking, Throwable, Byte], WebSocketHandler] =
     SttpBackendStub(new RIOMonadAsyncError[Blocking])
+
+  val stubLayer: ZLayer[Any,
+                        Nothing,
+                        Has[zio.SttpClientStubbing.Service] with Has[
+                          SttpBackend[BlockingTask, ZStream[Blocking, Throwable, Byte], WebSocketHandler]
+                        ]] =
+    SttpClientStubbing.layer
 }

--- a/httpclient-backend/zio/src/main/scala/sttp/client/httpclient/zio/ZioWebSocketHandler.scala
+++ b/httpclient-backend/zio/src/main/scala/sttp/client/httpclient/zio/ZioWebSocketHandler.scala
@@ -5,7 +5,6 @@ import sttp.client.httpclient.internal.NativeWebSocketHandler
 import sttp.client.impl.zio.RIOMonadAsyncError
 import sttp.client.ws.{WebSocket, WebSocketEvent}
 import sttp.client.ws.internal.AsyncQueue
-import sttp.model.ws.WebSocketBufferFull
 import zio.{Queue, Runtime, Task, ZIO}
 
 object ZioWebSocketHandler {

--- a/httpclient-backend/zio/src/test/scala/sttp/client/httpclient/zio/HttpClientZioHttpTest.scala
+++ b/httpclient-backend/zio/src/test/scala/sttp/client/httpclient/zio/HttpClientZioHttpTest.scala
@@ -1,6 +1,5 @@
 package sttp.client.httpclient.zio
 
-import sttp.client.httpclient.zio.BlockingTask
 import sttp.client._
 import sttp.client.impl.zio._
 import sttp.client.testing.{ConvertToFuture, HttpTest}
@@ -14,7 +13,7 @@ class HttpClientZioHttpTest extends HttpTest[BlockingTask] {
     "SttpClient usage" in {
       import zio.blocking._
       val request = basicRequest.post(uri"http://example.com").body("hello")
-      SttpClient.send(request).provideSomeLayer(HttpClientZioBackend.layer()).provideLayer(Blocking.live)
+      SttpClient.send(request).provideLayer(Blocking.live >+> HttpClientZioBackend.layer())
       succeed
     }
   }

--- a/httpclient-backend/zio/src/test/scala/sttp/client/httpclient/zio/SttpBackendStubZioTests.scala
+++ b/httpclient-backend/zio/src/test/scala/sttp/client/httpclient/zio/SttpBackendStubZioTests.scala
@@ -1,0 +1,103 @@
+package sttp.client.httpclient.zio
+
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import sttp.client._
+import sttp.client.impl.zio._
+import sttp.client.monad.MonadError
+import sttp.client.testing.SttpBackendStub
+import sttp.client.ws.{WebSocket, WebSocketEvent}
+import sttp.model.{Headers, Method}
+import sttp.model.ws.WebSocketFrame
+import zio.blocking.Blocking
+import zio.{Queue, Task}
+import zio.stream.ZStream
+
+class SttpBackendStubZioTests extends AnyFlatSpec with Matchers with ScalaFutures {
+
+  "backend stub" should "cycle through responses using a single sent request" in {
+    // given
+    implicit val b: SttpBackendStub[Task, Nothing, NothingT] = SttpBackendStub(new RIOMonadAsyncError[Any])
+      .whenRequestMatches(_ => true)
+      .thenRespondCyclic("a", "b", "c")
+
+    // when
+    val r = basicRequest.get(uri"http://example.org/a/b/c").send()
+
+    // then
+    runtime.unsafeRun(r).body shouldBe Right("a")
+    runtime.unsafeRun(r).body shouldBe Right("b")
+    runtime.unsafeRun(r).body shouldBe Right("c")
+    runtime.unsafeRun(r).body shouldBe Right("a")
+  }
+
+  it should "return given web socket response" in {
+    val rioMonad: MonadError[zio.RIO[Blocking, *]] = new RIOMonadAsyncError[Blocking]
+    val frame1 = WebSocketFrame.text("initial frame")
+    val sentFrame = WebSocketFrame.text("sent frame")
+
+    def webSocket(queue: Queue[WebSocketFrame.Incoming]) =
+      new WebSocket[zio.RIO[Blocking, *]] {
+        override def isOpen: zio.Task[Boolean] = Task.succeed(true)
+
+        override def monad: MonadError[zio.RIO[Blocking, *]] = rioMonad
+
+        override def receive: zio.Task[Either[WebSocketEvent.Close, WebSocketFrame.Incoming]] = queue.take.map(Right(_))
+
+        override def send(f: WebSocketFrame, isContinuation: Boolean): zio.RIO[Blocking, Unit] =
+          f match {
+            case t: WebSocketFrame.Text => queue.offer(t).unit
+            case _                      => Task.unit
+          }
+      }
+
+    def makeBackend(queue: Queue[WebSocketFrame.Incoming]) =
+      HttpClientZioBackend.stub
+        .whenRequestMatches(_ => true)
+        .thenRespondWebSocket(Headers(List.empty), webSocket(queue))
+
+    val test = for {
+      queue <- Queue.unbounded[WebSocketFrame.Incoming]
+      _ <- queue.offer(frame1)
+      backend = makeBackend(queue)
+      handler <- ZioWebSocketHandler()
+      request = basicRequest.get(uri"http://example.org/a/b/c")
+      ws <- backend.openWebsocket(request, handler).map(_.result)
+      msg1 <- ws.receive
+      _ <- ws.send(sentFrame, false)
+      msg2 <- ws.receive
+    } yield (msg1, msg2)
+
+    runtime.unsafeRun(test) shouldBe ((Right(frame1), Right(sentFrame)))
+  }
+
+  it should "allow effectful stubbing" in {
+    import stubbing._
+    val r1 = SttpClient.send(basicRequest.get(uri"http://example.org/a")).map(_.body)
+    val r2 = SttpClient.send(basicRequest.post(uri"http://example.org/a/b")).map(_.body)
+    val r3 = SttpClient.send(basicRequest.get(uri"http://example.org/a/b/c")).map(_.body)
+
+    val effect = for {
+      _ <- whenRequestMatches(_.uri.toString.endsWith("c")).thenRespond("c")
+      _ <- whenRequestMatchesPartial { case r if r.method == Method.POST => Response.ok("b") }
+      _ <- whenAnyRequest.thenRespond("a")
+      resp <- r1 <&> r2 <&> r3
+    } yield resp
+
+    runtime.unsafeRun(effect.provideCustomLayer(HttpClientZioBackend.stubLayer)) shouldBe
+      (((Right("a"), Right("b")), Right("c")))
+  }
+
+  it should "allow effectful cyclical stubbing" in {
+    import stubbing._
+    val r = basicRequest.get(uri"http://example.org/a/b/c")
+
+    val effect = (for {
+      _ <- whenAnyRequest.thenRespondCyclic("a", "b", "c")
+      resp <- ZStream.repeatEffect(SttpClient.send(r)).take(4).runCollect
+    } yield resp).provideCustomLayer(HttpClientZioBackend.stubLayer)
+
+    runtime.unsafeRun(effect).map(_.body).toList shouldBe List(Right("a"), Right("b"), Right("c"), Right("a"))
+  }
+}

--- a/implementations/zio/src/main/scala/sttp/client/impl/zio/SttpClientStubbingBase.scala
+++ b/implementations/zio/src/main/scala/sttp/client/impl/zio/SttpClientStubbingBase.scala
@@ -35,7 +35,7 @@ trait SttpClientStubbingBase[R, S, WS_HANDLER[_]] {
     ) = stub.update(f)
   }
 
-  case class StubbingWhenRequest private[zio] (p: Request[_, _] => Boolean) {
+  case class StubbingWhenRequest private[sttp] (p: Request[_, _] => Boolean) {
     implicit val _serviceTag: Tag[Service] = serviceTag
     val thenRespondOk: URIO[SttpClientStubbing, Unit] =
       thenRespondWithCode(StatusCode.Ok)

--- a/implementations/zio/src/main/scala/sttp/client/impl/zio/SttpClientStubbingBase.scala
+++ b/implementations/zio/src/main/scala/sttp/client/impl/zio/SttpClientStubbingBase.scala
@@ -1,0 +1,122 @@
+package sttp.client.impl.zio
+
+import sttp.client.monad.MonadError
+import sttp.client.testing.{SttpBackendStub, WebSocketStub}
+import sttp.client.ws.WebSocketResponse
+import sttp.client.{Request, Response, SttpBackend}
+import sttp.model.{Headers, StatusCode}
+import zio.{Has, Queue, RIO, Ref, Tag, UIO, URIO, ZLayer}
+
+trait SttpClientStubbingBase[R, S, WS_HANDLER[_]] {
+
+  type SttpClientStubbing = Has[Service]
+  // the tag as viewed by the implementing object. Needs to be passed explicitly, otherwise Has[] breaks.
+  private[sttp] def serviceTag: Tag[Service]
+  private[sttp] def sttpBackendTag: Tag[SttpBackend[RIO[R, *], S, WS_HANDLER]]
+
+  trait Service {
+    def whenRequestMatchesPartial(
+        partial: PartialFunction[Request[_, _], Response[_]]
+    ): URIO[SttpClientStubbing, Unit]
+
+    private[zio] def update(
+        f: SttpBackendStub[RIO[R, *], S, WS_HANDLER] => SttpBackendStub[RIO[R, *], S, WS_HANDLER]
+    ): UIO[Unit]
+  }
+
+  private[sttp] class StubWrapper(stub: Ref[SttpBackendStub[RIO[R, *], S, WS_HANDLER]]) extends Service {
+    override def whenRequestMatchesPartial(
+        partial: PartialFunction[Request[_, _], Response[_]]
+    ): URIO[SttpClientStubbing, Unit] =
+      update(_.whenRequestMatchesPartial(partial))
+
+    override private[zio] def update(
+        f: SttpBackendStub[RIO[R, *], S, WS_HANDLER] => SttpBackendStub[RIO[R, *], S, WS_HANDLER]
+    ) = stub.update(f)
+  }
+
+  case class StubbingWhenRequest private[zio] (p: Request[_, _] => Boolean) {
+    implicit val _serviceTag: Tag[Service] = serviceTag
+    val thenRespondOk: URIO[SttpClientStubbing, Unit] =
+      thenRespondWithCode(StatusCode.Ok)
+
+    def thenRespondNotFound(): URIO[SttpClientStubbing, Unit] =
+      thenRespondWithCode(StatusCode.NotFound, "Not found")
+
+    def thenRespondServerError(): URIO[SttpClientStubbing, Unit] =
+      thenRespondWithCode(StatusCode.InternalServerError, "Internal server error")
+
+    def thenRespondWithCode(status: StatusCode, msg: String = ""): URIO[SttpClientStubbing, Unit] = {
+      thenRespond(Response(msg, status, msg))
+    }
+
+    def thenRespond[T](body: T): URIO[SttpClientStubbing, Unit] =
+      thenRespond(Response[T](body, StatusCode.Ok, "OK"))
+
+    def thenRespond[T](resp: => Response[T]): URIO[SttpClientStubbing, Unit] =
+      URIO.accessM(_.get.update(_.whenRequestMatches(p).thenRespond(resp)))
+
+    def thenRespondCyclic[T](bodies: T*): URIO[SttpClientStubbing, Unit] = {
+      thenRespondCyclicResponses(bodies.map(body => Response[T](body, StatusCode.Ok, "OK")): _*)
+    }
+
+    def thenRespondCyclicResponses[T](responses: Response[T]*): URIO[SttpClientStubbing, Unit] = {
+      for {
+        q <- Queue.bounded[Response[T]](responses.length)
+        _ <- q.offerAll(responses)
+        _ <- thenRespondWrapped(q.take.flatMap(t => q.offer(t) as t))
+      } yield ()
+    }
+
+    def thenRespondWrapped(resp: => RIO[R, Response[_]]): URIO[SttpClientStubbing, Unit] = {
+      val m: PartialFunction[Request[_, _], RIO[R, Response[_]]] = {
+        case r if p(r) => resp
+      }
+      URIO.accessM(_.get.update(_.whenRequestMatches(p).thenRespondWrapped(m)))
+    }
+
+    def thenRespondWrapped(resp: Request[_, _] => RIO[R, Response[_]]): URIO[SttpClientStubbing, Unit] = {
+      val m: PartialFunction[Request[_, _], RIO[R, Response[_]]] = {
+        case r if p(r) => resp(r)
+      }
+      URIO.accessM(_.get.update(_.whenRequestMatches(p).thenRespondWrapped(m)))
+    }
+
+    def thenRespondWebSocket[WS_RESULT](result: WS_RESULT): URIO[SttpClientStubbing, Unit] =
+      thenRespondWebSocket(Headers(List.empty), result)
+
+    def thenRespondWebSocket[WS_RESULT](headers: Headers, result: WS_RESULT): URIO[SttpClientStubbing, Unit] =
+      URIO.accessM(_.get.update(_.whenRequestMatches(p).thenRespondWebSocket(headers, result)))
+
+    def thenRespondWebSocket(wsStub: WebSocketStub[_]): URIO[SttpClientStubbing, Unit] =
+      thenRespondWebSocket(Headers(List.empty), wsStub)
+
+    def thenRespondWebSocket(headers: Headers, wsStub: WebSocketStub[_]): URIO[SttpClientStubbing, Unit] =
+      URIO.accessM(_.get.update(_.whenRequestMatches(p).thenRespondWebSocket(headers, wsStub)))
+  }
+
+  val layer: ZLayer[Any, Nothing, Has[Service] with Has[SttpBackend[RIO[R, *], S, WS_HANDLER]]] = {
+    val monad = new RIOMonadAsyncError[R]
+    implicit val _serviceTag: Tag[Service] = serviceTag
+    implicit val _backendTag: Tag[SttpBackend[RIO[R, *], S, WS_HANDLER]] = sttpBackendTag
+    ZLayer.fromEffectMany(for {
+      stub <- Ref.make(SttpBackendStub[RIO[R, *], S, WS_HANDLER](monad))
+      stubber = new StubWrapper(stub)
+      proxy = new SttpBackend[RIO[R, *], S, WS_HANDLER] {
+        override def send[T](request: Request[T, S]): RIO[R, Response[T]] =
+          stub.get >>= (_.send(request))
+
+        override def openWebsocket[T, WS_RESULT](
+            request: Request[T, S],
+            handler: WS_HANDLER[WS_RESULT]
+        ): RIO[R, WebSocketResponse[WS_RESULT]] =
+          stub.get >>= (_.openWebsocket(request, handler))
+
+        override def close(): RIO[R, Unit] =
+          stub.get >>= (_.close())
+
+        override def responseMonad: MonadError[RIO[R, *]] = monad
+      }
+    } yield Has.allOf[Service, SttpBackend[RIO[R, *], S, WS_HANDLER]](stubber, proxy))
+  }
+}


### PR DESCRIPTION
Before submitting pull request:
- [x] Check if the project compiles by running `sbt compile`
- [x] Verify docs compilation by running `sbt compileDocs`
- [x] Check if tests pass by running `sbt test`
- [x] Format code by running `sbt scalafmt`

This PR adds a more ergonomic subbing syntax to the ZIO backend. This allows the stubbing to be composed in a for comprehension, example in the tests.