### PR TITLE
Adding CE2 information to js fetch backends doc

### DIFF
--- a/docs/backends/javascript/fetch.md
+++ b/docs/backends/javascript/fetch.md
@@ -44,6 +44,12 @@ your project:
 "com.softwaremill.sttp.client3" %%% "cats" % "@VERSION@"
 ```
 
+If you are on Cats Effect 2 (CE2) you will need to add the CE2 specific dependency instead:
+
+```
+"com.softwaremill.sttp.client3" %%% "catsce2 % "@VERSION@"
+```
+
 And create the backend instance:
 
 ```scala


### PR DESCRIPTION
I had a bit of trouble identifying what the artifact name would be for CE2, so I figured this might help others in the future so they don't need to browse `https://repo1.maven.org/maven2/com/softwaremill/sttp/client3/` to find the dependency

Before submitting pull request:
- [x] Check if the project compiles by running `sbt compile`
- [x] Verify docs compilation by running `sbt compileDocs`
- [x] Check if tests pass by running `sbt test`
- [x] Format code by running `sbt scalafmt`
