### PR TITLE
Allow custom Span name for ZIO opentelemetry backend

### DIFF
--- a/docs/backends/wrappers/zio-opentelemetry.md
+++ b/docs/backends/wrappers/zio-opentelemetry.md
@@ -20,9 +20,8 @@ ZioTelemetryOpenTelemetryBackend(
 )
 ```
 
-Additionally you can add tags per request by supplying a `ZioTelemetryOpenTelemetryTracer`
-(by default, all that happens is that the span for the request is named after using the HTTP method
-and path).
+By default, the span is named after the HTTP method (e.g "HTTP POST") as [recommended by OpenTelemetry](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/http.md#name) for HTTP clients.
+You can override the default span name or add additional tags per request by supplying a `ZioTelemetryOpenTelemetryTracer`.
 
 ```scala mdoc:compile-only
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
@@ -35,6 +34,8 @@ val zioBackend: SttpBackend[Task, Any] = ???
 val tracing: Tracing.Service = ???
 
 def sttpTracer: ZioTelemetryOpenTelemetryTracer = new ZioTelemetryOpenTelemetryTracer {
+    override def spanName[T](request: Request[T, Nothing]): String = ???
+
     def before[T](request: Request[T, Nothing]): RIO[Tracing, Unit] =
       Tracing.setAttribute(SemanticAttributes.HTTP_METHOD.getKey, request.method.method) *>
       Tracing.setAttribute(SemanticAttributes.HTTP_URL.getKey, request.uri.toString()) *>

--- a/metrics/zio-telemetry-open-telemetry-backend/src/main/scala/sttp/client3/ziotelemetry/opentelemetry/ZioTelemetryOpenTelemetryBackend.scala
+++ b/metrics/zio-telemetry-open-telemetry-backend/src/main/scala/sttp/client3/ziotelemetry/opentelemetry/ZioTelemetryOpenTelemetryBackend.scala
@@ -27,7 +27,7 @@ private class ZioTelemetryOpenTelemetryBackend[+P](
       resp <- delegate.send(request.headers(carrier.toMap))
       _ <- tracer.after(resp)
     } yield resp)
-      .span(s"${request.method.method} ${request.uri.path.mkString("/")}", SpanKind.CLIENT)
+      .span(tracer.spanName(request), SpanKind.CLIENT)
       .provide(tracing)
   }
 }
@@ -43,6 +43,7 @@ object ZioTelemetryOpenTelemetryBackend {
 }
 
 trait ZioTelemetryOpenTelemetryTracer {
+  def spanName[T](request: Request[T, Nothing]): String = s"HTTP ${request.method.method}"
   def before[T](request: Request[T, Nothing]): RIO[Tracing, Unit]
   def after[T](response: Response[T]): RIO[Tracing, Unit]
 }

--- a/metrics/zio-telemetry-open-telemetry-backend/src/main/scala/sttp/client3/ziotelemetry/opentelemetry/ZioTelemetryOpenTelemetryBackend.scala
+++ b/metrics/zio-telemetry-open-telemetry-backend/src/main/scala/sttp/client3/ziotelemetry/opentelemetry/ZioTelemetryOpenTelemetryBackend.scala
@@ -1,6 +1,6 @@
 package sttp.client3.ziotelemetry.opentelemetry
 
-import io.opentelemetry.api.trace.SpanKind
+import io.opentelemetry.api.trace.{SpanKind, StatusCode}
 import io.opentelemetry.api.trace.propagation.W3CTraceContextPropagator
 import io.opentelemetry.context.propagation.{TextMapPropagator, TextMapSetter}
 import sttp.capabilities.Effect
@@ -27,7 +27,7 @@ private class ZioTelemetryOpenTelemetryBackend[+P](
       resp <- delegate.send(request.headers(carrier.toMap))
       _ <- tracer.after(resp)
     } yield resp)
