### PR TITLE
#1016 replace ZIO websocket example to be in line with Fs2

### DIFF
--- a/examples/src/main/scala/sttp/client3/examples/WebSocketZio.scala
+++ b/examples/src/main/scala/sttp/client3/examples/WebSocketZio.scala
@@ -2,24 +2,36 @@ package sttp.client3.examples
 
 import sttp.client3._
 import sttp.client3.asynchttpclient.zio._
-import sttp.ws.WebSocket
+import sttp.ws.WebSocketFrame
 import zio._
-import zio.console.Console
+import zio.stream.Stream
+import sttp.capabilities.zio.ZioStreams
+import ZioStreams.Pipe
 
 object WebSocketZio extends App {
-  def useWebSocket(ws: WebSocket[RIO[Console, *]]): RIO[Console, Unit] = {
-    def send(i: Int) = ws.sendText(s"Hello $i!")
-    val receive = ws.receiveText().flatMap(t => console.putStrLn(s"RECEIVED: $t"))
-    send(1) *> send(2) *> receive *> receive
+  def webSocketFramePipe: Pipe[WebSocketFrame.Data[_], WebSocketFrame] = { input =>
+    Stream(WebSocketFrame.text("1")) ++ input.flatMap {
+      case WebSocketFrame.Text("10", _, _) =>
+        println("Received 10 messages, sending close frame")
+        Stream(WebSocketFrame.close)
+      case WebSocketFrame.Text(n, _, _) =>
+        val next = (n.toInt + 1).toString
+        println(s"Received $n messages, replying with $next")
+        Stream(WebSocketFrame.text(next))
+      case _ => Stream.empty // ignoring
+    }
   }
 
-  // create a description of a program, which requires two dependencies in the environment:
-  // the SttpClient, and the Console
-  val sendAndPrint: RIO[Console with SttpClient, Response[Unit]] =
-    sendR(basicRequest.get(uri"wss://echo.websocket.org").response(asWebSocketAlways(useWebSocket)))
+  // create a description of a program, which requires SttpClient dependency in the environment
+  val sendAndPrint: RIO[SttpClient, Response[Either[String, Unit]]] =
+    sendR(
+      basicRequest
+        .get(uri"wss://echo.websocket.org")
+        .response(asWebSocketStream(ZioStreams)(webSocketFramePipe))
+    )
 
   override def run(args: List[String]): ZIO[ZEnv, Nothing, ExitCode] = {
-    // provide an implementation for the SttpClient dependency; other dependencies are
+    // provide an implementation for the SttpClient dependency; other dependencies (if required) are
     // provided by Zio
     sendAndPrint
       .provideCustomLayer(AsyncHttpClientZioBackend.layer())


### PR DESCRIPTION
 showing the same… interesting API, which is `asWebSocketStream`

If reviewer agrees to this, I'd like additionally to find a non-side-effecting way to print in both `fs2` and `zio` websocket examples as this is not "idiomatic" to use `println` as we do in the examples.
