### PR TITLE
Links in Note section of the docs fixed

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -30,7 +30,7 @@
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = []
+extensions = ['recommonmark']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/docs/requests/basics.md
+++ b/docs/requests/basics.md
@@ -52,7 +52,7 @@ val response = backend.send(request)
 ```eval_rst
 .. note::
 
-  Only requests with the request method and uri can be sent. If trying to send a request without these components specified, a compile-time error will be reported. On how this is implemented, see the documentation on the `type of request definitions <type.md>`_.
+  Only requests with the request method and uri can be sent. If trying to send a request without these components specified, a compile-time error will be reported. On how this is implemented, see the documentation on the :doc:`type of request definitions <type>`.
 ```
 
 ## Initial requests

--- a/docs/requests/streaming.md
+++ b/docs/requests/streaming.md
@@ -5,7 +5,7 @@ Some backends (see [backends summary](../backends/summary.md)) support streaming
 ```eval_rst
 .. note::
 
- Here, streaming refers to (usually) non-blocking, asynchronous streams of data. To send data which is available as an ``InputStream``, or a file from local storage (which is available as a ``File`` or ``Path``), no special backend support is needed. See the documenttation on `setting the request body <body.md>`_.
+ Here, streaming refers to (usually) non-blocking, asynchronous streams of data. To send data which is available as an ``InputStream``, or a file from local storage (which is available as a ``File`` or ``Path``), no special backend support is needed. See the documenttation on :doc:`setting the request body <body>`.
 ```
 
 For example, using the [akka-http backend](../backends/akka.md), a request with a streaming body can be defined as follows:

--- a/docs/responses/basics.md
+++ b/docs/responses/basics.md
@@ -5,7 +5,7 @@ Responses are represented as instances of the case class `Response[T]`, where `T
 If sending the request fails, either due to client or connection errors, an exception will be thrown (synchronous backends), or an error will be represented in the wrapper (e.g. a failed future).
 
 ```eval_rst
-.. note:: If the request completes, but results in a non-2xx return code, the request is still considered successful, that is, a ``Response[T]`` will be returned. See `response body specifications <body.md>`_ for details on how such cases are handled.
+.. note:: If the request completes, but results in a non-2xx return code, the request is still considered successful, that is, a ``Response[T]`` will be returned. See :doc:`response body specifications <body>` for details on how such cases are handled.
 ```
 
 ## Response code


### PR DESCRIPTION
Before submitting pull request:
- [x] Check if the project compiles by running `sbt compile`
- [x] Verify docs compilation by running `sbt compileDocs`
- [x] Check if tests pass by running `sbt test`
- [x] Format code by running `sbt scalafmt`

this pr fixes  #686