-      .span(tracer.spanName(request), SpanKind.CLIENT)
+      .span(tracer.spanName(request), SpanKind.CLIENT, { case _ => StatusCode.ERROR })
       .provide(tracing)
   }
 }

--- a/metrics/zio-telemetry-open-telemetry-backend/src/test/scala/sttp/client3/ziotelemetry/opentelemetry/ZioTelemetryOpenTelemetryBackendTest.scala
+++ b/metrics/zio-telemetry-open-telemetry-backend/src/test/scala/sttp/client3/ziotelemetry/opentelemetry/ZioTelemetryOpenTelemetryBackendTest.scala
@@ -64,4 +64,13 @@ class ZioTelemetryOpenTelemetryBackendTest extends AnyFlatSpec with Matchers wit
     recordedRequests(0).header("traceparent") shouldBe Some(s"00-${traceId}-${spanId}-01")
   }
 
+  it should "set span status in case of error" in {
+    runtime.unsafeRunSync(basicRequest.post(uri"http://stub/error").send(backend))
+
+    val spans = spanExporter.getFinishedSpanItems.asScala
+    spans should have size 1
+
+    spans.head.getStatus.getStatusCode shouldBe io.opentelemetry.api.trace.StatusCode.ERROR
+  }
+
 }

--- a/metrics/zio-telemetry-open-telemetry-backend/src/test/scala/sttp/client3/ziotelemetry/opentelemetry/ZioTelemetryOpenTelemetryBackendTest.scala
+++ b/metrics/zio-telemetry-open-telemetry-backend/src/test/scala/sttp/client3/ziotelemetry/opentelemetry/ZioTelemetryOpenTelemetryBackendTest.scala
@@ -49,7 +49,7 @@ class ZioTelemetryOpenTelemetryBackendTest extends AnyFlatSpec with Matchers wit
 
     val spans = spanExporter.getFinishedSpanItems.asScala
     spans should have size 1
-    spans.head.getName shouldBe "POST echo"
+    spans.head.getName shouldBe "HTTP POST"
   }
 
   it should "propagate span" in {


### PR DESCRIPTION
By default, Span name for each request is **fixed** and based on the HTTP method and path.

https://github.com/softwaremill/sttp/blob/e4b66b6bdef8b6ae68f618839a0896fec377ea89/metrics/zio-telemetry-open-telemetry-backend/src/main/scala/sttp/client3/ziotelemetry/opentelemetry/ZioTelemetryOpenTelemetryBackend.scala#L29-L31

This default is not recommended by [OpenTelemetry HTTP conventions](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/http.md#name).

>Many REST APIs encode parameters into URI path, e.g. /api/users/123 where 123 is a user id, which creates high cardinality value space not suitable for span names. In case of HTTP servers, these endpoints are often mapped by the server frameworks to more concise HTTP routes, e.g. /api/users/{user_id}, which are recommended as the low cardinality span names. However, the same approach usually does not work for HTTP client spans, especially when instrumentation is provided by a lower-level middleware that is not aware of the specifics of how the URIs are formed. Therefore, HTTP client spans SHOULD be using conservative, low cardinality names formed from the available parameters of an HTTP request, such as "HTTP {METHOD_NAME}". Instrumentation MUST NOT default to using URI path as span name, but MAY provide hooks to allow custom logic to override the default span name.

This PR provides a better default Span name and allow users to override if needed. Also, it would set Span status to Error in case of failures, as suggested by [OpenTelemetry HTTP conventions](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/http.md#status).

>Span Status MUST be left unset if HTTP status code was in the 1xx, 2xx or 3xx ranges, unless there was another error (e.g., network error receiving the response body; or 3xx codes with max redirects exceeded), in which case status MUST be set to Error.
>For HTTP status codes in the 4xx and 5xx ranges, as well as any other code the client failed to interpret, status MUST be set to Error.
>Don't set the span status description if the reason can be inferred from http.status_code.