### PR TITLE
HTTP client support for unwrapped deflate responses

### DIFF
--- a/armeria-backend/cats-ce2/src/test/scala/sttp/client3/armeria/cats/ArmeriaCatsHttpTest.scala
+++ b/armeria-backend/cats-ce2/src/test/scala/sttp/client3/armeria/cats/ArmeriaCatsHttpTest.scala
@@ -19,4 +19,5 @@ class ArmeriaCatsHttpTest extends HttpTest[IO] with CatsTestBase {
   override def supportsHostHeaderOverride = false
   override def supportsCancellation = false
   override def supportsAutoDecompressionDisabling = false
+  override def supportsDeflateWrapperChecking = false // armeria hangs
 }

--- a/armeria-backend/cats/src/test/scala/sttp/client3/armeria/cats/ArmeriaCatsHttpTest.scala
+++ b/armeria-backend/cats/src/test/scala/sttp/client3/armeria/cats/ArmeriaCatsHttpTest.scala
@@ -19,4 +19,5 @@ class ArmeriaCatsHttpTest extends HttpTest[IO] with CatsTestBase {
   override def supportsHostHeaderOverride = false
   override def supportsCancellation = false
   override def supportsAutoDecompressionDisabling = false
+  override def supportsDeflateWrapperChecking = false // armeria hangs
 }

--- a/armeria-backend/fs2-ce2/src/test/scala/sttp/client3/armeria/fs2/ArmeriaFs2HttpTest.scala
+++ b/armeria-backend/fs2-ce2/src/test/scala/sttp/client3/armeria/fs2/ArmeriaFs2HttpTest.scala
@@ -11,4 +11,5 @@ class ArmeriaFs2HttpTest extends HttpTest[IO] with CatsTestBase {
   override def supportsHostHeaderOverride = false
   override def supportsCancellation = false
   override def supportsAutoDecompressionDisabling = false
+  override def supportsDeflateWrapperChecking = false // armeria hangs
 }

--- a/armeria-backend/fs2/src/test/scala/sttp/client3/armeria/fs2/ArmeriaFs2HttpTest.scala
+++ b/armeria-backend/fs2/src/test/scala/sttp/client3/armeria/fs2/ArmeriaFs2HttpTest.scala
@@ -11,4 +11,5 @@ class ArmeriaFs2HttpTest extends HttpTest[IO] with CatsTestBase with TestIODispa
   override def supportsHostHeaderOverride = false
   override def supportsCancellation = false
   override def supportsAutoDecompressionDisabling = false
+  override def supportsDeflateWrapperChecking = false // armeria hangs
 }

--- a/armeria-backend/monix/src/test/scala/sttp/client3/armeria/monix/ArmeriaMonixHttpTest.scala
+++ b/armeria-backend/monix/src/test/scala/sttp/client3/armeria/monix/ArmeriaMonixHttpTest.scala
@@ -21,5 +21,6 @@ class ArmeriaMonixHttpTest extends HttpTest[Task] {
 
   override def supportsHostHeaderOverride = false
   override def supportsAutoDecompressionDisabling = false
+  override def supportsDeflateWrapperChecking = false // armeria hangs
 
 }

--- a/armeria-backend/scalaz/src/test/scala/sttp/client3/armeria/scalaz/ArmeriaScalazHttpTest.scala
+++ b/armeria-backend/scalaz/src/test/scala/sttp/client3/armeria/scalaz/ArmeriaScalazHttpTest.scala
@@ -13,6 +13,7 @@ class ArmeriaScalazHttpTest extends HttpTest[Task] {
   override def supportsHostHeaderOverride = false
   override def supportsCancellation = false
   override def supportsAutoDecompressionDisabling = false
+  override def supportsDeflateWrapperChecking = false // armeria hangs
 
   override def timeoutToNone[T](t: Task[T], timeoutMillis: Int): Task[Option[T]] = t.map(Some(_))
 }

--- a/armeria-backend/src/test/scala/sttp/client3/armeria/future/ArmeriaFutureHttpTest.scala
+++ b/armeria-backend/src/test/scala/sttp/client3/armeria/future/ArmeriaFutureHttpTest.scala
@@ -13,6 +13,7 @@ class ArmeriaFutureHttpTest extends HttpTest[Future] {
   override def supportsHostHeaderOverride = false
   override def supportsCancellation = false
   override def supportsAutoDecompressionDisabling = false
+  override def supportsDeflateWrapperChecking = false // armeria hangs
 
   override def timeoutToNone[T](t: Future[T], timeoutMillis: Int): Future[Option[T]] = t.map(Some(_))
 }

