### PR TITLE
Split zio-json module for zio 1.x and 2.x

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -118,10 +118,6 @@ val circeVersion: Option[(Long, Long)] => String = {
 
 val jsoniterVersion = "2.13.2"
 
-val zioJsonVersion: Option[(Long, Long)] => String = {
-  case Some((3, _)) => "0.2.0-M3"
-  case _            => "0.1.5"
-}
 val playJsonVersion: Option[(Long, Long)] => String = {
   case Some((2, 11)) => "2.7.4"
   case _             => "2.9.2"
@@ -205,6 +201,7 @@ lazy val allAggregates = projectsWithOptionalNative ++
   http4sCe2Backend.projectRefs ++
   http4sBackend.projectRefs ++
   circe.projectRefs ++
+  zio1Json.projectRefs ++
   zioJson.projectRefs ++
   json4s.projectRefs ++
   jsoniter.projectRefs ++
@@ -847,6 +844,23 @@ lazy val zioJson = (projectMatrix in file("json/zio-json"))
     name := "zio-json",
     libraryDependencies ++= Seq(
       "dev.zio" %%% "zio-json" % "0.3.0-RC3",
+      "com.softwaremill.sttp.shared" %%% "zio" % sttpSharedVersion
+    ),
+    scalaTest
+  )
+  .jvmPlatform(
+    scalaVersions = Seq(scala2_12, scala2_13) ++ scala3,
+    settings = commonJvmSettings
+  )
+  .jsPlatform(scalaVersions = List(scala2_12, scala2_13) ++ scala3, settings = commonJsSettings)
+  .dependsOn(core, jsonCommon)
+
+
+lazy val zio1Json = (projectMatrix in file("json/zio1-json"))
+  .settings(
+    name := "zio1-json",
+    libraryDependencies ++= Seq(
+      "dev.zio" %%% "zio-json" % "0.2.0-M3",
       "com.softwaremill.sttp.shared" %%% "zio1" % sttpSharedVersion
     ),
     scalaTest

--- a/build.sbt
+++ b/build.sbt
@@ -855,7 +855,6 @@ lazy val zioJson = (projectMatrix in file("json/zio-json"))
   .jsPlatform(scalaVersions = List(scala2_12, scala2_13) ++ scala3, settings = commonJsSettings)
   .dependsOn(core, jsonCommon)
 
-
 lazy val zio1Json = (projectMatrix in file("json/zio1-json"))
   .settings(
     name := "zio1-json",

--- a/docs/json.md
+++ b/docs/json.md
@@ -140,7 +140,7 @@ To use, add an import: `import sttp.client3.playJson._`.
 ## zio-json
 
 To encode and decode JSON using the high-performance [zio-json](https://zio.github.io/zio-json/) library, one add the following dependency to your project.
-The json-zio modules depend on ZIO 2.x. For ZIO 1.x support, use zio1-json.
+The zio-json module depends on ZIO 2.x. For ZIO 1.x support, use zio1-json.
 
 ```scala
 "com.softwaremill.sttp.client3" %% "zio-json" % "@VERSION@"  // for ZIO 2.x

--- a/docs/json.md
+++ b/docs/json.md
@@ -140,13 +140,16 @@ To use, add an import: `import sttp.client3.playJson._`.
 ## zio-json
 
 To encode and decode JSON using the high-performance [zio-json](https://zio.github.io/zio-json/) library, one add the following dependency to your project.
+The json-zio modules depend on ZIO 2.x. For ZIO 1.x support, use zio1-json.
 
 ```scala
-"com.softwaremill.sttp.client3" %% "zio-json" % "@VERSION@"
+"com.softwaremill.sttp.client3" %% "zio-json" % "@VERSION@"  // for ZIO 2.x
+"com.softwaremill.sttp.client3" %% "zio1-json" % "@VERSION@" // for ZIO 1.x
 ```
 or for ScalaJS (cross build) projects:
 ```scala
-"com.softwaremill.sttp.client3" %%% "zio-json" % "@VERSION@"
+"com.softwaremill.sttp.client3" %%% "zio-json" % "@VERSION@"  // for ZIO 2.x
+"com.softwaremill.sttp.client3" %%% "zio1-json" % "@VERSION@" // for ZIO 1.x
 ```
 
 To use, add an import: `import sttp.client3.ziojson._` (or extend `SttpZioJsonApi`), define an implicit `JsonCodec`, or `JsonDecoder`/`JsonEncoder` for your datatype.

--- a/json/zio1-json/src/main/scala/sttp/client3/ziojson/SttpZioJsonApi.scala
+++ b/json/zio1-json/src/main/scala/sttp/client3/ziojson/SttpZioJsonApi.scala
@@ -1,0 +1,57 @@
+package sttp.client3.ziojson
+
+import sttp.client3.internal.Utf8
+import sttp.client3.json.RichResponseAs
+import sttp.client3.{
+  BodySerializer,
+  DeserializationException,
+  HttpError,
+  IsOption,
+  JsonInput,
+  ResponseAs,
+  ResponseException,
+  ShowError,
+  StringBody,
+  asString,
+  asStringAlways
+}
+import sttp.model.MediaType
+
+trait SttpZioJsonApi extends SttpZioJsonApiExtensions {
+  import zio.json._
+  private[ziojson] implicit val stringShowError: ShowError[String] = t => t
+
+  implicit def zioJsonBodySerializer[B: JsonEncoder]: BodySerializer[B] =
+    b => StringBody(b.toJson, Utf8, MediaType.ApplicationJson)
+
+  /** If the response is successful (2xx), tries to deserialize the body from a string into JSON. Returns:
+    *   - `Right(b)` if the parsing was successful
+    *   - `Left(HttpError(String))` if the response code was other than 2xx (deserialization is not attempted)
+    *   - `Left(DeserializationException)` if there's an error during deserialization
+    */
+  def asJson[B: JsonDecoder: IsOption]: ResponseAs[Either[ResponseException[String, String], B], Any] =
+    asString.mapWithMetadata(ResponseAs.deserializeRightWithError(deserializeJson)).showAsJson
+
+  /** Tries to deserialize the body from a string into JSON, regardless of the response code. Returns:
+    *   - `Right(b)` if the parsing was successful
+    *   - `Left(DeserializationException)` if there's an error during deserialization
+    */
+  def asJsonAlways[B: JsonDecoder: IsOption]: ResponseAs[Either[DeserializationException[String], B], Any] =
+    asStringAlways.map(ResponseAs.deserializeWithError(deserializeJson)).showAsJsonAlways
+
+  /** Tries to deserialize the body from a string into JSON, using different deserializers depending on the status code.
+    * Returns:
+    *   - `Right(B)` if the response was 2xx and parsing was successful
+    *   - `Left(HttpError(E))` if the response was other than 2xx and parsing was successful
+    *   - `Left(DeserializationException)` if there's an error during deserialization
+    */
+  def asJsonEither[E: JsonDecoder: IsOption, B: JsonDecoder: IsOption]
+      : ResponseAs[Either[ResponseException[E, String], B], Any] =
+    asJson[B].mapLeft {
+      case HttpError(e, code) => deserializeJson[E].apply(e).fold(DeserializationException(e, _), HttpError(_, code))
+      case de @ DeserializationException(_, _) => de
+    }.showAsJsonEither
+
+  def deserializeJson[B: JsonDecoder: IsOption]: String => Either[String, B] =
+    JsonInput.sanitize[B].andThen(_.fromJson[B])
+}

--- a/json/zio1-json/src/main/scala/sttp/client3/ziojson/ziojson.scala
+++ b/json/zio1-json/src/main/scala/sttp/client3/ziojson/ziojson.scala
@@ -1,0 +1,3 @@
+package sttp.client3
+
+package object ziojson extends SttpZioJsonApi

--- a/json/zio1-json/src/main/scalajs/sttp/client3/ziojson/SttpZioJsonApiExtensions.scala
+++ b/json/zio1-json/src/main/scalajs/sttp/client3/ziojson/SttpZioJsonApiExtensions.scala
@@ -1,0 +1,3 @@
+package sttp.client3.ziojson
+
+trait SttpZioJsonApiExtensions {}

--- a/json/zio1-json/src/main/scalajvm/sttp/client3/ziojson/SttpZioJsonApiExtensions.scala
+++ b/json/zio1-json/src/main/scalajvm/sttp/client3/ziojson/SttpZioJsonApiExtensions.scala
@@ -1,0 +1,23 @@
+package sttp.client3.ziojson
+
+import sttp.capabilities.Effect
+import sttp.capabilities.zio.ZioStreams
+import sttp.client3.{DeserializationException, HttpError, IsOption, ResponseAs, ResponseException, asStream}
+import zio.blocking.Blocking
+import zio.json.JsonDecoder
+import zio.stream.ZTransducer
+import zio.{RIO, ZIO}
+
+trait SttpZioJsonApiExtensions { this: SttpZioJsonApi =>
+  def asJsonStream[B: JsonDecoder: IsOption]
+      : ResponseAs[Either[ResponseException[String, String], B], Effect[RIO[Blocking, *]] with ZioStreams] =
+    asStream(ZioStreams)(s =>
+      JsonDecoder[B]
+        .decodeJsonStream(s >>> ZTransducer.utf8Decode.mapChunks(_.flatMap(_.toCharArray)))
+        .map(Right(_))
+        .catchSome { case e => ZIO.left(DeserializationException("", e.getMessage)) }
+    ).mapWithMetadata {
+      case (Left(s), meta) => Left(HttpError(s, meta.code))
+      case (Right(s), _)   => s
+    }
+}

--- a/json/zio1-json/src/test/scala/sttp/client3/ziojson/ZioJsonTests.scala
+++ b/json/zio1-json/src/test/scala/sttp/client3/ziojson/ZioJsonTests.scala
@@ -1,0 +1,131 @@
+package sttp.client3.ziojson
+
+import org.scalatest.EitherValues
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import zio.json._
+import sttp.client3._
+import sttp.client3.internal.Utf8
+
+import sttp.model._
+
+class ZioJsonTests extends AnyFlatSpec with Matchers with EitherValues {
+
+  "The ziojson module" should "encode arbitrary bodies given an encoder" in {
+    val body = Outer(Inner(42, true, "horses"), "cats")
+    val expected = """{"foo":{"a":42,"b":true,"c":"horses"},"bar":"cats"}"""
+    val req = basicRequest.body(body)
+    extractBody(req) shouldBe expected
+  }
+
+  it should "decode arbitrary bodies given a decoder" in {
+    val body = """{"foo":{"a":42,"b":true,"c":"horses"},"bar":"cats"}"""
+    val expected = Outer(Inner(42, true, "horses"), "cats")
+
+    val responseAs = asJson[Outer]
+
+    runJsonResponseAs(responseAs)(body).right.value shouldBe expected
+  }
+
+  it should "decode None from empty body" in {
+    val responseAs = asJson[Option[Inner]]
+
+    runJsonResponseAs(responseAs)("").right.value shouldBe None
+  }
+
+  it should "decode Left(None) from empty body" in {
+    import EitherDecoders._
+    val responseAs = asJson[Either[Option[Inner], Outer]]
+
+    runJsonResponseAs(responseAs)("").right.value shouldBe Left(None)
+  }
+
+  it should "decode Right(None) from empty body" in {
+    import EitherDecoders._
+    val responseAs = asJson[Either[Outer, Option[Inner]]]
+
+    runJsonResponseAs(responseAs)("").right.value shouldBe Right(None)
+  }
+
+  it should "fail to decode invalid json" in {
+    val body = """not valid json"""
+
+    val responseAs = asJson[Outer]
+
+    val Left(DeserializationException(original, _)) = runJsonResponseAs(responseAs)(body)
+    original shouldBe body
+  }
+
+  it should "fail to decode from empty input" in {
+    val responseAs = asJson[Inner]
+
+    runJsonResponseAs(responseAs)("").left.value should matchPattern { case DeserializationException("", _: String) =>
+    }
+  }
+
+  it should "read what it writes" in {
+    val outer = Outer(Inner(42, true, "horses"), "cats")
+
+    val encoded = extractBody(basicRequest.body(outer))
+    val decoded = runJsonResponseAs(asJson[Outer])(encoded)
+
+    decoded.right.value shouldBe outer
+  }
+
+  it should "set the content type" in {
+    val body = Outer(Inner(42, true, "horses"), "cats")
+    val req = basicRequest.body(body)
+
+    val ct = req.headers.map(h => (h.name, h.value)).toMap.get("Content-Type")
+
+    ct shouldBe Some(MediaType.ApplicationJson.copy(charset = Some(Utf8)).toString)
+  }
+
+  it should "only set the content type if it was not set earlier" in {
+    val body = Outer(Inner(42, true, "horses"), "cats")
+    val req = basicRequest.contentType("horses/cats").body(body)
+
+    val ct = req.headers.map(h => (h.name, h.value)).toMap.get("Content-Type")
+
+    ct shouldBe Some("horses/cats")
+  }
+
+  def extractBody[A[_], B, C](request: RequestT[A, B, C]): String =
+    request.body match {
+      case StringBody(body, "utf-8", MediaType.ApplicationJson) =>
+        body
+      case wrongBody =>
+        fail(s"Request body does not serialize to correct StringBody: $wrongBody")
+    }
+
+  def runJsonResponseAs[A](responseAs: ResponseAs[A, Nothing]): String => A =
+    responseAs match {
+      case responseAs: MappedResponseAs[_, A, Nothing] =>
+        responseAs.raw match {
+          case ResponseAsByteArray =>
+            s => responseAs.g(s.getBytes(Utf8), ResponseMetadata(StatusCode.Ok, "", Nil))
+          case _ =>
+            fail("MappedResponseAs does not wrap a ResponseAsByteArray")
+        }
+      case _ => fail("ResponseAs is not a MappedResponseAs")
+    }
+
+  object EitherDecoders {
+    implicit def decoder[L: JsonDecoder, R: JsonDecoder]: JsonDecoder[Either[L, R]] =
+      implicitly[JsonDecoder[L]] <+> implicitly[JsonDecoder[R]]
+  }
+}
+
+case class Inner(a: Int, b: Boolean, c: String)
+
+object Inner {
+  implicit val encoder: JsonEncoder[Inner] = DeriveJsonEncoder.gen[Inner]
+  implicit val codec: JsonDecoder[Inner] = DeriveJsonDecoder.gen[Inner]
+}
+
+case class Outer(foo: Inner, bar: String)
+
+object Outer {
+  implicit val encoder: JsonEncoder[Outer] = DeriveJsonEncoder.gen[Outer]
+  implicit val codec: JsonDecoder[Outer] = DeriveJsonDecoder.gen[Outer]
+}


### PR DESCRIPTION
As described in the zio-json releases:
```
For some time, releases targetting ZIO 1 will be using the version 0.2.x, whereas releases targetting ZIO 2 will be using the version 0.3.x
```

I think we should publish two targets:
1. `com.softwaremill.sttp.client3:zio-json_2.13`  which depends on `zio-json:0.3.X` for ZIO2
2. `com.softwaremill.sttp.client3:zio1-json_2.13`  which depends on `zio-json:0.2.X` for ZIO

The helper to get the zio-json version was not used anymore.
I think that this was not spotted because the matrix release is only for zio-2 at the moment

Before submitting pull request:
- [x] Check if the project compiles by running `sbt compile`
- [x] Verify docs compilation by running `sbt compileDocs`
- [x] Check if tests pass by running `sbt test`
- [x] Format code by running `sbt scalafmt`
