### PR TITLE
Update resilience to disclose that sttp does retry

### DIFF
--- a/generated-docs/out/resilience.md
+++ b/generated-docs/out/resilience.md
@@ -12,6 +12,11 @@ All of these are lazily evaluated, and can be repeated. Such a representation al
 
 Still, the input for a particular resilience model might involve both the result (either an exception, or a response) and the original description of the request being sent. E.g. retries can depend on the request method; circuit-breaking can depend on the host, to which the request is sent; same for rate limiting.
 
+## Except that sometimes sttp does retry
+
+Note: Yes, sttp does retry if a [channel is closed](https://github.com/AsyncHttpClient/async-http-client/blob/12f4b2a5654ec7427a10c049d06e3f05dac41f1e/client/src/main/java/org/asynchttpclient/netty/request/NettyRequestSender.java#L265).
+This documentation does not offer advice for working around this feature.
+
 ## Retries
 
 Here's an incomplete list of libraries which can be used to manage retries in various Scala stacks:


### PR DESCRIPTION
Users shouldn't have to debug to discover that sttp does in fact do more than a 1:1 connection.

If your server happens to have an idle timeout (e.g. play at 75 seconds),
and thus the server side's connection closes prematurely,
sttp will merrily retry the connection, and if that fails, it'll merrily try again, and again, ....

Before submitting pull request:
- [ ] Check if the project compiles by running `sbt compile`
- [ ] Verify docs compilation by running `sbt compileDocs`
- [ ] Check if tests pass by running `sbt test`
- [ ] Format code by running `sbt scalafmt`
