### PR TITLE
Changed .toCurl output in an attempt to make it easier to read and purely out of personal preference

### DIFF
--- a/core/src/test/scala/sttp/client3/ToCurlConverterTest.scala
+++ b/core/src/test/scala/sttp/client3/ToCurlConverterTest.scala
@@ -12,45 +12,45 @@ class ToCurlConverterTest extends AnyFlatSpec with Matchers with ToCurlConverter
   it should "convert base request" in {
     basicRequest
       .get(uri"$localhost")
-      .toCurl shouldBe """curl -L --max-redirs 32 -X GET 'http://localhost'"""
+      .toCurl shouldBe "curl \\\n  --request GET \\\n  --url 'http://localhost' \\\n  --location \\\n  --max-redirs 32"
   }
 
   it should "convert request with method to curl" in {
-    basicRequest.get(localhost).toCurl should include("-X GET")
-    basicRequest.post(localhost).toCurl should include("-X POST")
-    basicRequest.put(localhost).toCurl should include("-X PUT")
-    basicRequest.delete(localhost).toCurl should include("-X DELETE")
-    basicRequest.patch(localhost).toCurl should include("-X PATCH")
-    basicRequest.head(localhost).toCurl should include("-X HEAD")
-    basicRequest.options(localhost).toCurl should include("-X OPTIONS")
+    basicRequest.get(localhost).toCurl should include("--request GET")
+    basicRequest.post(localhost).toCurl should include("--request POST")
+    basicRequest.put(localhost).toCurl should include("--request PUT")
+    basicRequest.delete(localhost).toCurl should include("--request DELETE")
+    basicRequest.patch(localhost).toCurl should include("--request PATCH")
+    basicRequest.head(localhost).toCurl should include("--request HEAD")
+    basicRequest.options(localhost).toCurl should include("--request OPTIONS")
   }
 
   it should "convert request with header" in {
     basicRequest.header("User-Agent", "myapp").get(localhost).toCurl should include(
-      """-H 'User-Agent: myapp'"""
+      """--header 'User-Agent: myapp'"""
     )
   }
 
   it should "convert request with body" in {
     basicRequest.body(Map("name" -> "john", "org" -> "sml")).post(localhost).toCurl should include(
-      """-H 'Content-Type: application/x-www-form-urlencoded' -H 'Content-Length: 17' -F 'name=john&org=sml'"""
+      "--header 'Content-Type: application/x-www-form-urlencoded' \\\n  --header 'Content-Length: 17' \\\n  --form 'name=john&org=sml'"
     )
     basicRequest.body("name=john").post(localhost).toCurl should include(
-      """-H 'Content-Type: text/plain; charset=utf-8' -H 'Content-Length: 9' --data 'name=john'"""
+      "--header 'Content-Type: text/plain; charset=utf-8' \\\n  --header 'Content-Length: 9' \\\n  --data 'name=john'"
     )
     basicRequest.body("name=john", StandardCharsets.ISO_8859_1.name()).post(localhost).toCurl should include(
-      """-H 'Content-Type: text/plain; charset=ISO-8859-1' -H 'Content-Length: 9' --data 'name=john'"""
+      "--header 'Content-Type: text/plain; charset=ISO-8859-1' \\\n  --header 'Content-Length: 9' \\\n  --data 'name=john'"
     )
     basicRequest.body("name='john'").post(localhost).toCurl should include(
-      """-H 'Content-Type: text/plain; charset=utf-8' -H 'Content-Length: 11' --data 'name=\'john\''"""
+      "--header 'Content-Type: text/plain; charset=utf-8' \\\n  --header 'Content-Length: 11' \\\n  --data 'name=\\'john\\''"
     )
     basicRequest.body("name=\"john\"").post(localhost).toCurl should include(
-      """-H 'Content-Type: text/plain; charset=utf-8' -H 'Content-Length: 11' --data 'name="john"'"""
+      "--header 'Content-Type: text/plain; charset=utf-8' \\\n  --header 'Content-Length: 11' \\\n  --data 'name=\"john\"'"
     )
   }
 
   it should "convert request with options" in {
-    basicRequest.followRedirects(false).get(localhost).toCurl should not include "-L"
+    basicRequest.followRedirects(false).get(localhost).toCurl should not include "--location"
     basicRequest.maxRedirects(11).get(localhost).toCurl should include("--max-redirs 11")
   }
 
@@ -66,7 +66,7 @@ class ToCurlConverterTest extends AnyFlatSpec with Matchers with ToCurlConverter
 
   it should "render multipart form data if content is a plain string" in {
     basicRequest.multipartBody(multipart("k1", "v1"), multipart("k2", "v2")).post(localhost).toCurl should include(
-      """--form 'k1=v1' --form 'k2=v2'"""
+      "--form 'k1=v1' \\\n  --form 'k2=v2'"
     )
   }
 }


### PR DESCRIPTION
Made it both more verbose, added line breaks and rearranged the order
of parameters in an attempt to make it easier to read by humans.

Now curl output looks like this:

```shell
curl \
  --request POST \
  --url 'http://localhost' \
  --form 'k1=v1' \
  --form 'k2=v2' \
  --location \
  --max-redirs 32
```

whereas before it was one very long chain of shortened flags (`-L`, `-F`, `-H`, `-X`) in one single line. I found that hard to read.

Ultimately this is of course purely personal preference so if there are reservations about this, I'm not gonna start arguing :)
And yes, I am aware that if someone has started working on https://github.com/softwaremill/sttp/issues/965 already that this would result in merge conflicts. It should be easy to redo this PR on top of a bugfix though.

## Additional Homework
- [X] Check if the project compiles by running `sbt compile`
- [X] Verify docs compilation by running `sbt compileDocs`
- [X] Check if tests pass by running `sbt test`
- [X] Format code by running `sbt scalafmt`

(I ran only the tests (+ for the code) I touched, because a full test run ran out of memory (4G))