### PR TITLE
Fix typo in examples.md

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -147,7 +147,7 @@ Example code:
 Required dependencies:
 
 ```scala
-libraryDependencies ++= List("com.softwaremill.sttp.client3" %% "async-http-client-backend-fs2 % "@VERSION@")
+libraryDependencies ++= List("com.softwaremill.sttp.client3" %% "async-http-client-backend-fs2" % "@VERSION@")
 ```
 
 Example code:


### PR DESCRIPTION
Just a missing double quote in the sbt deps.

Before submitting pull request:
- [x] Check if the project compiles by running `sbt compile`
- [x] Verify docs compilation by running `sbt compileDocs`
- [x] Check if tests pass by running `sbt test`
- [x] Format code by running `sbt scalafmt`
