### PR TITLE
Have ZioTelemetryOpenTelemetryBackend absorb the Tracing dependency

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -852,8 +852,10 @@ lazy val zioTelemetryOpenTelemetryBackend = (projectMatrix in file("metrics/zio-
     name := "zio-telemetry-opentelemetry-backend",
     libraryDependencies ++= Seq(
       "dev.zio" %% "zio-opentelemetry" % "0.8.0",
-      "org.scala-lang.modules" %% "scala-collection-compat" % "2.4.4"
-    )
+      "org.scala-lang.modules" %% "scala-collection-compat" % "2.4.4",
+      "io.opentelemetry" % "opentelemetry-sdk-testing" % "1.3.0" % Test
+    ),
+    scalaTest
   )
   .jvmPlatform(scalaVersions = List(scala2_12, scala2_13))
   .dependsOn(zio % compileAndTest)

--- a/docs/backends/wrappers/zio-opentelemetry.md
+++ b/docs/backends/wrappers/zio-opentelemetry.md
@@ -8,15 +8,21 @@ To use, add the following dependency to your project:
 
 This backend depends on [zio-opentelemetry](https://github.com/zio/zio-telemetry).
 
-The opentelemetry backend wraps a `Task` based ZIO backend and yields a backend of type `SttpBackend[RIO[Tracing, *], Nothing, WS_HANDLER]`. The yielded effects are of type `RIO[Tracing, *]` which mean they can be a child of a other span created in your ZIO program.
+The opentelemetry backend wraps a `Task` based ZIO backend.
+In order to do that, you need to provide the wrapper with a `Tracing.Service` from zio-telemetry.
 
 Here's how you construct `ZioTelemetryOpenTelemetryBackend`. I would recommend wrapping this is in `ZLayer`
 
 ```scala
-new ZioTelemetryOpenTelemetryBackend(zioBackend)
+ZioTelemetryOpenTelemetryBackend(
+  sttpBackend,
+  tracing
+)
 ```
 
 Additionally you can add tags per request by supplying a `ZioTelemetryOpenTelemetryTracer`
+(by default, all that happens is that the span for the request is named after using the HTTP method
+and path).
 
 ```scala mdoc:compile-only
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
@@ -25,7 +31,8 @@ import zio._
 import zio.telemetry.opentelemetry._
 import sttp.client3.ziotelemetry.opentelemetry._
 
-implicit val zioBackend: SttpBackend[Task, Any] = ???
+val zioBackend: SttpBackend[Task, Any] = ???
+val tracing: Tracing.Service = ???
 
 def sttpTracer: ZioTelemetryOpenTelemetryTracer = new ZioTelemetryOpenTelemetryTracer {
     def before[T](request: Request[T, Nothing]): RIO[Tracing, Unit] =
@@ -38,7 +45,7 @@ def sttpTracer: ZioTelemetryOpenTelemetryTracer = new ZioTelemetryOpenTelemetryT
       ZIO.unit
 }
 
-ZioTelemetryOpenTelemetryBackend(zioBackend, sttpTracer)
+ZioTelemetryOpenTelemetryBackend(zioBackend, tracing, sttpTracer)
 ```
 
 

--- a/metrics/zio-telemetry-open-telemetry-backend/src/main/scala/sttp/client3/ziotelemetry/opentelemetry/ZioTelemetryOpenTelemetryBackend.scala
+++ b/metrics/zio-telemetry-open-telemetry-backend/src/main/scala/sttp/client3/ziotelemetry/opentelemetry/ZioTelemetryOpenTelemetryBackend.scala
@@ -5,38 +5,41 @@ import io.opentelemetry.api.trace.propagation.W3CTraceContextPropagator
 import io.opentelemetry.context.propagation.{TextMapPropagator, TextMapSetter}
 import sttp.capabilities.Effect
 import sttp.client3._
-import sttp.client3.impl.zio.ExtendEnv
 import zio._
 import zio.telemetry.opentelemetry.TracingSyntax.OpenTelemetryZioOps
 import zio.telemetry.opentelemetry._
 
 import scala.collection.mutable
 
-class ZioTelemetryOpenTelemetryBackend[+P] private (
-    delegate: SttpBackend[RIO[Tracing, *], P],
-    tracer: ZioTelemetryOpenTelemetryTracer
-) extends DelegateSttpBackend[RIO[Tracing, *], P](delegate) {
-  def send[T, R >: P with Effect[RIO[Tracing, *]]](request: Request[T, R]): RIO[Tracing, Response[T]] = {
+private class ZioTelemetryOpenTelemetryBackend[+P] (
+    delegate: SttpBackend[Task, P],
+    tracer: ZioTelemetryOpenTelemetryTracer,
+    tracing: Tracing
+) extends DelegateSttpBackend[Task, P](delegate) {
+  def send[T, R >: P with Effect[Task]](request: Request[T, R]): Task[Response[T]] = {
     val carrier: mutable.Map[String, String] = mutable.Map().empty
     val propagator: TextMapPropagator = W3CTraceContextPropagator.getInstance()
     val setter: TextMapSetter[mutable.Map[String, String]] = (carrier, key, value) => carrier.update(key, value)
-    Tracing.inject(propagator, carrier, setter).flatMap { _ =>
-      (for {
-        _ <- tracer.before(request)
-        resp <- delegate.send(request.headers(carrier.toMap))
-        _ <- tracer.after(resp)
-      } yield resp).span(s"${request.method.method} ${request.uri.path.mkString("/")}", SpanKind.CLIENT)
-    }
+
+    (for {
+      _ <- Tracing.inject(propagator, carrier, setter)
+      _ <- tracer.before(request)
+      resp <- delegate.send(request.headers(carrier.toMap))
+      _ <- tracer.after(resp)
+    } yield resp)
+      .span(s"${request.method.method} ${request.uri.path.mkString("/")}", SpanKind.CLIENT)
+      .provide(tracing)
   }
 }
 
 object ZioTelemetryOpenTelemetryBackend {
   def apply[P](
       other: SttpBackend[Task, P],
+      tracing: Tracing.Service,
       tracer: ZioTelemetryOpenTelemetryTracer = ZioTelemetryOpenTelemetryTracer.empty
-  ): SttpBackend[RIO[Tracing, *], P] = {
-    new ZioTelemetryOpenTelemetryBackend[P](other.extendEnv[Tracing], tracer)
-  }
+  ): SttpBackend[Task, P] =
+    new ZioTelemetryOpenTelemetryBackend[P](other, tracer, Has(tracing))
+
 }
 
 trait ZioTelemetryOpenTelemetryTracer {

--- a/metrics/zio-telemetry-open-telemetry-backend/src/test/scala/sttp/client3/ziotelemetry/opentelemetry/ZioTelemetryOpenTelemetryBackendTest.scala
+++ b/metrics/zio-telemetry-open-telemetry-backend/src/test/scala/sttp/client3/ziotelemetry/opentelemetry/ZioTelemetryOpenTelemetryBackendTest.scala
@@ -1,0 +1,67 @@
+package sttp.client3.ziotelemetry.opentelemetry
+
+import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter
+import io.opentelemetry.sdk.trace.SdkTracerProvider
+import io.opentelemetry.sdk.trace.`export`.SimpleSpanProcessor
+import org.scalatest.BeforeAndAfter
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import sttp.client3.impl.zio.{RIOMonadAsyncError, ZioTestBase}
+import sttp.client3.testing.SttpBackendStub
+import sttp.client3.{Request, Response, SttpBackend, UriContext, basicRequest}
+import sttp.model.StatusCode
+import zio.{Managed, Task}
+import zio.telemetry.opentelemetry.Tracing
+
+import scala.collection.mutable
+import scala.jdk.CollectionConverters.ListHasAsScala
+
+class ZioTelemetryOpenTelemetryBackendTest extends AnyFlatSpec with Matchers with BeforeAndAfter with ZioTestBase {
+
+  private val recordedRequests = mutable.ListBuffer[Request[_, _]]()
+
+  private val spanExporter = InMemorySpanExporter.create()
+
+  private val mockTracer =
+    SdkTracerProvider.builder().addSpanProcessor(SimpleSpanProcessor.create(spanExporter)).build().get(getClass.getName)
+  private val mockTracing = runtime.unsafeRun(Tracing.managed(mockTracer).useNow)
+
+  private val backend: SttpBackend[Task, Any] =
+    ZioTelemetryOpenTelemetryBackend(
+      SttpBackendStub(new RIOMonadAsyncError[Any]).whenRequestMatchesPartial {
+      case r if r.uri.toString.contains("echo") =>
+        recordedRequests += r
+        Response.ok("")
+      case r if r.uri.toString.contains("error") =>
+        throw new RuntimeException("something went wrong")
+      },
+      mockTracing
+    )
+
+  before {
+    recordedRequests.clear()
+    spanExporter.reset()
+  }
+
+  "ZioTelemetryOpenTelemetryBackend" should "record spans for requests" in {
+    val response = runtime.unsafeRun(basicRequest.post(uri"http://stub/echo").send(backend))
+    response.code shouldBe StatusCode.Ok
+
+    val spans = spanExporter.getFinishedSpanItems.asScala
+    spans should have size 1
+    spans.head.getName shouldBe "POST echo"
+  }
+
+  it should "propagate span" in {
+    val response = runtime.unsafeRun(basicRequest.post(uri"http://stub/echo").send(backend))
+    response.code shouldBe StatusCode.Ok
+
+    val spans = spanExporter.getFinishedSpanItems.asScala
+    spans should have size 1
+
+    val spanId = spans.head.getSpanId
+    val traceId = spans.head.getTraceId
+    recordedRequests(0).header("traceparent") shouldBe Some(s"00-${traceId}-${spanId}-01")
+  }
+
+}


### PR DESCRIPTION
As it stands,  ZioTelemetryOpenTelemetryBackend wraps an existing backend that works on Task into an enhanced one that does telemetry but then no longer works with Task (it exposes the extra dependency on Tracing.

>  The yielded effects are of type RIO[OpenTracing, *]

This means that you cannot use this backend as a drop-in replacement for all your code that needed a SttpClient (i.e. a Task-based backend) and everything has to be refactored to deal with the added dependency.

This PR changes this to have the wrapper absorb the dependency (by taking it in at construction time), so that this gets hidden from users.

See #1005 