### PR TITLE
Configure read timeout correctly for Armeria backend

### DIFF
--- a/armeria-backend/cats/src/main/scala/sttp/client3/armeria/cats/ArmeriaCatsBackend.scala
+++ b/armeria-backend/cats/src/main/scala/sttp/client3/armeria/cats/ArmeriaCatsBackend.scala
@@ -36,11 +36,14 @@ object ArmeriaCatsBackend {
 
   /** Creates a new Armeria backend, using the given or default `SttpBackendOptions`. Due to these customisations,
     * the client will manage its own connection pool. If you'd like to reuse the default Armeria `ClientFactory`,
-    * use `.usingDefaultClient`. */
+    * use `.usingDefaultClient`.
+    */
   def apply[F[_]: Concurrent](options: SttpBackendOptions = SttpBackendOptions.Default): SttpBackend[F, Any] =
     apply(newClient(options), closeFactory = true)
 
-  def resource[F[_]: Concurrent](options: SttpBackendOptions = SttpBackendOptions.Default): Resource[F, SttpBackend[F, Any]] = {
+  def resource[F[_]: Concurrent](
+      options: SttpBackendOptions = SttpBackendOptions.Default
+  ): Resource[F, SttpBackend[F, Any]] = {
     Resource.make(Sync[F].delay(apply(newClient(options), closeFactory = true)))(_.close())
   }
 

--- a/armeria-backend/fs2/src/main/scala/sttp/client3/armeria/fs2/ArmeriaFs2Backend.scala
+++ b/armeria-backend/fs2/src/main/scala/sttp/client3/armeria/fs2/ArmeriaFs2Backend.scala
@@ -43,13 +43,16 @@ object ArmeriaFs2Backend {
 
   /** Creates a new Armeria backend, using the given or default `SttpBackendOptions`. Due to these customisations,
     * the client will manage its own connection pool. If you'd like to reuse the default Armeria `ClientFactory`,
-    * use `.usingDefaultClient`. */
+    * use `.usingDefaultClient`.
+    */
   def apply[F[_]: ConcurrentEffect](
       options: SttpBackendOptions = SttpBackendOptions.Default
   ): SttpBackend[F, Fs2Streams[F]] =
     apply(newClient(options), closeFactory = true)
 
-  def resource[F[_]: ConcurrentEffect](options: SttpBackendOptions = SttpBackendOptions.Default): Resource[F, SttpBackend[F, Fs2Streams[F]]] = {
+  def resource[F[_]: ConcurrentEffect](
+      options: SttpBackendOptions = SttpBackendOptions.Default
+  ): Resource[F, SttpBackend[F, Fs2Streams[F]]] = {
     Resource.make(Sync[F].delay(apply(newClient(options), closeFactory = true)))(_.close())
   }
 

--- a/armeria-backend/fs2/src/test/scala/sttp/client3/armeria/fs2/ArmeriaFs2StreamingTest.scala
+++ b/armeria-backend/fs2/src/test/scala/sttp/client3/armeria/fs2/ArmeriaFs2StreamingTest.scala
@@ -5,9 +5,9 @@ import sttp.capabilities.fs2.Fs2Streams
 import sttp.client3.SttpBackend
 import sttp.client3.impl.fs2.Fs2StreamingTest
 
-class ArmeriaFs2StreamingTest /*extends Fs2StreamingTest {
+class ArmeriaFs2StreamingTest extends Fs2StreamingTest {
   override val backend: SttpBackend[IO, Fs2Streams[IO]] =
     ArmeriaFs2Backend()
 
   override protected def supportsStreamingMultipartParts: Boolean = false
-}*/
+}

--- a/armeria-backend/scalaz/src/main/scala/sttp/client3/armeria/scalaz/ArmeriaScalazBackend.scala
+++ b/armeria-backend/scalaz/src/main/scala/sttp/client3/armeria/scalaz/ArmeriaScalazBackend.scala
@@ -33,9 +33,11 @@ private final class ArmeriaScalazBackend(client: WebClient, closeFactory: Boolea
 }
 
 object ArmeriaScalazBackend {
+
   /** Creates a new Armeria backend, using the given or default `SttpBackendOptions`. Due to these customisations,
     * the client will manage its own connection pool. If you'd like to reuse the default Armeria `ClientFactory`,
-    * use `.usingDefaultClient`. */
+    * use `.usingDefaultClient`.
+    */
   def apply(options: SttpBackendOptions = SttpBackendOptions.Default): SttpBackend[Task, Any] =
     apply(newClient(options), closeFactory = true)
 

--- a/armeria-backend/zio/src/main/scala/sttp/client3/armeria/zio/ArmeriaZioBackend.scala
+++ b/armeria-backend/zio/src/main/scala/sttp/client3/armeria/zio/ArmeriaZioBackend.scala
@@ -39,9 +39,11 @@ private final class ArmeriaZioBackend(runtime: Runtime[Any], client: WebClient, 
 }
 
 object ArmeriaZioBackend {
+
   /** Creates a new Armeria backend, using the given or default `SttpBackendOptions`. Due to these customisations,
     * the client will manage its own connection pool. If you'd like to reuse the default Armeria `ClientFactory`,
-    * use `.usingDefaultClient`. */
+    * use `.usingDefaultClient`.
+    */
   def apply(options: SttpBackendOptions = SttpBackendOptions.Default): Task[SttpBackend[Task, ZioStreams]] =
     ZIO
       .runtime[Any]


### PR DESCRIPTION
Motivation:

Armeria backend did not configure read timeout if default value is used.

Modifications:

- Correctly configure read timeout which is response timeout for Armeria

Result:

- No longer see unexpected read timeout
- Maybe fixes #873

Before submitting pull request:
- [x] Check if the project compiles by running `sbt compile`
- [x] Verify docs compilation by running `sbt compileDocs`
- [x] Check if tests pass by running `sbt test`
- [x] Format code by running `sbt scalafmt`
