### PR TITLE
Update future.md

### DIFF
--- a/docs/backends/future.md
+++ b/docs/backends/future.md
@@ -141,7 +141,7 @@ jdk.httpclient.allowRestrictedHeaders=host
 To use, add the following dependency to your project:
 
 ```
-"com.softwaremill.sttp.client3" %% "armeria-backend-future" % "@VERSION@"
+"com.softwaremill.sttp.client3" %% "armeria-backend" % "@VERSION@"
 ```
 
 add imports:


### PR DESCRIPTION
There is no armeria artefact with "-future" postfix in its name, it looks like documentation is trying to refer to "armeria-backend" artefact instead

Before submitting pull request:
- [ ] Check if the project compiles by running `sbt compile`
- [ ] Verify docs compilation by running `sbt compileDocs`
- [ ] Check if tests pass by running `sbt test`
- [ ] Format code by running `sbt scalafmt`
