### PR TITLE
Redact sensitive headers in cURL logging

### DIFF
--- a/core/src/main/scala/sttp/client3/logging/Log.scala
+++ b/core/src/main/scala/sttp/client3/logging/Log.scala
@@ -53,7 +53,7 @@ class DefaultLog[F[_]](
     logger(
       beforeRequestSendLogLevel, {
         s"Sending request: ${
-            if (beforeCurlInsteadOfShow && _logRequestBody && _logRequestHeaders) request.toCurl
+            if (beforeCurlInsteadOfShow && _logRequestBody && _logRequestHeaders) request.toCurl(sensitiveHeaders)
             else request.show(includeBody = _logRequestBody, _logRequestHeaders, sensitiveHeaders)
           }"
       }


### PR DESCRIPTION
Fixes #1390.

Looks like sensitive headers argument was just missing.

Before submitting pull request:
- [x] Check if the project compiles by running `sbt compile`
- [x] Verify docs compilation by running `sbt compileDocs`
- [x] Check if tests pass by running `sbt test`
- [x] Format code by running `sbt scalafmt`
