### PR TITLE
Don't explicitly set Content-Type on multipart/form-data requests

### DIFF
--- a/core/src/test/scala/sttp/client3/testing/HttpTest.scala
+++ b/core/src/test/scala/sttp/client3/testing/HttpTest.scala
@@ -371,6 +371,13 @@ trait HttpTest[F[_]]
       req.send(backend).toFuture().map { resp => resp.body should be(s"p1=v1$defaultFileName, p2=v2$defaultFileName") }
     }
 
+    "send a multipart message with an explicitly set content type header" in {
+      val req = mp
+        .multipartBody(multipart("p1", "v1"), multipart("p2", "v2"))
+        .contentType("multipart/form-data")
+      req.send(backend).toFuture().map { resp => resp.body should be(s"p1=v1$defaultFileName, p2=v2$defaultFileName") }
+    }
+
     "send a multipart message with filenames" in {
       val req = mp.multipartBody(multipart("p1", "v1").fileName("f1"), multipart("p2", "v2").fileName("f2"))
       req.send(backend).toFuture().map { resp => resp.body should be("p1=v1 (f1), p2=v2 (f2)") }

--- a/core/src/test/scalajs/sttp/client3/testing/HttpTestExtensions.scala
+++ b/core/src/test/scalajs/sttp/client3/testing/HttpTestExtensions.scala
@@ -87,5 +87,16 @@ trait HttpTestExtensions[F[_]] extends AsyncExecutionContext { self: HttpTest[F]
         }
       }
     }
+
+    "throw an exception when trying to send a multipart message with an unsupported content type" in {
+      val req = basicRequest
+        .post(uri"$endpoint/multipart/other")
+        .response(asStringAlways)
+        .multipartBody(multipart("p1", "v1"))
+        .contentType("multipart/mixed")
+      assertThrows[IllegalArgumentException](
+        req.send(backend).toFuture()
+      )
+    }
   }
 }


### PR DESCRIPTION
This came up in https://github.com/softwaremill/tapir/pull/860

Before submitting pull request:
- [X] Check if the project compiles by running `sbt compile`
- [X] Verify docs compilation by running `sbt compileDocs`
- [X] Check if tests pass by running `sbt test`
- [X] Format code by running `sbt scalafmt`
