### PR TITLE
Exclude CE3 core dependency from `cats` module

### DIFF
--- a/armeria-backend/cats/src/main/scala/sttp/client3/armeria/cats/ArmeriaCatsBackend.scala
+++ b/armeria-backend/cats/src/main/scala/sttp/client3/armeria/cats/ArmeriaCatsBackend.scala
@@ -1,6 +1,6 @@
 package sttp.client3.armeria.cats
 
-import cats.effect.{Async, Resource, Sync}
+import cats.effect.kernel.{Async, Resource, Sync}
 import com.linecorp.armeria.client.WebClient
 import com.linecorp.armeria.common.HttpData
 import com.linecorp.armeria.common.stream.StreamMessage

--- a/armeria-backend/fs2/src/main/scala/sttp/client3/armeria/fs2/ArmeriaFs2Backend.scala
+++ b/armeria-backend/fs2/src/main/scala/sttp/client3/armeria/fs2/ArmeriaFs2Backend.scala
@@ -1,7 +1,7 @@
 package sttp.client3.armeria.fs2
 
 import cats.effect.std.Dispatcher
-import cats.effect.{Async, Resource, Sync}
+import cats.effect.kernel.{Async, Resource, Sync}
 import com.linecorp.armeria.client.WebClient
 import com.linecorp.armeria.common.HttpData
 import com.linecorp.armeria.common.stream.StreamMessage

--- a/async-http-client-backend/cats/src/main/scala/sttp/client3/asynchttpclient/cats/AsyncHttpClientCatsBackend.scala
+++ b/async-http-client-backend/cats/src/main/scala/sttp/client3/asynchttpclient/cats/AsyncHttpClientCatsBackend.scala
@@ -3,7 +3,7 @@ package sttp.client3.asynchttpclient.cats
 import java.io.{ByteArrayInputStream, File}
 import java.nio.ByteBuffer
 
-import cats.effect.{Async, Resource, Sync}
+import cats.effect.kernel.{Async, Resource, Sync}
 import io.netty.buffer.ByteBuf
 import org.asynchttpclient.{
   AsyncHttpClient,

--- a/async-http-client-backend/fs2/src/main/scala/sttp/client3/asynchttpclient/fs2/AsyncHttpClientFs2Backend.scala
+++ b/async-http-client-backend/fs2/src/main/scala/sttp/client3/asynchttpclient/fs2/AsyncHttpClientFs2Backend.scala
@@ -2,7 +2,7 @@ package sttp.client3.asynchttpclient.fs2
 
 import java.io.File
 import java.nio.ByteBuffer
-import cats.effect._
+import cats.effect.kernel._
 import cats.effect.std.{Dispatcher, Queue}
 import cats.implicits._
 import fs2.{Chunk, Pipe, Stream}

--- a/build.sbt
+++ b/build.sbt
@@ -312,7 +312,8 @@ lazy val cats = (projectMatrix in file("effects/cats"))
     name := "cats",
     Test / publishArtifact := true,
     libraryDependencies ++= Seq(
-      "org.typelevel" %%% "cats-effect" % catsEffect_3_version
+      "org.typelevel" %%% "cats-effect-kernel" % catsEffect_3_version,
+      "org.typelevel" %%% "cats-effect" % catsEffect_3_version % Test
     )
   )
   .dependsOn(core % compileAndTest)

--- a/effects/cats/src/main/scala/sttp/client3/impl/cats/CatsMonadAsyncError.scala
+++ b/effects/cats/src/main/scala/sttp/client3/impl/cats/CatsMonadAsyncError.scala
@@ -1,6 +1,6 @@
 package sttp.client3.impl.cats
 
-import cats.effect.Async
+import cats.effect.kernel.Async
 import cats.syntax.functor._
 import cats.syntax.option._
 import sttp.monad.{Canceler, MonadAsyncError}

--- a/effects/cats/src/main/scala/sttp/client3/impl/cats/implicits.scala
+++ b/effects/cats/src/main/scala/sttp/client3/impl/cats/implicits.scala
@@ -1,6 +1,6 @@
 package sttp.client3.impl.cats
 
-import cats.effect.Async
+import cats.effect.kernel.Async
 import cats.~>
 import sttp.capabilities.Effect
 import sttp.client3.monad.{FunctionK, MapEffect}

--- a/effects/cats/src/main/scalajs/sttp/client3/impl/cats/FetchCatsBackend.scala
+++ b/effects/cats/src/main/scalajs/sttp/client3/impl/cats/FetchCatsBackend.scala
@@ -1,7 +1,7 @@
 package sttp.client3.impl.cats
 
-import cats.effect.syntax.all._
-import cats.effect.Async
+import cats.effect.kernel.syntax.monadCancel._
+import cats.effect.kernel.Async
 import org.scalajs.dom.experimental.{BodyInit, Request => FetchRequest, Response => FetchResponse}
 import sttp.capabilities.WebSockets
 import sttp.client3.internal.{ConvertFromFuture, NoStreams}

--- a/effects/fs2/src/main/scala/sttp/client3/impl/fs2/Fs2WebSockets.scala
+++ b/effects/fs2/src/main/scala/sttp/client3/impl/fs2/Fs2WebSockets.scala
@@ -1,8 +1,7 @@
 package sttp.client3.impl.fs2
 
-import cats.effect.Concurrent
-import cats.effect.kernel.Ref
-import cats.effect.implicits._
+import cats.effect.kernel.{Concurrent, Ref}
+import cats.effect.kernel.syntax.monadCancel._
 import fs2.{Pipe, Stream}
 import sttp.ws.{WebSocket, WebSocketClosed, WebSocketFrame}
 

--- a/effects/fs2/src/main/scalajs/sttp.client3.impl.fs2/Fs2SimpleQueue.scala
+++ b/effects/fs2/src/main/scalajs/sttp.client3.impl.fs2/Fs2SimpleQueue.scala
@@ -1,9 +1,8 @@
 package sttp.client3.impl.fs2
 
 import cats.MonadError
-import cats.effect.std.Dispatcher
+import cats.effect.std.{Dispatcher, Queue}
 import cats.syntax.flatMap._
-import cats.effect.std.Queue
 import sttp.client3.internal.ws.SimpleQueue
 import sttp.ws.WebSocketBufferFull
 

--- a/httpclient-backend/fs2/src/main/scala/sttp/client3/httpclient/fs2/Fs2BodyFromHttpClient.scala
+++ b/httpclient-backend/fs2/src/main/scala/sttp/client3/httpclient/fs2/Fs2BodyFromHttpClient.scala
@@ -1,6 +1,6 @@
 package sttp.client3.httpclient.fs2
 
-import cats.effect.Async
+import cats.effect.kernel.Async
 import fs2.io.file.Files
 import fs2.{Pipe, Stream}
 import sttp.capabilities.fs2.Fs2Streams

--- a/httpclient-backend/fs2/src/main/scala/sttp/client3/httpclient/fs2/HttpClientFs2Backend.scala
+++ b/httpclient-backend/fs2/src/main/scala/sttp/client3/httpclient/fs2/HttpClientFs2Backend.scala
@@ -5,7 +5,7 @@ import java.net.http.HttpRequest.BodyPublishers
 import java.net.http.{HttpClient, HttpRequest}
 import java.nio.ByteBuffer
 import java.util
-import cats.effect._
+import cats.effect.kernel._
 import cats.effect.std.{Dispatcher, Queue}
 import cats.implicits._
 import fs2.compression.InflateParams


### PR DESCRIPTION
This is a tiny change that removes the dependency on `ce3-core` from sttp cats module where `ce3-kernel` is enough.