### PR TITLE
Add zio-telemetry-opentelemetry-backend

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -960,6 +960,7 @@ lazy val docs: ProjectMatrix = (projectMatrix in file("generated-docs")) // impo
       "io.jaegertracing" % "jaeger-client" % jeagerClientVersion,
       "io.opentracing.brave" % "brave-opentracing" % braveOpentracingVersion,
       "io.zipkin.reporter2" % "zipkin-sender-okhttp3" % zipkinSenderOkHttpVersion,
+      "io.opentelemetry" % "opentelemetry-semconv" % "1.1.0-alpha",
       akkaStreams
     ),
     evictionErrorLevel := Level.Info

--- a/build.sbt
+++ b/build.sbt
@@ -176,6 +176,7 @@ lazy val allAggregates = projectsWithOptionalNative ++
   playJson.projectRefs ++
   openTracingBackend.projectRefs ++
   prometheusBackend.projectRefs ++
+  zioTelemetryOpenTelemetryBackend.projectRefs ++
   zioTelemetryOpenTracingBackend.projectRefs ++
   httpClientBackend.projectRefs ++
   httpClientMonixBackend.projectRefs ++
@@ -838,6 +839,19 @@ lazy val prometheusBackend = (projectMatrix in file("metrics/prometheus-backend"
   .jvmPlatform(scalaVersions = scala2)
   .dependsOn(core)
 
+lazy val zioTelemetryOpenTelemetryBackend = (projectMatrix in file("metrics/zio-telemetry-open-telemetry-backend"))
+  .settings(commonJvmSettings)
+  .settings(
+    name := "zio-telemetry-opentelemetry-backend",
+    libraryDependencies ++= Seq(
+      "dev.zio" %% "zio-opentelemetry" % "0.8.0",
+      "org.scala-lang.modules" %% "scala-collection-compat" % "2.4.3"
+    )
+  )
+  .jvmPlatform(scalaVersions = List(scala2_12, scala2_13))
+  .dependsOn(zio % compileAndTest)
+  .dependsOn(core)
+
 lazy val zioTelemetryOpenTracingBackend = (projectMatrix in file("metrics/zio-telemetry-open-tracing-backend"))
   .settings(commonJvmSettings)
   .settings(
@@ -978,6 +992,7 @@ lazy val docs: ProjectMatrix = (projectMatrix in file("generated-docs")) // impo
     openTracingBackend,
     prometheusBackend,
     slf4jBackend,
+    zioTelemetryOpenTelemetryBackend,
     zioTelemetryOpenTracingBackend
   )
   .jvmPlatform(scalaVersions = List(scala2_13))

--- a/docs/backends/wrappers/zio-opentelemetry.md
+++ b/docs/backends/wrappers/zio-opentelemetry.md
@@ -1,0 +1,44 @@
+# zio-telemetry opentelemetry backend 
+
+To use, add the following dependency to your project:
+
+```
+"com.softwaremill.sttp.client3" %% "zio-telemetry-opentelemetry-backend" % "@VERSION@"
+```
+
+This backend depends on [zio-opentelemetry](https://github.com/zio/zio-telemetry).
+
+The opentelemetry backend wraps a `Task` based ZIO backend and yields a backend of type `SttpBackend[RIO[Tracing, *], Nothing, WS_HANDLER]`. The yielded effects are of type `RIO[Tracing, *]` which mean they can be a child of a other span created in your ZIO program.
+
+Here's how you construct `ZioTelemetryOpenTelemetryBackend`. I would recommend wrapping this is in `ZLayer`
+
+```scala
+new ZioTelemetryOpenTelemetryBackend(zioBackend)
+```
+
+Additionally you can add tags per request by supplying a `ZioTelemetryOpenTelemetryTracer`
+
+```scala mdoc:compile-only
+import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
+import sttp.client3._
+import zio._
+import zio.telemetry.opentelemetry._
+import sttp.client3.ziotelemetry.opentelemetry._
+
+implicit val zioBackend: SttpBackend[Task, Any] = ???
+
+def sttpTracer: ZioTelemetryOpenTelemetryTracer = new ZioTelemetryOpenTelemetryTracer {
+    def before[T](request: Request[T, Nothing]): RIO[Tracing, Unit] =
+      Tracing.setAttribute(SemanticAttributes.HTTP_METHOD.getKey, request.method.method) *>
+      Tracing.setAttribute(SemanticAttributes.HTTP_URL.getKey, request.uri.toString()) *>
+      ZIO.unit
+    
+    def after[T](response: Response[T]): RIO[Tracing, Unit] =
+      Tracing.setAttribute(SemanticAttributes.HTTP_STATUS_CODE.getKey, response.code.code) *>
+      ZIO.unit
+}
+
+ZioTelemetryOpenTelemetryBackend(zioBackend, sttpTracer)
+```
+
+

--- a/metrics/zio-telemetry-open-telemetry-backend/src/main/scala/sttp/client3/ziotelemetry/opentelemetry/ZioTelemetryOpenTelemetryBackend.scala
+++ b/metrics/zio-telemetry-open-telemetry-backend/src/main/scala/sttp/client3/ziotelemetry/opentelemetry/ZioTelemetryOpenTelemetryBackend.scala
@@ -1,0 +1,52 @@
+package sttp.client3.ziotelemetry.opentelemetry
+
+import io.opentelemetry.api.trace.SpanKind
+import io.opentelemetry.api.trace.propagation.W3CTraceContextPropagator
+import io.opentelemetry.context.propagation.{TextMapPropagator, TextMapSetter}
+import sttp.capabilities.Effect
+import sttp.client3._
+import sttp.client3.impl.zio.ExtendEnv
+import zio._
+import zio.telemetry.opentelemetry.TracingSyntax.OpenTelemetryZioOps
+import zio.telemetry.opentelemetry._
+
+import scala.collection.mutable
+
+class ZioTelemetryOpenTelemetryBackend[+P] private (
+    delegate: SttpBackend[RIO[Tracing, *], P],
+    tracer: ZioTelemetryOpenTelemetryTracer
+) extends DelegateSttpBackend[RIO[Tracing, *], P](delegate) {
+  def send[T, R >: P with Effect[RIO[Tracing, *]]](request: Request[T, R]): RIO[Tracing, Response[T]] = {
+    val carrier: mutable.Map[String, String] = mutable.Map().empty
+    val propagator: TextMapPropagator = W3CTraceContextPropagator.getInstance()
+    val setter: TextMapSetter[mutable.Map[String, String]] = (carrier, key, value) => carrier.update(key, value)
+    Tracing.inject(propagator, carrier, setter).flatMap { _ =>
+      (for {
+        _ <- tracer.before(request)
+        resp <- delegate.send(request.headers(carrier.toMap))
+        _ <- tracer.after(resp)
+      } yield resp).span(s"${request.method.method} ${request.uri.path.mkString("/")}", SpanKind.CLIENT)
+    }
+  }
+}
+
+object ZioTelemetryOpenTelemetryBackend {
+  def apply[P](
+      other: SttpBackend[Task, P],
+      tracer: ZioTelemetryOpenTelemetryTracer = ZioTelemetryOpenTelemetryTracer.empty
+  ): SttpBackend[RIO[Tracing, *], P] = {
+    new ZioTelemetryOpenTelemetryBackend[P](other.extendEnv[Tracing], tracer)
+  }
+}
+
+trait ZioTelemetryOpenTelemetryTracer {
+  def before[T](request: Request[T, Nothing]): RIO[Tracing, Unit]
+  def after[T](response: Response[T]): RIO[Tracing, Unit]
+}
+
+object ZioTelemetryOpenTelemetryTracer {
+  val empty: ZioTelemetryOpenTelemetryTracer = new ZioTelemetryOpenTelemetryTracer {
+    def before[T](request: Request[T, Nothing]): RIO[Tracing, Unit] = ZIO.unit
+    def after[T](response: Response[T]): RIO[Tracing, Unit] = ZIO.unit
+  }
+}


### PR DESCRIPTION
Before submitting pull request:
- [x] Check if the project compiles by running `sbt compile`
- [x] Verify docs compilation by running `sbt compileDocs`
- [x] Check if tests pass by running `sbt test`
- [x] Format code by running `sbt scalafmt`

There is a backend for opentracing, but there's none for opentelemetry, so it's time to fix that 🙂