### PR TITLE
Cross-compile json4s module to Scala 3

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -794,7 +794,7 @@ lazy val json4s = (projectMatrix in file("json/json4s"))
     ),
     scalaTest
   )
-  .jvmPlatform(scalaVersions = scala2)
+  .jvmPlatform(scalaVersions = scala2 ++ scala3)
   .dependsOn(core, jsonCommon)
 
 lazy val sprayJson = (projectMatrix in file("json/spray-json"))


### PR DESCRIPTION
[json4s](https://mvnrepository.com/artifact/org.json4s/json4s-core_3/4.0.3) is already cross-compiled to scala3, so i think that json4s module could also support it