### PR TITLE
Drop java8-compat dependency

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
-import com.softwaremill.UpdateVersionInDocs
-import com.softwaremill.Publish.{updateDocs, ossPublishSettings}
+import com.softwaremill.Publish.{ossPublishSettings, updateDocs}
 import com.softwaremill.SbtSoftwareMillCommon.commonSmlBuildSettings
+import com.softwaremill.UpdateVersionInDocs
 import sbt.Keys.publishArtifact
 import sbt.Reference.display
 import sbt.internal.ProjectMatrix
@@ -268,12 +268,6 @@ lazy val testServer = (projectMatrix in file("testing/server"))
 
 lazy val testServer2_13 = testServer.jvm(scala2_13)
 
-val scalajava8compatVersion: Option[(Long, Long)] => String = {
-  case Some((2, 11)) => "0.8.0"
-  case Some((2, 12)) => "0.8.0"
-  case _             => "1.0.2"
-}
-
 lazy val core = (projectMatrix in file("core"))
   .settings(
     name := "core",
@@ -293,10 +287,7 @@ lazy val core = (projectMatrix in file("core"))
         scalacOptions ++= Seq("-J--add-modules", "-Jjava.net.http"),
         scalacOptions ++= {
           if (scalaVersion.value == scala2_13) List("-target:jvm-11") else Nil
-        },
-        libraryDependencies ++= dependenciesFor(scalaVersion.value)(
-          "org.scala-lang.modules" %% "scala-java8-compat" % scalajava8compatVersion(_)
-        )
+        }
       )
     }
   )

--- a/core/src/main/scalajvm/sttp/client3/internal/SttpToJavaConverters.scala
+++ b/core/src/main/scalajvm/sttp/client3/internal/SttpToJavaConverters.scala
@@ -1,0 +1,19 @@
+package sttp.client3.internal
+
+object SttpToJavaConverters {
+
+  def toJavaFunction[U, V](f: Function1[U, V]): java.util.function.Function[U, V] =
+    new java.util.function.Function[U, V] {
+      override def apply(t: U): V = f(t)
+    }
+
+  def toJavaBiConsumer[U, R](f: Function2[U, R, Unit]): java.util.function.BiConsumer[U, R] =
+    new java.util.function.BiConsumer[U, R] {
+      override def accept(t: U, u: R): Unit = f(t, u)
+    }
+
+  def toJavaSupplier[U](f: Function0[U]): java.util.function.Supplier[U] =
+    new java.util.function.Supplier[U] {
+      override def get(): U = f()
+    }
+}

--- a/core/src/main/scalajvm/sttp/client3/internal/httpclient/BodyToHttpClient.scala
+++ b/core/src/main/scalajvm/sttp/client3/internal/httpclient/BodyToHttpClient.scala
@@ -1,7 +1,7 @@
 package sttp.client3.internal.httpclient
 
 import sttp.capabilities.Streams
-import scala.compat.java8.FunctionConverters._
+import sttp.client3.internal.SttpToJavaConverters.toJavaSupplier
 import sttp.client3.internal.{Utf8, throwNestedMultipartNotAllowed}
 import sttp.client3.{
   ByteArrayBody,
@@ -42,7 +42,7 @@ private[client3] trait BodyToHttpClient[F[_], S] {
       case ByteBufferBody(b, _) =>
         if (b.hasArray) BodyPublishers.ofByteArray(b.array(), 0, b.limit()).unit
         else { val a = new Array[Byte](b.remaining()); b.get(a); BodyPublishers.ofByteArray(a).unit }
-      case InputStreamBody(b, _) => BodyPublishers.ofInputStream((() => b).asJava).unit
+      case InputStreamBody(b, _) => BodyPublishers.ofInputStream(toJavaSupplier(() => b)).unit
       case FileBody(f, _)        => BodyPublishers.ofFile(f.toFile.toPath).unit
       case StreamBody(s)         => streamToPublisher(s.asInstanceOf[streams.BinaryStream])
       case MultipartBody(parts) =>

--- a/core/src/main/scalajvm/sttp/client3/internal/httpclient/InputStreamSubscriber.scala
+++ b/core/src/main/scalajvm/sttp/client3/internal/httpclient/InputStreamSubscriber.scala
@@ -1,8 +1,8 @@
 package sttp.client3.internal.httpclient
 
-import InputStreamSubscriber._
+import sttp.client3.internal.SttpToJavaConverters.toJavaFunction
+import sttp.client3.internal.httpclient.InputStreamSubscriber._
 
-import scala.compat.java8.FunctionConverters._
 import java.io.InputStream
 import java.nio.ByteBuffer
 import java.util
@@ -74,7 +74,9 @@ private[client3] class InputStreamSubscriber extends Subscriber[java.util.List[B
   private val toListCollector: Collector[Message, _, util.List[Message]] = Collectors.toList()
   override def onNext(b: java.util.List[ByteBuffer]): Unit = {
     assert(b != null)
-    chunks.addAll(b.stream().map[Message]((d => nextItemMsg(d)).asJava).collect(toListCollector))
+    chunks.addAll(
+      b.stream().map[Message](toJavaFunction(d => nextItemMsg(d))).collect(toListCollector)
+    )
   }
 
   override def onError(t: Throwable): Unit = {


### PR DESCRIPTION
There is a problem with conflicting cross-version for java8-compat dependency on scala-3.
In fact we only a few converters so I deiced to write our own converters for sttp and drop whole dependency.