### PR TITLE
Fix handling of host header in finagle-backend

### DIFF
--- a/finagle-backend/src/test/scala/sttp/client3/finagle/FinagleBackendTest.scala
+++ b/finagle-backend/src/test/scala/sttp/client3/finagle/FinagleBackendTest.scala
@@ -1,10 +1,11 @@
 package sttp.client3.finagle
 
-import sttp.client3.SttpBackend
 import com.twitter.util.{Return, Throw, Future => TFuture}
 import sttp.client3.testing.{ConvertToFuture, HttpTest}
 
+import sttp.client3.{SttpBackend, _}
 import scala.concurrent.{Future, Promise}
+import sttp.client3.testing.HttpTest.endpoint
 
 class FinagleBackendTest extends HttpTest[TFuture] {
 
@@ -21,4 +22,13 @@ class FinagleBackendTest extends HttpTest[TFuture] {
   }
   override def throwsExceptionOnUnsupportedEncoding = false
   override def supportsCustomMultipartContentType = false
+
+  "Host header" - {
+    "Should not send the URL's hostname as the host header" in {
+      basicRequest.get(uri"$endpoint/echo/headers").header("Host", "test.com").response(asStringAlways).send(backend).toFuture().map { response =>
+        response.body should include("Host->test.com")
+        response.body should not include "Host->localhost"
+      }
+    }
+  }
 }


### PR DESCRIPTION
Prior to this change, the finagle backend did not handle the `Host:` HTTP header correctly.

Invoking a request to a URL (for example, directly at an IP address) and setting a `Host:` header would result in two hosts being sent. This is because of a weird quirk in the FinagleRequestBuilder.

Example:

```
basicRequest
  .get(uri"127.0.0.1/my-resource")
  .header("Host", "my-service-name")
  .send()
```

Would create an invalid HTTP request with two host headers, a la:

```
  curl 127.0.0.1/my-resource \
    -H "Host: 127.0.0.1" \
    -H "Host: my-service-name"
```

This isn't what we want, nor is it actually a valid HTTP request at all.

For context, my datacenter has a mesh proxy setup where each service connects
to other services via a proxy, who delegates to the right service via the HTTP
`Host` header. Without this change, I cannot use STTP for my service-to-service
communication, since the Finagle backend is doing this unintuitive thing.

Before submitting pull request:
- [x] Check if the project compiles by running `sbt compile`
- [x] Verify docs compilation by running `sbt compileDocs`
- [x] Check if tests pass by running `sbt test`
- [x] Format code by running `sbt scalafmt`
