### PR TITLE
update client if request-timeout differs from client-timeout

### DIFF
--- a/okhttp-backend/src/main/scala/sttp/client3/okhttp/OkHttpBackend.scala
+++ b/okhttp-backend/src/main/scala/sttp/client3/okhttp/OkHttpBackend.scala
@@ -153,12 +153,13 @@ object OkHttpBackend {
   }
 
   private[okhttp] def updateClientIfCustomReadTimeout[T, S](r: Request[T, S], client: OkHttpClient): OkHttpClient = {
-    val readTimeout = r.options.readTimeout
-    if (readTimeout == DefaultReadTimeout) client
+    val readTimeoutMillis = if (r.options.readTimeout.isFinite) r.options.readTimeout.toMillis else 0
+    val reuseClient = readTimeoutMillis == client.readTimeoutMillis()
+    if (reuseClient) client
     else
       client
         .newBuilder()
-        .readTimeout(if (readTimeout.isFinite) readTimeout.toMillis else 0, TimeUnit.MILLISECONDS)
+        .readTimeout(readTimeoutMillis, TimeUnit.MILLISECONDS)
         .build()
   }
 


### PR DESCRIPTION
Before submitting pull request:
- [x] Check if the project compiles by running `sbt compile`
- [x] Verify docs compilation by running `sbt compileDocs`
- [ ] Check if tests pass by running `sbt test` (please see my comment below)
- [x] Format code by running `sbt scalafmt` 

Hi 👋 

I have noticed a problem when using sttp with OkHttp the following way:
```
// the following line creates an OkHttpClient with a default read timeout of 10seconds
val okHttpClient = new OkHttpClient.Builder().build()
val okHttpBackend = OkHttpFutureBackend.usingClient(okHttpClient)

basicRequest
      .post(uri)
      .body("hello")
      .readTimeout(60.seconds)
      .send(okHttpBackend)
```

I would expected that the read timeout for this request should be 60 seconds, but in reality it is 10 seconds.
The problem is that the `updateClientIfCustomReadTimeout` in `OkHttpBackend.scala` checks if the read-timeout from the request equals `DefaultReadTimeout` (which is true since it is also 60 seconds) and then it just returns the original client (I think this is because the function `OkHttpBackend.defaultClient` creates a client with a 60 second read-timeout). However, my client timeout is set to 10 seconds. My suggestion would be to instead of checking if the read-timeout from the request equals `DefaultReadTimeout` to check if the request read-timeout differs from the client read-timeout.
If so, we should update the client with the read-timeout from the requests, otherwise we can reuse the client as is.

I look forward to your feedback!

Note: the following tests failed when running `sbt test`, but they also failed for the current master commit without my changes. Unfortunately, I am not sure how to setup this project on my Mac properly in order to run the tests:
(finagleBackend2_12 / Test / test) sbt.TestsFailedException: Tests unsuccessful
[error] (core2_12 / Test / test) sbt.TestsFailedException: Tests unsuccessful
[error] (json4s2_11 / Test / test) sbt.TestsFailedException: Tests unsuccessful
[error] (json4s / Test / test) sbt.TestsFailedException: Tests unsuccessful
[error] (finagleBackend / Test / test) sbt.TestsFailedException: Tests unsuccessful
[error] (core3 / Test / test) sbt.TestsFailedException: Tests unsuccessful
[error] (core2_11 / Test / test) sbt.TestsFailedException: Tests unsuccessful
[error] (json4s2_12 / Test / test) sbt.TestsFailedException: Tests unsuccessful
[error] (core / Test / test) sbt.TestsFailedException: Tests unsuccessful