### PR TITLE
extend exception message if connection via proxyServer couldn't be es…

### DIFF
--- a/core/src/main/scala/sttp/client3/SttpBackendOptions.scala
+++ b/core/src/main/scala/sttp/client3/SttpBackendOptions.scala
@@ -83,8 +83,10 @@ object SttpBackendOptions {
         }
 
         override def connectFailed(uri: net.URI, sa: SocketAddress, ioe: IOException): Unit = {
-          throw new UnsupportedOperationException(s"Couldn't connect to the proxy server, uri: ${uri}, " +
-            s"socket: ${sa}, ioe: ${ioe.getMessage}")
+          throw new UnsupportedOperationException(
+            s"Couldn't connect to the proxy server, uri: ${uri}, " +
+              s"socket: ${sa}, ioe: ${ioe.getMessage}"
+          )
         }
       }
     def asJavaProxy = new java.net.Proxy(proxyType.asJava, inetSocketAddress)

--- a/core/src/main/scala/sttp/client3/SttpBackendOptions.scala
+++ b/core/src/main/scala/sttp/client3/SttpBackendOptions.scala
@@ -83,7 +83,8 @@ object SttpBackendOptions {
         }
 
         override def connectFailed(uri: net.URI, sa: SocketAddress, ioe: IOException): Unit = {
-          throw new UnsupportedOperationException("Couldn't connect to the proxy server.")
+          throw new UnsupportedOperationException(s"Couldn't connect to the proxy server, uri: ${uri}, " +
+            s"socket: ${sa}, ioe: ${ioe.getMessage}")
         }
       }
     def asJavaProxy = new java.net.Proxy(proxyType.asJava, inetSocketAddress)

--- a/core/src/test/scala/sttp/client3/SttpBackendOptionsProxyTest.scala
+++ b/core/src/test/scala/sttp/client3/SttpBackendOptionsProxyTest.scala
@@ -1,7 +1,12 @@
 package sttp.client3
 
+import org.scalatest.Assertions.assertThrows
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
+
+import java.io.IOException
+import java.net
+import java.net.SocketAddress
 
 class SttpBackendOptionsProxyTest extends AnyFlatSpec with Matchers {
 
@@ -127,5 +132,24 @@ class SttpBackendOptionsProxyTest extends AnyFlatSpec with Matchers {
     )
 
     proxySetting.ignoreProxy("localhost") should be(false)
+  }
+
+  it should "throw UnsupportedOperationException with reason" in {
+    val proxySetting = SttpBackendOptions.Proxy(
+      "fakeproxyserverhost",
+      8080,
+      SttpBackendOptions.ProxyType.Http,
+      nonProxyHosts = Nil,
+      onlyProxyHosts = Nil
+    )
+    val uri = new net.URI("foo")
+    val localAddress = new net.InetSocketAddress(8888)
+    val ioe = new IOException("bar")
+
+    val proxySelector = proxySetting.asJavaProxySelector
+    val ex = intercept[UnsupportedOperationException] {
+      proxySelector.connectFailed(uri, localAddress, ioe)
+    }
+    ex.getMessage should be("Couldn't connect to the proxy server, uri: foo, socket: 0.0.0.0/0.0.0.0:8888, ioe: bar")
   }
 }

--- a/core/src/test/scala/sttp/client3/SttpBackendOptionsProxyTest.scala
+++ b/core/src/test/scala/sttp/client3/SttpBackendOptionsProxyTest.scala
@@ -1,12 +1,10 @@
 package sttp.client3
 
-import org.scalatest.Assertions.assertThrows
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
 import java.io.IOException
-import java.net
-import java.net.SocketAddress
+import java.net.URI
 
 class SttpBackendOptionsProxyTest extends AnyFlatSpec with Matchers {
 
@@ -142,14 +140,13 @@ class SttpBackendOptionsProxyTest extends AnyFlatSpec with Matchers {
       nonProxyHosts = Nil,
       onlyProxyHosts = Nil
     )
-    val uri = new net.URI("foo")
-    val localAddress = new net.InetSocketAddress(8888)
-    val ioe = new IOException("bar")
 
     val proxySelector = proxySetting.asJavaProxySelector
     val ex = intercept[UnsupportedOperationException] {
-      proxySelector.connectFailed(uri, localAddress, ioe)
+      val uri = new URI("foo")
+      val ioe = new IOException("bar")
+      proxySelector.connectFailed(uri, proxySetting.inetSocketAddress, ioe)
     }
-    ex.getMessage should be("Couldn't connect to the proxy server, uri: foo, socket: 0.0.0.0/0.0.0.0:8888, ioe: bar")
+    ex.getMessage should be("Couldn't connect to the proxy server, uri: foo, socket: fakeproxyserverhost:8080, ioe: bar")
   }
 }


### PR DESCRIPTION
…tablished

Before submitting pull request:
- [x] Check if the project compiles by running `sbt compile`
- [x] Verify docs compilation by running `sbt compileDocs`
- [ ] Check if tests pass by running `sbt test`
- [x] Format code by running `sbt scalafmt`

Issue https://github.com/softwaremill/sttp/issues/1031#issuecomment-877213332
We use sttp with okhttpbackaend to connect external service via proxy.
Sometimes SttpBackendOptions fired UnsupportedOperationException without any message from IOException.
This change could help to find the reason why the connection could not be established.