--- a/armeria-backend/zio/src/test/scala/sttp/client3/armeria/zio/ArmeriaZioHttpTest.scala
+++ b/armeria-backend/zio/src/test/scala/sttp/client3/armeria/zio/ArmeriaZioHttpTest.scala
@@ -13,4 +13,5 @@ class ArmeriaZioHttpTest extends HttpTest[Task] with ZioTestBase {
   override def supportsHostHeaderOverride = false
   override def supportsCancellation = false
   override def supportsAutoDecompressionDisabling = false
+  override def supportsDeflateWrapperChecking = false // armeria hangs
 }

--- a/armeria-backend/zio1/src/test/scala/sttp/client3/armeria/zio/ArmeriaZioHttpTest.scala
+++ b/armeria-backend/zio1/src/test/scala/sttp/client3/armeria/zio/ArmeriaZioHttpTest.scala
@@ -13,4 +13,5 @@ class ArmeriaZioHttpTest extends HttpTest[Task] with ZioTestBase {
   override def supportsHostHeaderOverride = false
   override def supportsCancellation = false
   override def supportsAutoDecompressionDisabling = false
+  override def supportsDeflateWrapperChecking = false // armeria hangs
 }

--- a/core/src/test/scala/sttp/client3/testing/streaming/StreamingTest.scala
+++ b/core/src/test/scala/sttp/client3/testing/streaming/StreamingTest.scala
@@ -208,8 +208,8 @@ abstract class StreamingTest[F[_], S]
       .response(asStreamAlways[F, Int, S](streams)(_ => throw error))
       .send(backend)
       .map(_.body)
