### PR TITLE
HttpClientBackend: fixed binary subparts' headers of a multipart request

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -146,7 +146,7 @@ val scalaTest = libraryDependencies ++= Seq("freespec", "funsuite", "flatspec", 
 val zioVersion = "1.0.3"
 val zioInteropRsVersion = "1.3.0.7-2"
 
-val sttpModelVersion = "1.2.0-RC5"
+val sttpModelVersion = "1.2.0-RC6"
 val sttpSharedVersion = "1.0.0-RC8"
 
 val logback = "ch.qos.logback" % "logback-classic" % "1.2.3"

--- a/core/src/test/scala/sttp/client3/testing/HttpTest.scala
+++ b/core/src/test/scala/sttp/client3/testing/HttpTest.scala
@@ -383,6 +383,18 @@ trait HttpTest[F[_]]
       req.send(backend).toFuture().map { resp => resp.body should be("p1=v1 (f1), p2=v2 (f2)") }
     }
 
+    "send a multipart message with binary data and filename" in {
+      val binaryPart = {
+        multipart("p1", "v1".getBytes)
+          .fileName("f1")
+      }
+      val req = mp.multipartBody(binaryPart)
+      req.send(backend).toFuture().map { resp =>
+        resp.body should include("f1")
+        resp.body should include("v1")
+      }
+    }
+
     if (supportsCustomMultipartContentType) {
       "send a multipart message with custom content type" in {
         val req = basicRequest

--- a/httpclient-backend/src/main/scala/sttp/client3/httpclient/MultiPartBodyPublisher.java
+++ b/httpclient-backend/src/main/scala/sttp/client3/httpclient/MultiPartBodyPublisher.java
@@ -48,13 +48,12 @@ public class MultiPartBodyPublisher {
         return this;
     }
 
-    public MultiPartBodyPublisher addPart(String name, Supplier<InputStream> value, String filename, String contentType) {
+    public MultiPartBodyPublisher addPart(String name, Supplier<InputStream> value, Map<String, String> headers) {
         PartsSpecification newPart = new PartsSpecification();
         newPart.type = PartsSpecification.TYPE.STREAM;
         newPart.name = name;
         newPart.stream = value;
-        newPart.filename = filename;
-        newPart.contentType = contentType;
+        newPart.headers = headers;
         partsSpecificationList.add(newPart);
         return this;
     }
@@ -77,8 +76,6 @@ public class MultiPartBodyPublisher {
         String value;
         Path path;
         Supplier<InputStream> stream;
-        String filename;
-        String contentType;
         Map<String, String> headers = new HashMap<>();
     }
 


### PR DESCRIPTION
Before submitting pull request:
- [x] Check if the project compiles by running `sbt compile`
- [x] Verify docs compilation by running `sbt compileDocs`
- [x] Check if tests pass by running `sbt test`
- [x] Format code by running `sbt scalafmt`

This fixes https://github.com/softwaremill/sttp/issues/773
Also depends on fixes to sttp-model https://github.com/softwaremill/sttp-model/pull/45
