### PR TITLE
Implement non-blocking gunzip and deflate in HttpClientMonixBackend

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -405,7 +405,7 @@ lazy val monix = (projectMatrix in file("implementations/monix"))
     name := "monix",
     publishArtifact in Test := true,
     libraryDependencies ++= Seq(
-      "io.monix" %%% "monix" % "3.2.2",
+      "io.monix" %%% "monix" % "3.2.2+63-46d91c2e-SNAPSHOT",
       "com.softwaremill.sttp.shared" %%% "monix" % sttpSharedVersion
     )
   )

--- a/docs/backends/summary.md
+++ b/docs/backends/summary.md
@@ -37,7 +37,7 @@ Class                                Effect type                  Supported stre
 ``Http4sBackend``                    ``F[_]: cats.effect.Effect`` ``fs2.Stream[F, Byte]``                           no                         no
 ``HttpClientSyncBackend``            None (``Identity``)          n/a                                               no                         no
 ``HttpClientFutureBackend``          ``scala.concurrent.Future``  n/a                                               yes (regular)              no
-``HttpClientMonixBackend``           ``monix.eval.Task``          ``monix.reactive.Observable[ByteBuffer]``         yes (regular & streaming)  no
+``HttpClientMonixBackend``           ``monix.eval.Task``          ``monix.reactive.Observable[ByteBuffer]``         yes (regular & streaming)  yes
 ``HttpClientFs2Backend``             ``F[_]: cats.effect.Async``  ``fs2.Stream[F, Byte]``                           yes (regular & streaming)  yes
 ``HttpClientZioBackend``             ``zio.Task``                 ``zio.stream.Stream[Throwable, Byte]``            yes (regular & streaming)  yes
 ``FinagleBackend``                   ``com.twitter.util.Future``  n/a                                               no                         no

