### PR TITLE
add setOpenTracingParentSpanContext to OpenTracingBackend

### DIFF
--- a/metrics/open-tracing-backend/src/main/scala/sttp/client3/opentracing/OpenTracingBackend.scala
+++ b/metrics/open-tracing-backend/src/main/scala/sttp/client3/opentracing/OpenTracingBackend.scala
@@ -1,7 +1,7 @@
 package sttp.client3.opentracing
 
 import io.opentracing.tag.Tags
-import io.opentracing.{Span, Tracer}
+import io.opentracing.{Span, SpanContext, Tracer}
 import io.opentracing.propagation.Format
 import io.opentracing.Tracer.SpanBuilder
 import sttp.capabilities.Effect
@@ -91,6 +91,10 @@ object OpenTracingBackend {
     /** Sets parent Span for OpenTracing Span of this request execution. */
     def setOpenTracingParentSpan(parent: Span): Request[T, S] =
       tagWithTransformSpanBuilder(_.asChildOf(parent))
+
+    /** Sets parent SpanContext for OpenTracing Span of this request execution. */
+    def setOpenTracingParentSpanContext(parentSpanContext: SpanContext): Request[T, S] =
+      tagWithTransformSpanBuilder(_.asChildOf(parentSpanContext))
   }
 
   def apply[F[_], P](delegate: SttpBackend[F, P], tracer: Tracer): SttpBackend[F, P] = {


### PR DESCRIPTION
Before submitting pull request:
- [X] Check if the project compiles by running `sbt compile`
- [X] Verify docs compilation by running `sbt compileDocs`
- [X] Check if tests pass by running `sbt test`
- [X] Format code by running `sbt scalafmt`

Adding `setOpenTracingParentSpanContext` to `OpenTracingBackend` as we don't usually have the current span available and have to build span context from B3 headers (e.g. in the case of Zipkin). 

If we create a new Span just so we can pass it to `OpenTracingBackend.setOpenTracingParentSpan` we have unnecessary additional trace/noise in tracing output. 

Also, there's no way to get Span out from SpanContext per this issue https://github.com/opentracing/specification/issues/81.
