### PR TITLE
add subprotocols option to httpbackend

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -114,7 +114,7 @@ val scalaTest = libraryDependencies ++= Seq("freespec", "funsuite", "flatspec", 
 val zioVersion = "1.0.6"
 val zioInteropRsVersion = "1.3.2"
 
-val sttpModelVersion = "1.4.1"
+val sttpModelVersion = "1.4.2"
 val sttpSharedVersion = "1.2.0"
 
 val logback = "ch.qos.logback" % "logback-classic" % "1.2.3"


### PR DESCRIPTION
Before submitting pull request:
- [x] Check if the project compiles by running `sbt compile`
- [x] Verify docs compilation by running `sbt compileDocs`
- [x] Check if tests pass by running `sbt test`
- [x] Format code by running `sbt scalafmt`

Not sure how to properly test these changes.
Any suggestions to a more generic approach across multiple backends is welcome.
