### PR TITLE
[#958] It is now possible to define for which hosts the requests should be proxied

### DIFF
--- a/core/src/main/scala/sttp/client3/SttpBackendOptions.scala
+++ b/core/src/main/scala/sttp/client3/SttpBackendOptions.scala
@@ -67,7 +67,7 @@ object SttpBackendOptions {
       nonProxyHosts.exists(isWildCardMatch(host, _))
 
     private def doesNotMatchAnyHostToProxy(host: String) =
-      hostsToProxy != Nil && hostsToProxy.forall(!isWildCardMatch(host, _))
+      hostsToProxy != Nil && !hostsToProxy.exists(isWildCardMatch(host, _))
 
     def asJavaProxySelector: net.ProxySelector =
       new net.ProxySelector {

--- a/core/src/main/scala/sttp/client3/SttpBackendOptions.scala
+++ b/core/src/main/scala/sttp/client3/SttpBackendOptions.scala
@@ -36,7 +36,8 @@ object SttpBackendOptions {
       port: Int,
       proxyType: ProxyType,
       nonProxyHosts: List[String] = Nil,
-      auth: Option[ProxyAuth] = None
+      auth: Option[ProxyAuth] = None,
+      hostsToProxy: List[String] = Nil
   ) {
     //only matches prefix or suffix wild card(*)
     private def isWildCardMatch(targetHost: String, nonProxyHost: String): Boolean = {
@@ -59,9 +60,14 @@ object SttpBackendOptions {
       }
     }
 
-    def ignoreProxy(host: String): Boolean = {
+    def ignoreProxy(host: String): Boolean =
+      matchesNonProxyHost(host) || doesNotMatchAnyHostToProxy(host)
+
+    private def matchesNonProxyHost(host: String) =
       nonProxyHosts.exists(isWildCardMatch(host, _))
-    }
+
+    private def doesNotMatchAnyHostToProxy(host: String) =
+      hostsToProxy != Nil && hostsToProxy.forall(!isWildCardMatch(host, _))
 
     def asJavaProxySelector: net.ProxySelector =
       new net.ProxySelector {

--- a/core/src/test/scala/sttp/client3/SttpBackendOptionsProxyTest.scala
+++ b/core/src/test/scala/sttp/client3/SttpBackendOptionsProxyTest.scala
@@ -52,4 +52,80 @@ class SttpBackendOptionsProxyTest extends AnyFlatSpec with Matchers {
     proxySetting.ignoreProxy("sttp.local.com") should be(false)
     proxySetting.ignoreProxy("10.127.0.1") should be(false)
   }
+
+  it should "return false for exact hostsToProxy match" in {
+    val proxySetting = SttpBackendOptions.Proxy(
+      "fakeproxyserverhost",
+      8080,
+      SttpBackendOptions.ProxyType.Http,
+      nonProxyHosts = Nil,
+      hostsToProxy = List("a.nonproxy.host", "localhost", "127.*")
+    )
+
+    proxySetting.ignoreProxy("a.nonproxy.host") should be(false)
+    proxySetting.ignoreProxy("localhost") should be(false)
+  }
+
+  it should "return false for hostsToProxy suffix match" in {
+    val proxySetting = SttpBackendOptions.Proxy(
+      "fakeproxyserverhost",
+      8080,
+      SttpBackendOptions.ProxyType.Http,
+      nonProxyHosts = Nil,
+      hostsToProxy = List("localhost", "127.*")
+    )
+
+    proxySetting.ignoreProxy("127.0.0.1") should be(false)
+    proxySetting.ignoreProxy("127.1.0.1") should be(false)
+  }
+
+  it should "return false for hostsToProxy prefix match" in {
+    val proxySetting = SttpBackendOptions.Proxy(
+      "fakeproxyserverhost",
+      8080,
+      SttpBackendOptions.ProxyType.Http,
+      nonProxyHosts = Nil,
+      hostsToProxy = List("localhost", "*.local")
+    )
+
+    proxySetting.ignoreProxy("sttp.local") should be(false)
+    proxySetting.ignoreProxy("www.sttp.local") should be(false)
+  }
+
+  it should "return true for if host does not match any host from hostsToProxy" in {
+    val proxySetting = SttpBackendOptions.Proxy(
+      "fakeproxyserverhost",
+      8080,
+      SttpBackendOptions.ProxyType.Http,
+      nonProxyHosts = Nil,
+      hostsToProxy = List("localhost", "*.local", "127.*")
+    )
+
+    proxySetting.ignoreProxy("dorime") should be(true)
+    proxySetting.ignoreProxy("interimo.adaptare") should be(true)
+  }
+
+  it should "return true if host matches nonProxyHost despite matching hostsToProxy" in {
+    val proxySetting = SttpBackendOptions.Proxy(
+      "fakeproxyserverhost",
+      8080,
+      SttpBackendOptions.ProxyType.Http,
+      nonProxyHosts = List("localhost"),
+      hostsToProxy = List("localhost")
+    )
+
+    proxySetting.ignoreProxy("localhost") should be(true)
+  }
+
+  it should "return false if both nonProxyHost and hostsToProxy is Nil" in {
+    val proxySetting = SttpBackendOptions.Proxy(
+      "fakeproxyserverhost",
+      8080,
+      SttpBackendOptions.ProxyType.Http,
+      nonProxyHosts = Nil,
+      hostsToProxy = Nil
+    )
+
+    proxySetting.ignoreProxy("localhost") should be(false)
+  }
 }

--- a/docs/conf/proxy.md
+++ b/docs/conf/proxy.md
@@ -30,3 +30,24 @@ import sttp.client3._
 
 SttpBackendOptions.httpProxy("some.host", 8080, "username", "password")
 ```
+
+## Ignoring and allowing specific hosts
+
+There are two additional settings that can be provided to via `SttpBackendOptions`:
+
+* `nonProxyHosts`
+
+Used to define hosts for which request SHOULD NOT be proxied
+
+* `hostsToProxy`
+
+Used to define hosts for which request SHOULD be proxied
+
+If only `nonProxyHosts` is provided, then some hosts will be skipped when proxying.
+If only `hostsToProxy` is provided, then requests will be proxied only if host matches provided list. 
+If both `nonProxyHosts` and `hostsToProxy` are provided, then `nonProxyHosts` takes precedence. 
+Both of these options are `Nil` by default.
+
+### Wildcards
+
+It is possible to use wildcard, but only as either prefix or suffix. E.g. `hostsToProxy = List("localhost", "*.local", "127.*")`

--- a/httpclient-backend/src/main/scala/sttp/client3/httpclient/HttpClientBackend.scala
+++ b/httpclient-backend/src/main/scala/sttp/client3/httpclient/HttpClientBackend.scala
@@ -118,7 +118,7 @@ object HttpClientBackend {
 
     clientBuilder = options.proxy match {
       case None => clientBuilder
-      case Some(p @ Proxy(_, _, _, _, Some(auth))) =>
+      case Some(p @ Proxy(_, _, _, _, Some(auth), _)) =>
         clientBuilder.proxy(p.asJavaProxySelector).authenticator(new ProxyAuthenticator(auth))
       case Some(p) => clientBuilder.proxy(p.asJavaProxySelector)
     }

--- a/okhttp-backend/src/main/scala/sttp/client3/okhttp/OkHttpBackend.scala
+++ b/okhttp-backend/src/main/scala/sttp/client3/okhttp/OkHttpBackend.scala
@@ -147,7 +147,7 @@ object OkHttpBackend {
 
     clientBuilder = options.proxy match {
       case None => clientBuilder
-      case Some(p @ Proxy(_, _, _, _, Some(auth))) =>
+      case Some(p @ Proxy(_, _, _, _, Some(auth), _)) =>
         clientBuilder.proxySelector(p.asJavaProxySelector).proxyAuthenticator(new ProxyAuthenticator(auth))
       case Some(p) => clientBuilder.proxySelector(p.asJavaProxySelector)
     }


### PR DESCRIPTION
Before submitting pull request:
- [x] Check if the project compiles by running `sbt compile`
- [x] Verify docs compilation by running `sbt compileDocs`
- [x] Check if tests pass by running `sbt test`
- [x] Format code by running `sbt scalafmt`
