### PR TITLE
queue instead of bytes concatenation

### DIFF
--- a/async-http-client-backend/fs2-ce2/src/main/scala/sttp/client3/asynchttpclient/fs2/AsyncHttpClientFs2Backend.scala
+++ b/async-http-client-backend/fs2-ce2/src/main/scala/sttp/client3/asynchttpclient/fs2/AsyncHttpClientFs2Backend.scala
@@ -24,6 +24,8 @@ import sttp.ws.{WebSocket, WebSocketFrame}
 import java.io.File
 import java.nio.ByteBuffer
 import java.util.concurrent.ConcurrentLinkedQueue
+import scala.collection.immutable
+import scala.collection.immutable.Queue
 
 class AsyncHttpClientFs2Backend[F[_]: ConcurrentEffect: ContextShift] private (
     asyncHttpClient: AsyncHttpClient,
@@ -57,7 +59,7 @@ class AsyncHttpClientFs2Backend[F[_]: ConcurrentEffect: ContextShift] private (
       override def publisherToBytes(p: Publisher[ByteBuffer]): F[Array[Byte]] = {
         p.toStream[F]
           .compile
-          .fold(new ConcurrentLinkedQueue[Array[Byte]]())(enqueueBytes)
+          .fold(Queue.empty[Array[Byte]])(enqueueBytes)
           .map(concatBytes)
       }
 

--- a/async-http-client-backend/fs2/src/main/scala/sttp/client3/asynchttpclient/fs2/AsyncHttpClientFs2Backend.scala
+++ b/async-http-client-backend/fs2/src/main/scala/sttp/client3/asynchttpclient/fs2/AsyncHttpClientFs2Backend.scala
@@ -1,13 +1,11 @@
 package sttp.client3.asynchttpclient.fs2
 
-import java.io.File
-import java.nio.ByteBuffer
 import cats.effect.kernel._
 import cats.effect.std.{Dispatcher, Queue}
 import cats.implicits._
-import fs2.{Chunk, Pipe, Stream}
 import fs2.interop.reactivestreams._
 import fs2.io.file.Files
+import fs2.{Chunk, Pipe, Stream}
 import io.netty.buffer.{ByteBuf, Unpooled}
 import org.asynchttpclient.{Request => _, Response => _, _}
 import org.reactivestreams.Publisher
@@ -22,6 +20,10 @@ import sttp.client3.testing.SttpBackendStub
 import sttp.client3.{FollowRedirectsBackend, SttpBackend, SttpBackendOptions}
 import sttp.monad.MonadAsyncError
 import sttp.ws.{WebSocket, WebSocketFrame}
+
+import java.io.File
+import java.nio.ByteBuffer
+import java.util.concurrent.ConcurrentLinkedQueue
 
 class AsyncHttpClientFs2Backend[F[_]: Async] private (
     asyncHttpClient: AsyncHttpClient,
@@ -49,8 +51,8 @@ class AsyncHttpClientFs2Backend[F[_]: Async] private (
       override def publisherToBytes(p: Publisher[ByteBuffer]): F[Array[Byte]] = {
         p.toStream[F]
           .compile
-          .fold(ByteBuffer.allocate(0))(concatByteBuffers)
-          .map(_.array())
+          .fold(new ConcurrentLinkedQueue[Array[Byte]]())(enqueueBytes)
+          .map(concatBytes)
       }
 
       override def publisherToFile(p: Publisher[ByteBuffer], f: File): F[Unit] = {

--- a/async-http-client-backend/fs2/src/main/scala/sttp/client3/asynchttpclient/fs2/AsyncHttpClientFs2Backend.scala
+++ b/async-http-client-backend/fs2/src/main/scala/sttp/client3/asynchttpclient/fs2/AsyncHttpClientFs2Backend.scala
@@ -24,6 +24,7 @@ import sttp.ws.{WebSocket, WebSocketFrame}
 import java.io.File
 import java.nio.ByteBuffer
 import java.util.concurrent.ConcurrentLinkedQueue
+import scala.collection.{immutable, mutable}
 
 class AsyncHttpClientFs2Backend[F[_]: Async] private (
     asyncHttpClient: AsyncHttpClient,
@@ -51,7 +52,7 @@ class AsyncHttpClientFs2Backend[F[_]: Async] private (
       override def publisherToBytes(p: Publisher[ByteBuffer]): F[Array[Byte]] = {
         p.toStream[F]
           .compile
-          .fold(new ConcurrentLinkedQueue[Array[Byte]]())(enqueueBytes)
+          .fold(immutable.Queue.empty[Array[Byte]])(enqueueBytes)
           .map(concatBytes)
       }
 

--- a/async-http-client-backend/monix/src/main/scala/sttp/client3/asynchttpclient/monix/AsyncHttpClientMonixBackend.scala
+++ b/async-http-client-backend/monix/src/main/scala/sttp/client3/asynchttpclient/monix/AsyncHttpClientMonixBackend.scala
@@ -21,7 +21,8 @@ import sttp.ws.{WebSocket, WebSocketFrame}
 
 import java.io.File
 import java.nio.ByteBuffer
-import java.util.concurrent.ConcurrentLinkedQueue
+import scala.collection.immutable
+import scala.collection.immutable.Queue
 
 class AsyncHttpClientMonixBackend private (
     asyncHttpClient: AsyncHttpClient,
@@ -50,7 +51,7 @@ class AsyncHttpClientMonixBackend private (
       override def publisherToBytes(p: Publisher[ByteBuffer]): Task[Array[Byte]] = {
         Observable
           .fromReactivePublisher(p)
-          .foldLeftL(new ConcurrentLinkedQueue[Array[Byte]]())(enqueueBytes)
+          .foldLeftL(Queue.empty[Array[Byte]])(enqueueBytes)
           .map(concatBytes)
       }
 

--- a/async-http-client-backend/zio/src/main/scala/sttp/client3/asynchttpclient/zio/AsyncHttpClientZioBackend.scala
+++ b/async-http-client-backend/zio/src/main/scala/sttp/client3/asynchttpclient/zio/AsyncHttpClientZioBackend.scala
@@ -1,8 +1,5 @@
 package sttp.client3.asynchttpclient.zio
 
-import java.io.{BufferedInputStream, File, FileInputStream, FileOutputStream}
-import java.nio.ByteBuffer
-
 import _root_.zio._
 import _root_.zio.blocking.Blocking
 import _root_.zio.interop.reactivestreams.{
@@ -11,13 +8,7 @@ import _root_.zio.interop.reactivestreams.{
 }
 import _root_.zio.stream._
 import io.netty.buffer.{ByteBuf, Unpooled}
-import org.asynchttpclient.{
-  AsyncHttpClient,
-  AsyncHttpClientConfig,
-  BoundRequestBuilder,
-  DefaultAsyncHttpClient,
-  DefaultAsyncHttpClientConfig
-}
+import org.asynchttpclient._
 import org.reactivestreams.Publisher
 import sttp.capabilities.WebSockets
 import sttp.capabilities.zio.ZioStreams
@@ -29,6 +20,10 @@ import sttp.client3.testing.SttpBackendStub
 import sttp.client3.{FollowRedirectsBackend, SttpBackend, SttpBackendOptions}
 import sttp.monad.MonadAsyncError
 import sttp.ws.{WebSocket, WebSocketFrame}
+
+import java.io.{BufferedInputStream, File, FileInputStream, FileOutputStream}
+import java.nio.ByteBuffer
+import java.util.concurrent.ConcurrentLinkedQueue
 
 class AsyncHttpClientZioBackend private (
     runtime: Runtime[Any],
@@ -56,7 +51,9 @@ class AsyncHttpClientZioBackend private (
         p.toStream(bufferSize).mapConcatChunk(Chunk.fromByteBuffer(_))
 
       override def publisherToBytes(p: Publisher[ByteBuffer]): Task[Array[Byte]] =
-        p.toStream(bufferSize).fold(ByteBuffer.allocate(0))(concatByteBuffers).map(_.array())
+        p.toStream(bufferSize)
+          .fold(new ConcurrentLinkedQueue[Array[Byte]]())(enqueueBytes)
+          .map(concatBytes)
 
       override def publisherToFile(p: Publisher[ByteBuffer], f: File): Task[Unit] = {
         p.toStream(bufferSize)

--- a/async-http-client-backend/zio/src/main/scala/sttp/client3/asynchttpclient/zio/AsyncHttpClientZioBackend.scala
+++ b/async-http-client-backend/zio/src/main/scala/sttp/client3/asynchttpclient/zio/AsyncHttpClientZioBackend.scala
@@ -23,7 +23,7 @@ import sttp.ws.{WebSocket, WebSocketFrame}
 
 import java.io.{BufferedInputStream, File, FileInputStream, FileOutputStream}
 import java.nio.ByteBuffer
-import java.util.concurrent.ConcurrentLinkedQueue
+import scala.collection.immutable
 
 class AsyncHttpClientZioBackend private (
     runtime: Runtime[Any],
@@ -52,7 +52,7 @@ class AsyncHttpClientZioBackend private (
 
       override def publisherToBytes(p: Publisher[ByteBuffer]): Task[Array[Byte]] =
         p.toStream(bufferSize)
-          .fold(new ConcurrentLinkedQueue[Array[Byte]]())(enqueueBytes)
+          .fold(immutable.Queue.empty[Array[Byte]])(enqueueBytes)
           .map(concatBytes)
 
       override def publisherToFile(p: Publisher[ByteBuffer], f: File): Task[Unit] = {

--- a/core/src/main/scala/sttp/client3/internal/package.scala
+++ b/core/src/main/scala/sttp/client3/internal/package.scala
@@ -2,9 +2,8 @@ package sttp.client3
 
 import java.io.{ByteArrayInputStream, ByteArrayOutputStream, InputStream, OutputStream}
 import java.nio.ByteBuffer
-import java.util.concurrent.ConcurrentLinkedQueue
 import scala.annotation.{implicitNotFound, tailrec}
-import scala.collection.JavaConverters._
+import scala.collection.immutable.Queue
 
 package object internal {
   private[client3] def contentTypeWithCharset(ct: String, charset: String): String =
@@ -40,18 +39,14 @@ package object internal {
   private[client3] def emptyInputStream(): InputStream = new ByteArrayInputStream(Array[Byte]())
 
   private[client3] def enqueueBytes(
-      queue: ConcurrentLinkedQueue[Array[Byte]],
+      queue: Queue[Array[Byte]],
       bytes: ByteBuffer
-  ): ConcurrentLinkedQueue[Array[Byte]] = {
-    queue.offer(bytes.array())
-    queue
-  }
+  ): Queue[Array[Byte]] = queue.enqueue(bytes.array())
 
-  private[client3] def concatBytes(queue: ConcurrentLinkedQueue[Array[Byte]]): Array[Byte] = {
-    val size = queue.asScala.map(_.length).sum
+  private[client3] def concatBytes(queue: Queue[Array[Byte]]): Array[Byte] = {
+    val size = queue.map(_.length).sum
     val bytes = ByteBuffer.allocate(size)
-    queue.asScala.foreach(bytes.put)
-    queue.clear()
+    queue.foreach(bytes.put)
     bytes.array()
   }
 


### PR DESCRIPTION
So it's faster now, ~ 80 to ~ 30 seconds on my computer. Also memory usage is normal, with byte concatenation it was up to 8 GB for the 50 MB file from the affected example.