### PR TITLE
Cross-compile more Scala.js modules to Scala 3

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -42,9 +42,13 @@ val commonJsSettings = commonSettings ++ Seq(
     if (isSnapshot.value) Seq.empty
     else
       Seq {
+        val mapSourcePrefix = if (ScalaArtifacts.isScala3(scalaVersion.value))
+          "-scalajs-mapSourceURI"
+        else
+          "-P:scalajs:mapSourceURI"
         val dir = project.base.toURI.toString.replaceFirst("[^/]+/?$", "")
         val url = "https://raw.githubusercontent.com/softwaremill/sttp"
-        s"-P:scalajs:mapSourceURI:$dir->$url/v${version.value}/"
+        s"$mapSourcePrefix:$dir->$url/v${version.value}/"
       }
   }
 )
@@ -114,8 +118,8 @@ val scalaTest = libraryDependencies ++= Seq("freespec", "funsuite", "flatspec", 
 val zioVersion = "1.0.6"
 val zioInteropRsVersion = "1.3.2"
 
-val sttpModelVersion = "1.4.2"
-val sttpSharedVersion = "1.2.0"
+val sttpModelVersion = "1.4.3"
+val sttpSharedVersion = "1.2.1"
 
 val logback = "ch.qos.logback" % "logback-classic" % "1.2.3"
 
@@ -137,7 +141,7 @@ lazy val projectsWithOptionalNative: Seq[ProjectReference] = if (sys.env.isDefin
 } else {
   println("[info] STTP_NATIVE *not* defined, *not* including sttp-native in the aggregate projects")
   scala2.flatMap(v => List[ProjectReference](core.jvm(v), core.js(v), jsonCommon.jvm(v), jsonCommon.js(v))) ++
-    scala3.flatMap(v => List[ProjectReference](core.jvm(v))) ++
+    scala3.flatMap(v => List[ProjectReference](core.jvm(v), core.js(v))) ++
     List[ProjectReference](
       upickle.jvm(scala2_12),
       upickle.jvm(scala2_13),
@@ -259,7 +263,7 @@ lazy val core = (projectMatrix in file("core"))
     }
   )
   .jsPlatform(
-    scalaVersions = scala2,
+    scalaVersions = scala2 ++ scala3,
     settings = {
       commonJsSettings ++ commonJsBackendSettings ++ browserChromeTestSettings ++ List(
         Test / publishArtifact := true
@@ -322,7 +326,7 @@ lazy val cats = (projectMatrix in file("effects/cats"))
     settings = commonJvmSettings
   )
   .jsPlatform(
-    scalaVersions = List(scala2_12, scala2_13),
+    scalaVersions = List(scala2_12, scala2_13) ++ scala3,
     settings = commonJsSettings ++ commonJsBackendSettings ++ browserChromeTestSettings ++ testServerSettings
   )
 
@@ -356,7 +360,7 @@ lazy val fs2 = (projectMatrix in file("effects/fs2"))
     scalaVersions = List(scala2_12, scala2_13) ++ scala3,
     settings = commonJvmSettings
   )
-  .jsPlatform(scalaVersions = List(scala2_12, scala2_13), settings = commonJsSettings)
+  .jsPlatform(scalaVersions = List(scala2_12, scala2_13) ++ scala3, settings = commonJsSettings)
 
 lazy val monix = (projectMatrix in file("effects/monix"))
   .settings(
@@ -708,7 +712,7 @@ lazy val jsonCommon = (projectMatrix in (file("json/common")))
     scalaVersions = scala2 ++ scala3,
     settings = commonJvmSettings
   )
-  .jsPlatform(scalaVersions = scala2, settings = commonJsSettings)
+  .jsPlatform(scalaVersions = scala2 ++ scala3, settings = commonJsSettings)
   .nativePlatform(scalaVersions = scala2, settings = commonNativeSettings)
   .dependsOn(core)
 
@@ -737,7 +741,7 @@ lazy val circe = (projectMatrix in file("json/circe"))
     scalaVersions = scala2 ++ scala3,
     settings = commonJvmSettings
   )
-  .jsPlatform(scalaVersions = List(scala2_12, scala2_13), settings = commonJsSettings)
+  .jsPlatform(scalaVersions = List(scala2_12, scala2_13) ++ scala3, settings = commonJsSettings)
   .dependsOn(core, jsonCommon)
 
 lazy val zioJson = (projectMatrix in file("json/zio-json"))

--- a/core/src/main/scalajs/sttp/client3/AbstractFetchBackend.scala
+++ b/core/src/main/scalajs/sttp/client3/AbstractFetchBackend.scala
@@ -102,19 +102,19 @@ abstract class AbstractFetchBackend[F[_], S <: Streams[S], P](
       val rsignal = signal.orUndefined
 
       val requestInitStatic = new RequestInit() {
-        method = request.method.method.asInstanceOf[HttpMethod]
-        headers = rheaders
-        body = rbody
-        referrer = js.undefined
-        referrerPolicy = js.undefined
-        mode = options.mode.orUndefined
-        credentials = options.credentials.orUndefined
-        cache = js.undefined
-        redirect = rredirect
-        integrity = js.undefined
-        keepalive = js.undefined
-        signal = rsignal
-        window = js.undefined
+        this.method = request.method.method.asInstanceOf[HttpMethod]
+        this.headers = rheaders
+        this.body = rbody
+        this.referrer = js.undefined
+        this.referrerPolicy = js.undefined
+        this.mode = options.mode.orUndefined
+        this.credentials = options.credentials.orUndefined
+        this.cache = js.undefined
+        this.redirect = rredirect
+        this.integrity = js.undefined
+        this.keepalive = js.undefined
+        this.signal = rsignal
+        this.window = js.undefined
       }
 
       val requestInitDynamic = requestInitStatic.asInstanceOf[js.Dynamic]

--- a/core/src/test/scalajs/sttp/client3/testing/HttpTestExtensions.scala
+++ b/core/src/test/scalajs/sttp/client3/testing/HttpTestExtensions.scala
@@ -17,7 +17,7 @@ import HttpTest.endpoint
 trait HttpTestExtensions[F[_]] extends AsyncExecutionContext { self: HttpTest[F] =>
 
   private def withTemporaryFile[T](content: Option[Array[Byte]])(f: DomFileWithBody => Future[T]): Future[T] = {
-    val data = content.getOrElse(Array.empty)
+    val data = content.getOrElse(Array.empty[Byte])
     val file = new DomFileWithBody(
       Array(data.toTypedArray.asInstanceOf[js.Any]).toJSArray,
       "temp.txt",


### PR DESCRIPTION
Before submitting pull request:
- [X] Check if the project compiles by running `sbt compile` (some 2.11 modules don't compile on my machine, but I don't think my changes have to do anything with it)
- [X] Verify docs compilation by running `sbt compileDocs`
- [X] Check if tests pass by running `sbt test`
- [X] Format code by running `sbt scalafmt`
