### PR TITLE
[sttp-finagle] Adds concurrent cache to prevent Finagle client leak

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@ project/metals.sbt
 
 # scala-native
 lowered.hnir
+
+# VSCode
+.vscode/

--- a/.jvmopts
+++ b/.jvmopts
@@ -1,4 +1,0 @@
--Xms512M
--Xmx4096M
--Xss2M
--XX:MaxMetaspaceSize=1024M

--- a/.jvmopts
+++ b/.jvmopts
@@ -1,0 +1,4 @@
+-Xms512M
+-Xmx4096M
+-Xss2M
+-XX:MaxMetaspaceSize=1024M


### PR DESCRIPTION
sttp-finagle creates a new Finagle HTTP client upon each STTP request, causing a client leak that will result in eventual GC and resolution issues for `dest`s that reflect large clusters.

This pull request adds a `ConcurrentHashMap[String, Service[http.Request, FResponse]]` to sttp-finagle, keyed upon the Finagle `dest`. This change will pair a single Finagle client to each backend `dest`, resolving this issue. I've also added a `.jvmopts` file to the root of this repository to address some OOM issues I ran into during the execution of `sbt test`.

Let me know what you think and thanks very much for the consideration!

Before submitting pull request:
- [x] Check if the project compiles by running `sbt compile`
- [x] Verify docs compilation by running `sbt compileDocs`
- [x] Check if tests pass by running `sbt test`
- [x] Format code by running `sbt scalafmt`
