### PR TITLE
Added separate instance for MonadError

### DIFF
--- a/effects/cats-ce2/src/main/scala/sttp/client3/impl/cats/CatsMonadAsyncError.scala
+++ b/effects/cats-ce2/src/main/scala/sttp/client3/impl/cats/CatsMonadAsyncError.scala
@@ -3,27 +3,7 @@ package sttp.client3.impl.cats
 import cats.effect.Concurrent
 import sttp.monad.{Canceler, MonadAsyncError}
 
-class CatsMonadAsyncError[F[_]](implicit F: Concurrent[F]) extends MonadAsyncError[F] {
-  override def unit[T](t: T): F[T] = F.pure(t)
-
-  override def map[T, T2](fa: F[T])(f: T => T2): F[T2] = F.map(fa)(f)
-
-  override def flatMap[T, T2](fa: F[T])(f: T => F[T2]): F[T2] =
-    F.flatMap(fa)(f)
-
-  override def error[T](t: Throwable): F[T] = F.raiseError(t)
-
-  override protected def handleWrappedError[T](rt: F[T])(h: PartialFunction[Throwable, F[T]]): F[T] =
-    F.recoverWith(rt)(h)
-
+class CatsMonadAsyncError[F[_]](implicit F: Concurrent[F]) extends CatsMonadError[F] with MonadAsyncError[F] {
   override def async[T](register: ((Either[Throwable, T]) => Unit) => Canceler): F[T] =
     F.cancelable(register.andThen(c => F.delay(c.cancel())))
-
-  override def eval[T](t: => T): F[T] = F.delay(t)
-
-  override def suspend[T](t: => F[T]): F[T] = F.suspend(t)
-
-  override def flatten[T](ffa: F[F[T]]): F[T] = F.flatten(ffa)
-
-  override def ensure[T](f: F[T], e: => F[Unit]): F[T] = F.guarantee(f)(e)
 }

--- a/effects/cats-ce2/src/main/scala/sttp/client3/impl/cats/CatsMonadError.scala
+++ b/effects/cats-ce2/src/main/scala/sttp/client3/impl/cats/CatsMonadError.scala
@@ -1,0 +1,26 @@
+package sttp.client3.impl.cats
+
+import cats.effect.Sync
+import sttp.monad.MonadError
+
+class CatsMonadError[F[_]](implicit F: Sync[F]) extends MonadError[F] {
+  override def unit[T](t: T): F[T] = F.pure(t)
+
+  override def map[T, T2](fa: F[T])(f: T => T2): F[T2] = F.map(fa)(f)
+
+  override def flatMap[T, T2](fa: F[T])(f: T => F[T2]): F[T2] =
+    F.flatMap(fa)(f)
+
+  override def error[T](t: Throwable): F[T] = F.raiseError(t)
+
+  override protected def handleWrappedError[T](rt: F[T])(h: PartialFunction[Throwable, F[T]]): F[T] =
+    F.recoverWith(rt)(h)
+
+  override def eval[T](t: => T): F[T] = F.delay(t)
+
+  override def suspend[T](t: => F[T]): F[T] = F.defer(t)
+
+  override def flatten[T](ffa: F[F[T]]): F[T] = F.flatten(ffa)
+
+  override def ensure[T](f: F[T], e: => F[Unit]): F[T] = F.guarantee(f)(e)
+}

--- a/effects/cats-ce2/src/main/scala/sttp/client3/impl/cats/implicits.scala
+++ b/effects/cats-ce2/src/main/scala/sttp/client3/impl/cats/implicits.scala
@@ -1,6 +1,6 @@
 package sttp.client3.impl.cats
 
-import cats.effect.Concurrent
+import cats.effect.{Concurrent, Sync}
 import cats.~>
 import sttp.capabilities.Effect
 import sttp.client3.monad.{FunctionK, MapEffect}
@@ -9,12 +9,16 @@ import sttp.monad.{MonadAsyncError, MonadError}
 
 object implicits extends CatsImplicits
 
-trait CatsImplicits {
+trait CatsImplicits extends LowerLevelCatsImplicits {
   implicit final def sttpBackendToCatsMappableSttpBackend[R[_], P](
       sttpBackend: SttpBackend[R, P]
   ): MappableSttpBackend[R, P] = new MappableSttpBackend(sttpBackend)
 
   implicit final def asyncMonadError[F[_]: Concurrent]: MonadAsyncError[F] = new CatsMonadAsyncError[F]
+}
+
+trait LowerLevelCatsImplicits {
+  implicit final def monadError[F[_]: Sync]: MonadError[F] = new CatsMonadError[F]
 }
 
 final class MappableSttpBackend[F[_], P] private[cats] (

--- a/effects/cats/src/main/scala/sttp/client3/impl/cats/CatsMonadAsyncError.scala
+++ b/effects/cats/src/main/scala/sttp/client3/impl/cats/CatsMonadAsyncError.scala
@@ -5,25 +5,7 @@ import cats.syntax.functor._
 import cats.syntax.option._
 import sttp.monad.{Canceler, MonadAsyncError}
 
-class CatsMonadAsyncError[F[_]](implicit F: Async[F]) extends MonadAsyncError[F] {
-  override def unit[T](t: T): F[T] = F.pure(t)
-
-  override def map[T, T2](fa: F[T])(f: T => T2): F[T2] = F.map(fa)(f)
-
-  override def flatMap[T, T2](fa: F[T])(f: T => F[T2]): F[T2] =
-    F.flatMap(fa)(f)
-
-  override def error[T](t: Throwable): F[T] = F.raiseError(t)
-
-  override protected def handleWrappedError[T](rt: F[T])(h: PartialFunction[Throwable, F[T]]): F[T] =
-    F.recoverWith(rt)(h)
-
+class CatsMonadAsyncError[F[_]](implicit F: Async[F]) extends CatsMonadError[F] with MonadAsyncError[F] {
   override def async[T](register: ((Either[Throwable, T]) => Unit) => Canceler): F[T] =
     F.async(cb => F.delay(register(cb)).map(c => F.delay(c.cancel()).some))
-
-  override def eval[T](t: => T): F[T] = F.delay(t)
-
-  override def flatten[T](ffa: F[F[T]]): F[T] = F.flatten(ffa)
-
-  override def ensure[T](f: F[T], e: => F[Unit]): F[T] = F.guaranteeCase(f)(_ => e)
 }

--- a/effects/cats/src/main/scala/sttp/client3/impl/cats/CatsMonadError.scala
+++ b/effects/cats/src/main/scala/sttp/client3/impl/cats/CatsMonadError.scala
@@ -1,0 +1,24 @@
+package sttp.client3.impl.cats
+
+import cats.effect.kernel.Sync
+import sttp.monad.MonadError
+
+class CatsMonadError[F[_]](implicit F: Sync[F]) extends MonadError[F] {
+  override def unit[T](t: T): F[T] = F.pure(t)
+
+  override def map[T, T2](fa: F[T])(f: T => T2): F[T2] = F.map(fa)(f)
+
+  override def flatMap[T, T2](fa: F[T])(f: T => F[T2]): F[T2] =
+    F.flatMap(fa)(f)
+
+  override def error[T](t: Throwable): F[T] = F.raiseError(t)
+
+  override protected def handleWrappedError[T](rt: F[T])(h: PartialFunction[Throwable, F[T]]): F[T] =
+    F.recoverWith(rt)(h)
+
+  override def eval[T](t: => T): F[T] = F.delay(t)
+
+  override def flatten[T](ffa: F[F[T]]): F[T] = F.flatten(ffa)
+
+  override def ensure[T](f: F[T], e: => F[Unit]): F[T] = F.guaranteeCase(f)(_ => e)
+}

--- a/effects/cats/src/main/scala/sttp/client3/impl/cats/implicits.scala
+++ b/effects/cats/src/main/scala/sttp/client3/impl/cats/implicits.scala
@@ -1,6 +1,6 @@
 package sttp.client3.impl.cats
 
-import cats.effect.kernel.Async
+import cats.effect.kernel.{Sync, Async}
 import cats.~>
 import sttp.capabilities.Effect
 import sttp.client3.monad.{FunctionK, MapEffect}
@@ -9,12 +9,16 @@ import sttp.monad.{MonadAsyncError, MonadError}
 
 object implicits extends CatsImplicits
 
-trait CatsImplicits {
+trait CatsImplicits extends LowerLevelCatsImplicits {
   implicit final def sttpBackendToCatsMappableSttpBackend[R[_], P](
       sttpBackend: SttpBackend[R, P]
   ): MappableSttpBackend[R, P] = new MappableSttpBackend(sttpBackend)
 
   implicit final def asyncMonadError[F[_]: Async]: MonadAsyncError[F] = new CatsMonadAsyncError[F]
+}
+
+trait LowerLevelCatsImplicits {
+  implicit final def monadError[F[_]: Sync]: MonadError[F] = new CatsMonadError[F]
 }
 
 final class MappableSttpBackend[F[_], P] private[cats] (


### PR DESCRIPTION
There was no cats instance for MonadError, and not every effect has Async instance, so I'd added separate instance for such effects.