### PR TITLE
ToCurlConverter should pass form data as --data-raw

### DIFF
--- a/core/src/main/scala/sttp/client3/internal/ToCurlConverter.scala
+++ b/core/src/main/scala/sttp/client3/internal/ToCurlConverter.scala
@@ -42,14 +42,7 @@ class ToCurlConverter[R <: RequestT[Identity, _, _]] {
 
   private def extractBody(r: R): String = {
     r.body match {
-      case StringBody(text, _, _)
-          if r.headers
-            .map(h => (h.name, h.value))
-            .toMap
-            .get(HeaderNames.ContentType)
-            .forall(_ == MediaType.ApplicationXWwwFormUrlencoded.toString) =>
-        s"""--form '${text.replace("'", "\\'")}'"""
-      case StringBody(text, _, _) => s"""--data '${text.replace("'", "\\'")}'"""
+      case StringBody(text, _, _) => s"""--data-raw '${text.replace("'", "\\'")}'"""
       case ByteArrayBody(_, _)    => s"--data-binary <PLACEHOLDER>"
       case ByteBufferBody(_, _)   => s"--data-binary <PLACEHOLDER>"
       case InputStreamBody(_, _)  => s"--data-binary <PLACEHOLDER>"

--- a/core/src/test/scala/sttp/client3/ToCurlConverterTest.scala
+++ b/core/src/test/scala/sttp/client3/ToCurlConverterTest.scala
@@ -47,19 +47,19 @@ class ToCurlConverterTest extends AnyFlatSpec with Matchers with ToCurlConverter
 
   it should "convert request with body" in {
     basicRequest.body(Map("name" -> "john", "org" -> "sml")).post(localhost).toCurl should include(
-      "--header 'Content-Type: application/x-www-form-urlencoded' \\\n  --header 'Content-Length: 17' \\\n  --form 'name=john&org=sml'"
+      "--header 'Content-Type: application/x-www-form-urlencoded' \\\n  --header 'Content-Length: 17' \\\n  --data-raw 'name=john&org=sml'"
     )
     basicRequest.body("name=john").post(localhost).toCurl should include(
-      "--header 'Content-Type: text/plain; charset=utf-8' \\\n  --header 'Content-Length: 9' \\\n  --data 'name=john'"
+      "--header 'Content-Type: text/plain; charset=utf-8' \\\n  --header 'Content-Length: 9' \\\n  --data-raw 'name=john'"
     )
     basicRequest.body("name=john", StandardCharsets.ISO_8859_1.name()).post(localhost).toCurl should include(
-      "--header 'Content-Type: text/plain; charset=ISO-8859-1' \\\n  --header 'Content-Length: 9' \\\n  --data 'name=john'"
+      "--header 'Content-Type: text/plain; charset=ISO-8859-1' \\\n  --header 'Content-Length: 9' \\\n  --data-raw 'name=john'"
     )
     basicRequest.body("name='john'").post(localhost).toCurl should include(
-      "--header 'Content-Type: text/plain; charset=utf-8' \\\n  --header 'Content-Length: 11' \\\n  --data 'name=\\'john\\''"
+      "--header 'Content-Type: text/plain; charset=utf-8' \\\n  --header 'Content-Length: 11' \\\n  --data-raw 'name=\\'john\\''"
     )
     basicRequest.body("name=\"john\"").post(localhost).toCurl should include(
-      "--header 'Content-Type: text/plain; charset=utf-8' \\\n  --header 'Content-Length: 11' \\\n  --data 'name=\"john\"'"
+      "--header 'Content-Type: text/plain; charset=utf-8' \\\n  --header 'Content-Length: 11' \\\n  --data-raw 'name=\"john\"'"
     )
   }
 


### PR DESCRIPTION
Before submitting pull request:
- [X] Check if the project compiles by running `sbt compile`
- [X] Verify docs compilation by running `sbt compileDocs`
- [X] Check if tests pass by running `sbt test`
- [X] Format code by running `sbt scalafmt`


This closes #965 
At the begging I was concerned about multiple `--data 'a=xyz'` segments in the issue, but it seems that it is an alternative way of expressing `--data 'a=xyz&b=xyz'` in curl. 

I also decided to change `--data` to `--data-raw` which does the same thing but do not have any special interpretation for the `@` character. It shouldn't really matter, but I thought that it would be better like that.