### PR TITLE
ZIO 2.0.0-RC5

### DIFF
--- a/armeria-backend/zio/src/main/scala/sttp/client3/armeria/zio/ArmeriaZioBackend.scala
+++ b/armeria-backend/zio/src/main/scala/sttp/client3/armeria/zio/ArmeriaZioBackend.scala
@@ -49,11 +49,13 @@ object ArmeriaZioBackend {
       .runtime[Any]
       .map(runtime => apply(runtime, newClient(options), closeFactory = true))
 
-  def managed(options: SttpBackendOptions = SttpBackendOptions.Default): TaskManaged[SttpBackend[Task, ZioStreams]] =
-    ZManaged.acquireReleaseWith(apply(options))(_.close().ignore)
+  def scoped(
+      options: SttpBackendOptions = SttpBackendOptions.Default
+  ): ZIO[Scope, Throwable, SttpBackend[Task, ZioStreams]] =
+    ZIO.acquireRelease(apply(options))(_.close().ignore)
 
   def layered(options: SttpBackendOptions = SttpBackendOptions.Default): Layer[Throwable, SttpClient] =
-    ZLayer.fromManaged(managed(options))
+    ZLayer.scoped(scoped(options))
 
   def usingClient(client: WebClient): Task[SttpBackend[Task, ZioStreams]] =
     ZIO

--- a/build.sbt
+++ b/build.sbt
@@ -845,7 +845,7 @@ lazy val zioJson = (projectMatrix in file("json/zio-json"))
   .settings(
     name := "zio-json",
     libraryDependencies ++= Seq(
-      "dev.zio" %%% "zio-json" % "0.3.0-RC3",
+      "dev.zio" %%% "zio-json" % "0.3.0-RC4",
       "com.softwaremill.sttp.shared" %%% "zio" % sttpSharedVersion
     ),
     scalaTest

--- a/build.sbt
+++ b/build.sbt
@@ -148,7 +148,7 @@ val zio1InteropRsVersion = "1.3.9"
 val zio2InteropRsVersion = "2.0.0-RC4"
 
 val sttpModelVersion = "1.4.25"
-val sttpSharedVersion = "1.3.2"
+val sttpSharedVersion = "1.3.4"
 
 val logback = "ch.qos.logback" % "logback-classic" % "1.2.11"
 
@@ -697,7 +697,7 @@ lazy val httpClientZioBackend =
       libraryDependencies ++=
         Seq(
           "dev.zio" %% "zio-interop-reactivestreams" % zio2InteropRsVersion,
-          "dev.zio" %% "zio-nio" % "2.0.0-RC3-1"
+          "dev.zio" %% "zio-nio" % "2.0.0-RC6"
         )
     )
     .dependsOn(zio % compileAndTest)
@@ -845,7 +845,7 @@ lazy val zioJson = (projectMatrix in file("json/zio-json"))
   .settings(
     name := "zio-json",
     libraryDependencies ++= Seq(
-      "dev.zio" %%% "zio-json" % "0.3.0-RC4",
+      "dev.zio" %%% "zio-json" % "0.3.0-RC7",
       "com.softwaremill.sttp.shared" %%% "zio" % sttpSharedVersion
     ),
     scalaTest
@@ -991,7 +991,7 @@ lazy val zioTelemetryOpenTelemetryBackend = (projectMatrix in file("metrics/zio-
   .settings(
     name := "zio-telemetry-opentelemetry-backend",
     libraryDependencies ++= Seq(
-      "dev.zio" %% "zio-opentelemetry" % "2.0.0-RC1",
+      "dev.zio" %% "zio-opentelemetry" % "2.0.0-RC2",
       "io.opentelemetry" % "opentelemetry-sdk-testing" % "1.13.0" % Test
     ),
     scalaTest
@@ -1005,7 +1005,7 @@ lazy val zioTelemetryOpenTracingBackend = (projectMatrix in file("metrics/zio-te
   .settings(
     name := "zio-telemetry-opentracing-backend",
     libraryDependencies ++= Seq(
-      "dev.zio" %% "zio-opentracing" % "2.0.0-RC1",
+      "dev.zio" %% "zio-opentracing" % "2.0.0-RC2",
       "org.scala-lang.modules" %% "scala-collection-compat" % "2.7.0"
     )
   )

--- a/build.sbt
+++ b/build.sbt
@@ -143,9 +143,9 @@ val scalaTest = libraryDependencies ++= Seq("freespec", "funsuite", "flatspec", 
 )
 
 val zio1Version = "1.0.14"
-val zio2Version = "2.0.0-RC2"
+val zio2Version = "2.0.0-RC5"
 val zio1InteropRsVersion = "1.3.9"
-val zio2InteropRsVersion = "2.0.0-RC3"
+val zio2InteropRsVersion = "2.0.0-RC4"
 
 val sttpModelVersion = "1.4.25"
 val sttpSharedVersion = "1.3.2"

--- a/effects/zio/src/main/scala/sttp/client3/impl/zio/RIOMonadAsyncError.scala
+++ b/effects/zio/src/main/scala/sttp/client3/impl/zio/RIOMonadAsyncError.scala
@@ -1,7 +1,7 @@
 package sttp.client3.impl.zio
 
 import sttp.monad.{Canceler, MonadAsyncError}
-import zio.{RIO, UIO, ZIO}
+import zio.RIO
 
 class RIOMonadAsyncError[R] extends MonadAsyncError[RIO[R, *]] {
   override def unit[T](t: T): RIO[R, T] = RIO.succeed(t)
@@ -12,13 +12,13 @@ class RIOMonadAsyncError[R] extends MonadAsyncError[RIO[R, *]] {
     fa.flatMap(f)
 
   override def async[T](register: (Either[Throwable, T] => Unit) => Canceler): RIO[R, T] =
-    RIO.effectAsyncInterrupt { cb =>
+    RIO.asyncInterrupt { cb =>
       val canceler = register {
         case Left(t)  => cb(RIO.fail(t))
         case Right(t) => cb(RIO.succeed(t))
       }
 
-      Left(UIO(canceler.cancel()))
+      Left(RIO.succeed(canceler.cancel()))
     }
 
   override def error[T](t: Throwable): RIO[R, T] = RIO.fail(t)
@@ -26,11 +26,11 @@ class RIOMonadAsyncError[R] extends MonadAsyncError[RIO[R, *]] {
   override protected def handleWrappedError[T](rt: RIO[R, T])(h: PartialFunction[Throwable, RIO[R, T]]): RIO[R, T] =
     rt.catchSome(h)
 
-  override def eval[T](t: => T): RIO[R, T] = RIO.effect(t)
+  override def eval[T](t: => T): RIO[R, T] = RIO.attempt(t)
 
-  override def suspend[T](t: => RIO[R, T]): RIO[R, T] = RIO.effectSuspend(t)
+  override def suspend[T](t: => RIO[R, T]): RIO[R, T] = RIO.suspend(t)
 
   override def flatten[T](ffa: RIO[R, RIO[R, T]]): RIO[R, T] = ffa.flatten
 
-  override def ensure[T](f: RIO[R, T], e: => RIO[R, Unit]): RIO[R, T] = f.ensuring(e.catchAll(_ => ZIO.unit))
+  override def ensure[T](f: RIO[R, T], e: => RIO[R, Unit]): RIO[R, T] = f.ensuring(e.ignore)
 }

--- a/effects/zio/src/main/scala/sttp/client3/impl/zio/SttpClientStubbingBase.scala
+++ b/effects/zio/src/main/scala/sttp/client3/impl/zio/SttpClientStubbingBase.scala
@@ -77,10 +77,10 @@ trait SttpClientStubbingBase[R, P] {
       stubber = new StubWrapper(stub): SttpClientStubbing
       proxy = new SttpBackend[RIO[R, *], P] {
         override def send[T, RR >: P with Effect[RIO[R, *]]](request: Request[T, RR]): RIO[R, Response[T]] =
-          stub.get >>= (_.send(request))
+          stub.get.flatMap(_.send(request))
 
         override def close(): RIO[R, Unit] =
-          stub.get >>= (_.close())
+          stub.get.flatMap(_.close())
 
         override def responseMonad: MonadError[RIO[R, *]] = monad
       }: SttpBackend[RIO[R, *], P]

--- a/effects/zio/src/test/scala/sttp/client3/impl/zio/ZioTestBase.scala
+++ b/effects/zio/src/test/scala/sttp/client3/impl/zio/ZioTestBase.scala
@@ -1,13 +1,13 @@
 package sttp.client3.impl.zio
 
 import sttp.client3.testing.ConvertToFuture
-import zio.{Clock, Exit, Runtime, Task, ZEnv, durationInt}
+import zio.{Clock, Exit, Runtime, Task, durationInt}
 
 import scala.concurrent.{Future, Promise}
 import scala.util.{Failure, Success}
 
 trait ZioTestBase {
-  val runtime: Runtime[ZEnv] = Runtime.default
+  val runtime: Runtime[Any] = Runtime.default
 
   val convertZioTaskToFuture: ConvertToFuture[Task] = new ConvertToFuture[Task] {
     override def toFuture[T](value: Task[T]): Future[T] = {

--- a/examples/src/main/scala/sttp/client3/examples/GetAndParseJsonZioCirce.scala
+++ b/examples/src/main/scala/sttp/client3/examples/GetAndParseJsonZioCirce.scala
@@ -9,8 +9,7 @@ import zio.Console
 
 object GetAndParseJsonZioCirce extends ZIOAppDefault {
 
-  override def run: ZIO[ZEnv, Nothing, ExitCode] = {
-
+  override def run = {
     case class HttpBinResponse(origin: String, headers: Map[String, String])
 
     val request = basicRequest
@@ -19,7 +18,7 @@ object GetAndParseJsonZioCirce extends ZIOAppDefault {
 
     // create a description of a program, which requires two dependencies in the environment:
     // the SttpClient, and the Console
-    val sendAndPrint: ZIO[Console with SttpClient, Throwable, Unit] = for {
+    val sendAndPrint: ZIO[SttpClient, Throwable, Unit] = for {
       response <- send(request)
       _ <- Console.printLine(s"Got response code: ${response.code}")
       _ <- Console.printLine(response.body.toString)
@@ -28,7 +27,7 @@ object GetAndParseJsonZioCirce extends ZIOAppDefault {
     // provide an implementation for the SttpClient dependency; other dependencies are
     // provided by Zio
     sendAndPrint
-      .provideCustomLayer(AsyncHttpClientZioBackend.layer())
+      .provide(AsyncHttpClientZioBackend.layer())
       .exitCode
   }
 }

--- a/examples/src/main/scala/sttp/client3/examples/RetryZio.scala
+++ b/examples/src/main/scala/sttp/client3/examples/RetryZio.scala
@@ -2,16 +2,16 @@ package sttp.client3.examples
 
 import sttp.client3._
 import sttp.client3.asynchttpclient.zio.AsyncHttpClientZioBackend
-import zio.{Clock, ExitCode, Schedule, ZIO, ZIOAppDefault, durationInt}
+import zio.{ExitCode, Schedule, Task, ZIOAppDefault, durationInt}
 
 object RetryZio extends ZIOAppDefault {
-  override def run: ZIO[zio.ZEnv, Nothing, ExitCode] = {
+  override def run = {
     AsyncHttpClientZioBackend().flatMap { backend =>
       val localhostRequest = basicRequest
         .get(uri"http://localhost/test")
         .response(asStringAlways)
 
-      val sendWithRetries: ZIO[Clock, Throwable, Response[String]] = localhostRequest
+      val sendWithRetries: Task[Response[String]] = localhostRequest
         .send(backend)
         .either
         .repeat(

--- a/examples/src/main/scala/sttp/client3/examples/StreamZio.scala
+++ b/examples/src/main/scala/sttp/client3/examples/StreamZio.scala
@@ -8,7 +8,7 @@ import zio.Console._
 import zio.stream._
 
 object StreamZio extends ZIOAppDefault {
-  def streamRequestBody: RIO[Console with SttpClient, Unit] = {
+  def streamRequestBody: RIO[SttpClient, Unit] = {
     val stream: Stream[Throwable, Byte] = Stream("Hello, world".getBytes: _*)
 
     send(
@@ -18,7 +18,7 @@ object StreamZio extends ZIOAppDefault {
     ).flatMap { response => printLine(s"RECEIVED:\n${response.body}") }
   }
 
-  def streamResponseBody: RIO[Console with SttpClient, Unit] = {
+  def streamResponseBody: RIO[SttpClient, Unit] = {
     send(
       basicRequest
         .body("I want a stream!")
@@ -27,9 +27,9 @@ object StreamZio extends ZIOAppDefault {
     ).flatMap { response => printLine(s"RECEIVED:\n${response.body}") }
   }
 
-  override def run: ZIO[ZEnv, Nothing, ExitCode] = {
+  override def run: ZIO[Any, Nothing, ExitCode] = {
     (streamRequestBody *> streamResponseBody)
-      .provideCustomLayer(AsyncHttpClientZioBackend.layer())
+      .provide(AsyncHttpClientZioBackend.layer())
       .exitCode
   }
 }

--- a/examples/src/main/scala/sttp/client3/examples/WebSocketZio.scala
+++ b/examples/src/main/scala/sttp/client3/examples/WebSocketZio.scala
@@ -7,22 +7,22 @@ import zio._
 import zio.Console
 
 object WebSocketZio extends ZIOAppDefault {
-  def useWebSocket(ws: WebSocket[RIO[Console, *]]): RIO[Console, Unit] = {
+  def useWebSocket(ws: WebSocket[Task]): Task[Unit] = {
     def send(i: Int) = ws.sendText(s"Hello $i!")
-    val receive = ws.receiveText().flatMap(t => Console.printLine(s"RECEIVED: $t"))
+    val receive = ws.receiveText().flatMap(t => Console.printLine(s"RECEIVED: $t")).orDie
     send(1) *> send(2) *> receive *> receive
   }
 
-  // create a description of a program, which requires two dependencies in the environment:
-  // the SttpClient, and the Console
-  val sendAndPrint: RIO[Console with SttpClient, Response[Unit]] =
-    sendR(basicRequest.get(uri"wss://echo.websocket.org").response(asWebSocketAlways(useWebSocket)))
+  // create a description of a program, which requires one dependency in the environment:
+  // the SttpClient
+  val sendAndPrint: RIO[SttpClient, Response[Unit]] =
+    send(basicRequest.get(uri"wss://echo.websocket.org").response(asWebSocketAlways(useWebSocket)))
 
-  override def run: ZIO[ZEnv, Nothing, ExitCode] = {
+  override def run = {
     // provide an implementation for the SttpClient dependency; other dependencies are
     // provided by Zio
     sendAndPrint
-      .provideCustomLayer(AsyncHttpClientZioBackend.layer())
+      .provide(AsyncHttpClientZioBackend.layer())
       .exitCode
   }
 }

--- a/httpclient-backend/zio/src/main/scala/sttp/client3/httpclient/zio/HttpClientZioBackend.scala
+++ b/httpclient-backend/zio/src/main/scala/sttp/client3/httpclient/zio/HttpClientZioBackend.scala
@@ -121,12 +121,12 @@ object HttpClientZioBackend {
       )
     )
 
-  def managed(
+  def scoped(
       options: SttpBackendOptions = SttpBackendOptions.Default,
       customizeRequest: HttpRequest => HttpRequest = identity,
       customEncodingHandler: ZioEncodingHandler = PartialFunction.empty
-  ): ZManaged[Any, Throwable, SttpBackend[Task, ZioStreams with WebSockets]] =
-    ZManaged.acquireReleaseWith(apply(options, customizeRequest, customEncodingHandler))(
+  ): ZIO[Scope, Throwable, SttpBackend[Task, ZioStreams with WebSockets]] =
+    ZIO.acquireRelease(apply(options, customizeRequest, customEncodingHandler))(
       _.close().ignore
     )
 
@@ -135,14 +135,14 @@ object HttpClientZioBackend {
       customizeRequest: HttpRequest => HttpRequest = identity,
       customEncodingHandler: ZioEncodingHandler = PartialFunction.empty
   ): ZLayer[Any, Throwable, SttpClient] = {
-    ZLayer.fromManaged(
+    ZLayer.scoped(
       (for {
         backend <- HttpClientZioBackend(
           options,
           customizeRequest,
           customEncodingHandler
         )
-      } yield backend).toManagedWith(_.close().ignore)
+      } yield backend).tap(client => ZIO.addFinalizer(client.close().ignore))
     )
   }
 
@@ -163,13 +163,15 @@ object HttpClientZioBackend {
       customizeRequest: HttpRequest => HttpRequest = identity,
       customEncodingHandler: ZioEncodingHandler = PartialFunction.empty
   ): ZLayer[Any, Throwable, SttpClient] = {
-    ZLayer.fromManaged(
-      ZManaged
-        .acquireReleaseAttemptWith(
-          usingClient(
-            client,
-            customizeRequest,
-            customEncodingHandler
+    ZLayer.scoped(
+      ZIO
+        .acquireRelease(
+          ZIO.attempt(
+            usingClient(
+              client,
+              customizeRequest,
+              customEncodingHandler
+            )
           )
         )(_.close().ignore)
     )

--- a/httpclient-backend/zio/src/main/scala/sttp/client3/httpclient/zio/ZioBodyFromHttpClient.scala
+++ b/httpclient-backend/zio/src/main/scala/sttp/client3/httpclient/zio/ZioBodyFromHttpClient.scala
@@ -42,7 +42,7 @@ private[zio] class ZioBodyFromHttpClient extends BodyFromHttpClient[Task, ZioStr
           case Right(file) =>
             ZIO.succeed(
               for {
-                fileChannel <- Stream.managed(
+                fileChannel <- Stream.scoped(
                   AsynchronousFileChannel.open(Path.fromJava(file.toPath), StandardOpenOption.READ)
                 )
                 bytes <- readAllBytes(fileChannel)
@@ -63,7 +63,7 @@ private[zio] class ZioBodyFromHttpClient extends BodyFromHttpClient[Task, ZioStr
           file: SttpFile
       ): Task[SttpFile] = response
         .run({
-          ZSink.unwrapManaged(
+          ZSink.unwrapScoped(
             AsynchronousFileChannel
               .open(Path.fromJava(file.toPath), StandardOpenOption.WRITE, StandardOpenOption.CREATE)
               .map { fileChannel =>

--- a/httpclient-backend/zio/src/test/scala/sttp/client3/httpclient/zio/SttpBackendStubZioTests.scala
+++ b/httpclient-backend/zio/src/test/scala/sttp/client3/httpclient/zio/SttpBackendStubZioTests.scala
@@ -58,7 +58,7 @@ class SttpBackendStubZioTests extends AnyFlatSpec with Matchers with ScalaFuture
       resp <- r1 <&> r2 <&> r3
     } yield resp
 
-    runtime.unsafeRun(effect.provideCustomLayer(HttpClientZioBackend.stubLayer)) shouldBe
+    runtime.unsafeRun(effect.provideLayer(HttpClientZioBackend.stubLayer)) shouldBe
       ((Right("a"), Right("b"), Right("c")))
   }
 
@@ -69,7 +69,7 @@ class SttpBackendStubZioTests extends AnyFlatSpec with Matchers with ScalaFuture
     val effect = (for {
       _ <- whenAnyRequest.thenRespondCyclic("a", "b", "c")
       resp <- ZStream.repeatZIO(send(r)).take(4).runCollect
-    } yield resp).provideCustomLayer(HttpClientZioBackend.stubLayer)
+    } yield resp).provideLayer(HttpClientZioBackend.stubLayer)
 
     runtime.unsafeRun(effect).map(_.body).toList shouldBe List(Right("a"), Right("b"), Right("c"), Right("a"))
   }

--- a/json/zio-json/src/main/scalajvm/sttp/client3/ziojson/SttpZioJsonApiExtensions.scala
+++ b/json/zio-json/src/main/scalajvm/sttp/client3/ziojson/SttpZioJsonApiExtensions.scala
@@ -16,7 +16,8 @@ trait SttpZioJsonApiExtensions { this: SttpZioJsonApi =>
         .map(Right(_))
         .catchSome { case e => ZIO.left(DeserializationException("", e.getMessage)) }
     ).mapWithMetadata {
-      case (Left(s), meta) => Left(HttpError(s, meta.code))
-      case (Right(s), _)   => s
+      case (Left(s), meta)           => Left(HttpError(s, meta.code))
+      case (Right(Left(deserEx)), _) => Left(deserEx)
+      case (Right(Right(s)), _)      => Right(s)
     }
 }

--- a/metrics/zio-telemetry-open-telemetry-backend/src/test/scala/sttp/client3/ziotelemetry/opentelemetry/ZioTelemetryOpenTelemetryBackendTest.scala
+++ b/metrics/zio-telemetry-open-telemetry-backend/src/test/scala/sttp/client3/ziotelemetry/opentelemetry/ZioTelemetryOpenTelemetryBackendTest.scala
@@ -10,7 +10,7 @@ import sttp.client3.impl.zio.{RIOMonadAsyncError, ZioTestBase}
 import sttp.client3.testing.SttpBackendStub
 import sttp.client3.{Request, Response, SttpBackend, UriContext, basicRequest}
 import sttp.model.StatusCode
-import zio.Task
+import zio.{Task, ZIO}
 import zio.telemetry.opentelemetry.Tracing
 import scala.collection.JavaConverters._
 
@@ -24,7 +24,7 @@ class ZioTelemetryOpenTelemetryBackendTest extends AnyFlatSpec with Matchers wit
 
   private val mockTracer =
     SdkTracerProvider.builder().addSpanProcessor(SimpleSpanProcessor.create(spanExporter)).build().get(getClass.getName)
-  private val mockTracing = runtime.unsafeRun(Tracing.managed(mockTracer).useNow)
+  private val mockTracing = runtime.unsafeRun(ZIO.scoped(Tracing.scoped(mockTracer)))
 
   private val backend: SttpBackend[Task, Any] =
     ZioTelemetryOpenTelemetryBackend(


### PR DESCRIPTION
This PR is based on #1367, bumping ZIO2 version to RC5 together with other ZIO-based libraries and fixing the compilation errors.