-      .handleError {
-        case `error` => monadError.unit(1)
+      .handleError { case `error` =>
+        monadError.unit(1)
       }
       .toFuture()
       .map(_ shouldBe 1)

--- a/core/src/test/scalajvm/sttp/client3/HttpClientFutureHttpTest.scala
+++ b/core/src/test/scalajvm/sttp/client3/HttpClientFutureHttpTest.scala
@@ -10,5 +10,7 @@ class HttpClientFutureHttpTest extends HttpTest[Future] {
 
   override def supportsHostHeaderOverride = false
   override def supportsCancellation: Boolean = false
+  override def supportsDeflateWrapperChecking = false
+
   override def timeoutToNone[T](t: Future[T], timeoutMillis: Int): Future[Option[T]] = t.map(Some(_))
 }

--- a/core/src/test/scalajvm/sttp/client3/HttpClientSyncHttpTest.scala
+++ b/core/src/test/scalajvm/sttp/client3/HttpClientSyncHttpTest.scala
@@ -8,6 +8,7 @@ class HttpClientSyncHttpTest extends HttpTest[Identity] {
 
   override def supportsHostHeaderOverride = false
   override def supportsCancellation: Boolean = false
+  override def supportsDeflateWrapperChecking = false
 
   override def timeoutToNone[T](t: Identity[T], timeoutMillis: Int): Identity[Option[T]] = Some(t)
 }

--- a/core/src/test/scalajvm/sttp/client3/HttpURLConnectionBackendHttpTest.scala
+++ b/core/src/test/scalajvm/sttp/client3/HttpURLConnectionBackendHttpTest.scala
@@ -13,6 +13,7 @@ class HttpURLConnectionBackendHttpTest extends HttpTest[Identity] {
   override def supportsCustomContentEncoding = true
   override def supportsHostHeaderOverride = false
   override def supportsCancellation = false
+  override def supportsDeflateWrapperChecking = false
 
   override def timeoutToNone[T](t: Identity[T], timeoutMillis: Int): Identity[Option[T]] = Some(t)
 }

--- a/core/src/test/scalajvm/sttp/client3/TryHttpURLConnectionHttpTest.scala
+++ b/core/src/test/scalajvm/sttp/client3/TryHttpURLConnectionHttpTest.scala
@@ -11,6 +11,7 @@ class TryHttpURLConnectionHttpTest extends HttpTest[Try] {
 
   override def supportsCancellation = false
   override def supportsHostHeaderOverride = false
+  override def supportsDeflateWrapperChecking = false
 
   override def timeoutToNone[T](t: Try[T], timeoutMillis: Int): Try[Option[T]] = t.map(Some(_))
 }

--- a/effects/fs2-ce2/src/main/scala/sttp/client3/impl/fs2/Fs2Compression.scala
+++ b/effects/fs2-ce2/src/main/scala/sttp/client3/impl/fs2/Fs2Compression.scala
@@ -1,0 +1,19 @@
+package sttp.client3.impl.fs2
+
+import cats.effect.Sync
+import fs2.{Pipe, Pull}
+
+object Fs2Compression {
+
+  def inflateCheckHeader[F[_]: Sync]: Pipe[F, Byte, Byte] = stream =>
+    stream.pull.uncons1
+      .flatMap {
+        case None                 => Pull.done
+        case Some((byte, stream)) => Pull.output1((byte, stream))
+      }
+      .stream
+      .flatMap { case (byte, stream) =>
+        val wrapped = (byte & 0x0f) == 0x08
+        stream.cons1(byte).through(fs2.compression.inflate(nowrap = !wrapped))
+      }
+}

--- a/effects/fs2-ce2/src/main/scalajvm/sttp/client3/httpclient/fs2/HttpClientFs2Backend.scala
+++ b/effects/fs2-ce2/src/main/scalajvm/sttp/client3/httpclient/fs2/HttpClientFs2Backend.scala
@@ -18,7 +18,7 @@ import sttp.client3.HttpClientBackend.EncodingHandler
 import sttp.client3.httpclient.fs2.HttpClientFs2Backend.Fs2EncodingHandler
 import sttp.client3.internal.httpclient.{BodyFromHttpClient, BodyToHttpClient, Sequencer}
 import sttp.client3.impl.cats.implicits._
-import sttp.client3.impl.fs2.Fs2SimpleQueue
+import sttp.client3.impl.fs2.{Fs2Compression, Fs2SimpleQueue}
 import sttp.client3.internal.ws.SimpleQueue
 import sttp.client3.testing.SttpBackendStub
 import sttp.client3.{
@@ -85,7 +85,7 @@ class HttpClientFs2Backend[F[_]: ConcurrentEffect: ContextShift] private (
 
   override protected def standardEncoding: (Stream[F, Byte], String) => Stream[F, Byte] = {
     case (body, "gzip")    => body.through(fs2.compression.gunzip()).flatMap(_.content)
-    case (body, "deflate") => body.through(fs2.compression.inflate())
+    case (body, "deflate") => body.through(Fs2Compression.inflateCheckHeader)
     case (_, ce)           => Stream.raiseError[F](new UnsupportedEncodingException(s"Unsupported encoding: $ce"))
   }
 }

--- a/effects/fs2/src/main/scalajvm/sttp/client3/httpclient/fs2/Fs2Compression.scala
+++ b/effects/fs2/src/main/scalajvm/sttp/client3/httpclient/fs2/Fs2Compression.scala
@@ -1,0 +1,20 @@
+package sttp.client3.httpclient.fs2
+
+import fs2.{Pipe, Pull}
+import fs2.compression.{Compression, InflateParams, ZLibParams}
+
+object Fs2Compression {
+
+  def inflateCheckHeader[F[_]: Compression]: Pipe[F, Byte, Byte] = stream =>
+    stream.pull.uncons1
+      .flatMap {
+        case None                 => Pull.done
+        case Some((byte, stream)) => Pull.output1((byte, stream))
+      }
+      .stream
+      .flatMap { case (byte, stream) =>
+        val header = if ((byte & 0x0f) == 0x08) ZLibParams.Header.ZLIB else ZLibParams.Header.GZIP
+        val params = InflateParams(header = header)
+        stream.cons1(byte).through(fs2.compression.Compression[F].inflate(params))
+      }
+}

--- a/effects/fs2/src/main/scalajvm/sttp/client3/httpclient/fs2/HttpClientFs2Backend.scala
+++ b/effects/fs2/src/main/scalajvm/sttp/client3/httpclient/fs2/HttpClientFs2Backend.scala
@@ -8,7 +8,6 @@ import java.util
 import cats.effect.kernel._
 import cats.effect.std.{Dispatcher, Queue}
 import cats.implicits._
-import fs2.compression.InflateParams
 import fs2.interop.reactivestreams.{PublisherOps, StreamUnicastPublisher}
 import fs2.{Chunk, Stream}
 import org.reactivestreams.FlowAdapters
@@ -89,7 +88,7 @@ class HttpClientFs2Backend[F[_]: Async] private (
 
   override protected def standardEncoding: (Stream[F, Byte], String) => Stream[F, Byte] = {
     case (body, "gzip")    => body.through(fs2.compression.Compression[F].gunzip()).flatMap(_.content)
-    case (body, "deflate") => body.through(fs2.compression.Compression[F].inflate(InflateParams.DEFAULT))
+    case (body, "deflate") => body.through(Fs2Compression.inflateCheckHeader[F])
     case (_, ce)           => Stream.raiseError[F](new UnsupportedEncodingException(s"Unsupported encoding: $ce"))
   }
 }

--- a/effects/monix/src/test/scalajvm/sttp/client3/impl/monix/HttpClientMonixHttpTest.scala
+++ b/effects/monix/src/test/scalajvm/sttp/client3/impl/monix/HttpClientMonixHttpTest.scala
@@ -14,6 +14,7 @@ class HttpClientMonixHttpTest extends HttpTest[Task] {
   override implicit val convertToFuture: ConvertToFuture[Task] = convertMonixTaskToFuture
 
   override def supportsHostHeaderOverride = false
+  override def supportsDeflateWrapperChecking = false
 
   override def timeoutToNone[T](t: Task[T], timeoutMillis: Int): Task[Option[T]] =
     t.map(Some(_))

--- a/http4s-backend/src/main/scala/sttp/client3/http4s/Http4sBackend.scala
+++ b/http4s-backend/src/main/scala/sttp/client3/http4s/Http4sBackend.scala
@@ -6,7 +6,6 @@ import cats.data.NonEmptyList
 import cats.effect.{Async, Deferred, Resource}
 import cats.implicits._
 import cats.effect.implicits._
-import fs2.compression.InflateParams
 import fs2.io.file.Files
 import fs2.{Chunk, Stream}
 import org.http4s.{ContentCoding, EntityBody, Status, Request => Http4sRequest}
@@ -16,6 +15,7 @@ import org.http4s.blaze.client.BlazeClientBuilder
 import org.typelevel.ci.CIString
 import sttp.capabilities.fs2.Fs2Streams
 import sttp.client3.http4s.Http4sBackend.EncodingHandler
+import sttp.client3.httpclient.fs2.Fs2Compression
 import sttp.client3.impl.cats.CatsMonadAsyncError
 import sttp.client3.internal.{BodyFromResponseAs, IOBufferSize, SttpFile, throwNestedMultipartNotAllowed}
 import sttp.model._
@@ -182,7 +182,7 @@ class Http4sBackend[F[_]: Async](
         if http4s.headers
           .`Accept-Encoding`(NonEmptyList.of(http4s.ContentCoding.deflate))
           .satisfiedBy(contentCoding) =>
-      body.through(fs2.compression.Compression[F].inflate(InflateParams.DEFAULT))
+      body.through(Fs2Compression.inflateCheckHeader[F])
     case (body, contentCoding)
         if http4s.headers
           .`Accept-Encoding`(NonEmptyList.of(http4s.ContentCoding.gzip, http4s.ContentCoding.`x-gzip`))

--- a/http4s-ce2-backend/src/main/scala/sttp/client3/http4s/Http4sBackend.scala
+++ b/http4s-ce2-backend/src/main/scala/sttp/client3/http4s/Http4sBackend.scala
@@ -17,6 +17,7 @@ import org.typelevel.ci.CIString
 import sttp.capabilities.fs2.Fs2Streams
 import sttp.client3.http4s.Http4sBackend.EncodingHandler
 import sttp.client3.impl.cats.CatsMonadAsyncError
+import sttp.client3.impl.fs2.Fs2Compression
 import sttp.client3.internal.{BodyFromResponseAs, IOBufferSize, SttpFile, throwNestedMultipartNotAllowed}
 import sttp.model._
 import sttp.monad.MonadError
@@ -182,7 +183,7 @@ class Http4sBackend[F[_]: ConcurrentEffect: ContextShift](
         if http4s.headers
           .`Accept-Encoding`(NonEmptyList.of(http4s.ContentCoding.deflate))
           .satisfiedBy(contentCoding) =>
-      body.through(fs2.compression.inflate())
+      body.through(Fs2Compression.inflateCheckHeader[F])
     case (body, contentCoding)
         if http4s.headers
           .`Accept-Encoding`(NonEmptyList.of(http4s.ContentCoding.gzip, http4s.ContentCoding.`x-gzip`))

--- a/okhttp-backend/monix/src/test/scala/sttp/client3/okhttp/monix/OkHttpMonixHttpTest.scala
+++ b/okhttp-backend/monix/src/test/scala/sttp/client3/okhttp/monix/OkHttpMonixHttpTest.scala
@@ -16,6 +16,8 @@ class OkHttpMonixHttpTest extends HttpTest[Task] {
   override val backend: SttpBackend[Task, MonixStreams] = OkHttpMonixBackend().runSyncUnsafe()
   override implicit val convertToFuture: ConvertToFuture[Task] = convertMonixTaskToFuture
 
+  override def supportsDeflateWrapperChecking = false
+
   override def timeoutToNone[T](t: Task[T], timeoutMillis: Int): Task[Option[T]] =
     t.map(Some(_))
       .timeout(timeoutMillis.milliseconds)

--- a/okhttp-backend/src/test/scala/sttp/client3/okhttp/OkHttpFutureHttpTest.scala
+++ b/okhttp-backend/src/test/scala/sttp/client3/okhttp/OkHttpFutureHttpTest.scala
@@ -13,4 +13,5 @@ class OkHttpFutureHttpTest extends HttpTest[Future] {
 
   override def supportsCancellation: Boolean = false
   override def timeoutToNone[T](t: Future[T], timeoutMillis: Int): Future[Option[T]] = t.map(Some(_))
+  override def supportsDeflateWrapperChecking = false
 }

--- a/okhttp-backend/src/test/scala/sttp/client3/okhttp/OkHttpSyncHttpTest.scala
+++ b/okhttp-backend/src/test/scala/sttp/client3/okhttp/OkHttpSyncHttpTest.scala
@@ -11,4 +11,5 @@ class OkHttpSyncHttpTest extends HttpTest[Identity] {
 
   override def supportsCancellation: Boolean = false
   override def timeoutToNone[T](t: Identity[T], timeoutMillis: Int): Identity[Option[T]] = Some(t)
+  override def supportsDeflateWrapperChecking = false
 }

--- a/testing/server/src/main/scala/akka/http/scaladsl/coding/DeflateNoWrap.scala
+++ b/testing/server/src/main/scala/akka/http/scaladsl/coding/DeflateNoWrap.scala
@@ -1,0 +1,20 @@
+package akka.http.scaladsl.coding
+
+import akka.http.scaladsl.model._
+import java.util.zip.Deflater
+
+/** [[Deflate]] but sets the `nowrap` flag to true instead of false.
+  */
+class DeflateNoWrap private[http] (
+    compressionLevel: Int,
+    override val messageFilter: HttpMessage => Boolean
+) extends Deflate(compressionLevel, messageFilter) {
+  def this(messageFilter: HttpMessage => Boolean) = {
+    this(DeflateCompressor.DefaultCompressionLevel, messageFilter)
+  }
+
+  override def newCompressor = new DeflateCompressor(compressionLevel) {
+    override protected lazy val deflater = new Deflater(compressionLevel, true)
+  }
+}
+object DeflateNoWrap extends DeflateNoWrap(Encoder.DefaultFilter)

--- a/testing/server/src/main/scala/sttp/client3/testing/server/HttpServer.scala
+++ b/testing/server/src/main/scala/sttp/client3/testing/server/HttpServer.scala
@@ -3,6 +3,7 @@ package sttp.client3.testing.server
 import akka.actor.ActorSystem
 import akka.http.scaladsl.Http
 import akka.http.scaladsl.coding.Coders._
+import akka.http.scaladsl.coding.DeflateNoWrap
 import akka.http.scaladsl.model._
 import akka.http.scaladsl.model.headers.CacheDirectives._
 import akka.http.scaladsl.model.headers._
@@ -267,6 +268,10 @@ private class HttpServer(port: Int, info: String => Unit) extends AutoCloseable 
       }
     } ~ path("compress") {
       encodeResponseWith(NoCoding, Gzip, Deflate) {
+        complete("I'm compressed!")
+      }
+    } ~ path("compress-deflate-nowrap") {
+      encodeResponseWith(DeflateNoWrap) {
         complete("I'm compressed!")
       }
     } ~ path("compress-empty-gzip") {


### PR DESCRIPTION
The fs2 and ZIO HTTP client backends can now handle decompressing a deflate response that is not wrapped with a ZLIB header.

Before submitting pull request:
- [ ] Check if the project compiles by running `sbt compile`
- [ ] Verify docs compilation by running `sbt compileDocs`
- [ ] Check if tests pass by running `sbt test`
- [ ] Format code by running `sbt scalafmt`
