### PR TITLE
DX: fix some issues

### DIFF
--- a/effects/zio/src/main/scalajvm/sttp/client3/httpclient/zio/package.scala
+++ b/effects/zio/src/main/scalajvm/sttp/client3/httpclient/zio/package.scala
@@ -1,0 +1,10 @@
+package sttp.client3.httpclient
+
+import sttp.capabilities.WebSockets
+import sttp.capabilities.zio.ZioStreams
+import sttp.client3.SttpBackend
+
+
+package object zio {
+  type SttpClient = SttpBackend[_root_.zio.Task, ZioStreams with WebSockets]
+}

--- a/effects/zio/src/main/scalajvm/sttp/client3/httpclient/zio/package.scala
+++ b/effects/zio/src/main/scalajvm/sttp/client3/httpclient/zio/package.scala
@@ -4,7 +4,6 @@ import sttp.capabilities.WebSockets
 import sttp.capabilities.zio.ZioStreams
 import sttp.client3.SttpBackend
 
-
 package object zio {
   type SttpClient = SttpBackend[_root_.zio.Task, ZioStreams with WebSockets]
 }

--- a/effects/zio1/src/main/scalajvm/sttp/client3/httpclient/zio/HttpClientZioBackend.scala
+++ b/effects/zio1/src/main/scalajvm/sttp/client3/httpclient/zio/HttpClientZioBackend.scala
@@ -175,7 +175,7 @@ object HttpClientZioBackend {
     *
     * See [[SttpBackendStub]] for details on how to configure stub responses.
     */
-  def stub: SttpBackendStub[Task, ZioStreams] =
+  def stub: SttpBackendStub[Task, ZioStreams with WebSockets] =
     SttpBackendStub(new RIOMonadAsyncError[Any])
 
   val stubLayer: ZLayer[Any, Nothing, SttpClientStubbing with SttpClient] = SttpClientStubbing.layer


### PR DESCRIPTION
- Seems with `zio` module the alias `SttpClient` was removed, brought this back to have smoother migration experience
- The `zio1` stub does not include `WebSockets` .. this causes compilation issues 

**Check list**
- [ ] Check if the project compiles by running `sbt compile` (exited due `java.lang.OutOfMemoryError: Java heap space` .. maybe include a `.sbtopts` to mitigate this?)
- [x] Verify docs compilation by running `sbt compileDocs`
- [ ] Check if tests pass by running `sbt test`
- [x] Format code by running `sbt scalafmt`