--- a/httpclient-backend/monix/src/main/scala/sttp/client3/httpclient/monix/HttpClientMonixBackend.scala
+++ b/httpclient-backend/monix/src/main/scala/sttp/client3/httpclient/monix/HttpClientMonixBackend.scala
@@ -62,7 +62,7 @@ class HttpClientMonixBackend private (
   override protected def publisherToBody(p: Publisher[util.List[ByteBuffer]]): Observable[ByteBuffer] = {
     Observable
       .fromReactivePublisher(p)
-      .map(list => ByteBuffer.wrap(list.asScala.toList.flatMap(_.safeRead()).toArray))
+      .flatMapIterable(list => list.asScala.toList)
   }
 
   override protected def emptyBody(): Observable[ByteBuffer] = Observable.empty

--- a/httpclient-backend/monix/src/main/scala/sttp/client3/httpclient/monix/HttpClientMonixBackend.scala
+++ b/httpclient-backend/monix/src/main/scala/sttp/client3/httpclient/monix/HttpClientMonixBackend.scala
@@ -62,7 +62,7 @@ class HttpClientMonixBackend private (
   override protected def publisherToBody(p: Publisher[util.List[ByteBuffer]]): Observable[ByteBuffer] = {
     Observable
       .fromReactivePublisher(p)
-      .flatMapIterable(list => list.asScala.toList)
+      .flatMapIterable(_.asScala.toList)
   }
 
   override protected def emptyBody(): Observable[ByteBuffer] = Observable.empty

--- a/httpclient-backend/monix/src/main/scala/sttp/client3/httpclient/monix/HttpClientMonixBackend.scala
+++ b/httpclient-backend/monix/src/main/scala/sttp/client3/httpclient/monix/HttpClientMonixBackend.scala
@@ -1,29 +1,30 @@
 package sttp.client3.httpclient.monix
 
-import java.io.{InputStream, UnsupportedEncodingException}
+import java.io.UnsupportedEncodingException
 import java.net.http.HttpRequest.BodyPublishers
 import java.net.http.{HttpClient, HttpRequest}
 import java.nio.ByteBuffer
 import java.util
-import java.util.zip.{GZIPInputStream, InflaterInputStream}
 
 import cats.effect.Resource
 import monix.eval.Task
 import monix.execution.Scheduler
 import monix.reactive.Observable
+import monix.reactive.compression._
 import org.reactivestreams.{FlowAdapters, Publisher}
 import sttp.capabilities.WebSockets
 import sttp.capabilities.monix.MonixStreams
 import sttp.client3.httpclient.HttpClientBackend.EncodingHandler
-import sttp.client3.httpclient.monix.HttpClientMonixBackend.MonixEncodingHandler
 import sttp.client3.httpclient._
-import sttp.client3.impl.monix.{MonixSimpleQueue, MonixWebSockets, TaskMonadAsyncError}
+import sttp.client3.httpclient.monix.HttpClientMonixBackend.MonixEncodingHandler
+import sttp.client3.impl.monix.{MonixSimpleQueue, TaskMonadAsyncError}
 import sttp.client3.internal._
 import sttp.client3.internal.ws.SimpleQueue
 import sttp.client3.testing.SttpBackendStub
 import sttp.client3.{FollowRedirectsBackend, SttpBackend, SttpBackendOptions}
 import sttp.monad.MonadError
-import sttp.ws.{WebSocket, WebSocketFrame}
+
+import scala.collection.JavaConverters._
 
 class HttpClientMonixBackend private (
     client: HttpClient,
@@ -31,7 +32,7 @@ class HttpClientMonixBackend private (
     customizeRequest: HttpRequest => HttpRequest,
     customEncodingHandler: MonixEncodingHandler
 )(implicit s: Scheduler)
-    extends HttpClientAsyncBackend[Task, MonixStreams, MonixStreams with WebSockets, InputStream](
+    extends HttpClientAsyncBackend[Task, MonixStreams, MonixStreams with WebSockets, MonixStreams.BinaryStream](
       client,
       TaskMonadAsyncError,
       closeClient,
@@ -49,47 +50,32 @@ class HttpClientMonixBackend private (
         monad.eval(BodyPublishers.fromPublisher(FlowAdapters.toFlowPublisher(stream.toReactivePublisher)))
     }
 
-  override protected val bodyFromHttpClient: BodyFromHttpClient[Task, MonixStreams, InputStream] =
-    new InputStreamBodyFromHttpClient[Task, MonixStreams] {
-      override def inputStreamToStream(is: InputStream): Task[(streams.BinaryStream, () => Task[Unit])] = {
-        Task.eval {
-          (
-            Observable
-              .fromInputStream(Task.now(is))
-              .map(ByteBuffer.wrap)
-              .guaranteeCase(_ => Task(is.close())),
-            () => Task.eval(is.close())
-          )
-        }
-      }
-      override val streams: MonixStreams = MonixStreams
-      override implicit def monad: MonadError[Task] = TaskMonadAsyncError
-      override def compileWebSocketPipe(
-          ws: WebSocket[Task],
-          pipe: Observable[WebSocketFrame.Data[_]] => Observable[WebSocketFrame]
-      ): Task[Unit] = MonixWebSockets.compilePipe(ws, pipe)
+  override protected val bodyFromHttpClient: BodyFromHttpClient[Task, MonixStreams, MonixStreams.BinaryStream] =
+    new MonixBodyFromHttpClient {
+      override implicit def scheduler: Scheduler = s
+      override implicit def monad: MonadError[Task] = responseMonad
     }
 
   override protected def createSimpleQueue[T]: Task[SimpleQueue[Task, T]] =
     Task.eval(new MonixSimpleQueue[T](None))
 
-  override protected def publisherToBody(p: Publisher[util.List[ByteBuffer]]): InputStream = {
-    val subscriber = new InputStreamSubscriber
-    p.subscribe(subscriber)
-    subscriber.inputStream
+  override protected def publisherToBody(p: Publisher[util.List[ByteBuffer]]): Observable[ByteBuffer] = {
+    Observable
+      .fromReactivePublisher(p)
+      .map(list => ByteBuffer.wrap(list.asScala.toList.flatMap(_.safeRead()).toArray))
   }
 
-  override protected def emptyBody(): InputStream = emptyInputStream()
+  override protected def emptyBody(): Observable[ByteBuffer] = Observable.empty
 
-  override protected def standardEncoding: (InputStream, String) => InputStream = {
-    case (body, "gzip")    => new GZIPInputStream(body)
-    case (body, "deflate") => new InflaterInputStream(body)
+  override protected def standardEncoding: (Observable[ByteBuffer], String) => Observable[ByteBuffer] = {
+    case (body, "gzip")    => body.map(_.safeRead()).transform(gunzip()).map(ByteBuffer.wrap)
+    case (body, "deflate") => body.map(_.safeRead()).transform(inflate()).map(ByteBuffer.wrap)
     case (_, ce)           => throw new UnsupportedEncodingException(s"Unsupported encoding: $ce")
   }
 }
 
 object HttpClientMonixBackend {
-  type MonixEncodingHandler = EncodingHandler[InputStream]
+  type MonixEncodingHandler = EncodingHandler[MonixStreams.BinaryStream]
 
   private def apply(
       client: HttpClient,

--- a/httpclient-backend/monix/src/main/scala/sttp/client3/httpclient/monix/MonixBodyFromHttpClient.scala
+++ b/httpclient-backend/monix/src/main/scala/sttp/client3/httpclient/monix/MonixBodyFromHttpClient.scala
@@ -1,0 +1,73 @@
+package sttp.client3.httpclient.monix
+
+import java.nio.ByteBuffer
+import java.nio.file.StandardOpenOption
+
+import monix.eval.Task
+import monix.execution.Scheduler
+import monix.reactive.{Consumer, Observable}
+import sttp.capabilities.monix.MonixStreams
+import sttp.client3.httpclient.BodyFromHttpClient
+import sttp.client3.impl.monix.MonixWebSockets
+import sttp.client3.internal.{BodyFromResponseAs, RichByteBuffer, SttpFile}
+import sttp.client3.ws.{GotAWebSocketException, NotAWebSocketException}
+import sttp.client3.{ResponseMetadata, WebSocketResponseAs}
+import sttp.ws.{WebSocket, WebSocketFrame}
+import monix.nio.file._
+
+trait MonixBodyFromHttpClient extends BodyFromHttpClient[Task, MonixStreams, MonixStreams.BinaryStream] {
+  override val streams: MonixStreams = MonixStreams
+  implicit def scheduler: Scheduler
+
+  override def compileWebSocketPipe(
+      ws: WebSocket[Task],
+      pipe: Observable[WebSocketFrame.Data[_]] => Observable[WebSocketFrame]
+  ): Task[Unit] =
+    MonixWebSockets.compilePipe(ws, pipe)
+
+  override protected def bodyFromResponseAs
+      : BodyFromResponseAs[Task, Observable[ByteBuffer], WebSocket[Task], Observable[ByteBuffer]] = {
+    new BodyFromResponseAs[Task, MonixStreams.BinaryStream, WebSocket[Task], MonixStreams.BinaryStream]() {
+      override protected def withReplayableBody(
+          response: Observable[ByteBuffer],
+          replayableBody: Either[Array[Byte], SttpFile]
+      ): Task[Observable[ByteBuffer]] = {
+        replayableBody match {
+          case Left(value) => Task.pure(Observable.now(ByteBuffer.wrap(value)))
+          case Right(file) => Task.pure(readAsync(file.toPath, 32 * 1024).map(ByteBuffer.wrap))
+        }
+      }
+
+      override protected def regularIgnore(response: Observable[ByteBuffer]): Task[Unit] =
+        response.consumeWith(Consumer.complete)
+
+      override protected def regularAsByteArray(response: Observable[ByteBuffer]): Task[Array[Byte]] =
+        response.consumeWith(Consumer.foldLeft(Array.emptyByteArray)((acc, item) => acc ++ item.safeRead()))
+
+      override protected def regularAsFile(response: Observable[ByteBuffer], file: SttpFile): Task[SttpFile] =
+        response
+          .map(_.safeRead())
+          .consumeWith(writeAsync(file.toPath, Seq(StandardOpenOption.WRITE, StandardOpenOption.CREATE)))
+          .as(file)
+
+      override protected def regularAsStream(
+          response: Observable[ByteBuffer]
+      ): Task[(Observable[ByteBuffer], () => Task[Unit])] =
+        Task.pure((response, () => response.consumeWith(Consumer.complete).onErrorFallbackTo(Task.unit)))
+
+      override protected def handleWS[T](
+          responseAs: WebSocketResponseAs[T, _],
+          meta: ResponseMetadata,
+          ws: WebSocket[Task]
+      ): Task[T] = bodyFromWs(responseAs, ws)
+
+      override protected def cleanupWhenNotAWebSocket(
+          response: Observable[ByteBuffer],
+          e: NotAWebSocketException
+      ): Task[Unit] = response.consumeWith(Consumer.complete)
+
+      override protected def cleanupWhenGotWebSocket(response: WebSocket[Task], e: GotAWebSocketException): Task[Unit] =
+        response.close()
+    }
+  }
+}


### PR DESCRIPTION
Before submitting pull request:
- [ ] Check if the project compiles by running `sbt compile`
- [ ] Verify docs compilation by running `sbt compileDocs`
- [ ] Check if tests pass by running `sbt test`
- [X] Format code by running `sbt scalafmt`


This build uses a snapshot version of monix (since compression hasn't been released yet), just to verify that all the things work together. Once confirmed we might want to trigger a monix release. 

It seems that we'll  need to revisit our decision of using `ByteBuffer` as an internal representation of chunk in monix streams, because both monix and monix-nio take different approach - they use `Array[Byte]`. How one is better than another?

Side note: This snapshot version also contains `bufferWhileInclusive` operator which could greatly simplify `MonixWebSocket` code, but it doesn't work for some reason. A further debugging will be needed.
