### PR TITLE
Add .resourceUsingClient to HttpClient backends.

### DIFF
--- a/effects/fs2-ce2/src/main/scalajvm/sttp/client3/httpclient/fs2/HttpClientFs2Backend.scala
+++ b/effects/fs2-ce2/src/main/scalajvm/sttp/client3/httpclient/fs2/HttpClientFs2Backend.scala
@@ -128,6 +128,16 @@ object HttpClientFs2Backend {
   ): Resource[F, SttpBackend[F, Fs2Streams[F] with WebSockets]] =
     Resource.make(apply(blocker, options, customizeRequest, customEncodingHandler))(_.close())
 
+  def resourceUsingClient[F[_]: ConcurrentEffect: ContextShift](
+      client: HttpClient,
+      blocker: Blocker,
+      customizeRequest: HttpRequest => HttpRequest = identity,
+      customEncodingHandler: Fs2EncodingHandler[F] = PartialFunction.empty
+  ): Resource[F, SttpBackend[F, Fs2Streams[F] with WebSockets]] =
+    Resource.make(
+      Sync[F].delay(HttpClientFs2Backend(client, blocker, closeClient = true, customizeRequest, customEncodingHandler))
+    )(_.close())
+
   def usingClient[F[_]: ConcurrentEffect: ContextShift](
       client: HttpClient,
       blocker: Blocker,

--- a/effects/fs2/src/main/scalajvm/sttp/client3/httpclient/fs2/HttpClientFs2Backend.scala
+++ b/effects/fs2/src/main/scalajvm/sttp/client3/httpclient/fs2/HttpClientFs2Backend.scala
@@ -132,6 +132,17 @@ object HttpClientFs2Backend {
       Resource.make(apply(dispatcher, options, customizeRequest, customEncodingHandler))(_.close())
     )
 
+  def resourceUsingClient[F[_]: Async](
+      client: HttpClient,
+      customizeRequest: HttpRequest => HttpRequest = identity,
+      customEncodingHandler: Fs2EncodingHandler[F] = PartialFunction.empty
+  ): Resource[F, SttpBackend[F, Fs2Streams[F] with WebSockets]] =
+    Dispatcher[F].flatMap(dispatcher =>
+      Resource.make(
+        Sync[F].delay(apply(client, closeClient = true, customizeRequest, customEncodingHandler, dispatcher))
+      )(_.close())
+    )
+
   def usingClient[F[_]: Async](
       client: HttpClient,
       dispatcher: Dispatcher[F],

--- a/effects/monix/src/main/scalajvm/sttp/client3/httpclient/monix/HttpClientMonixBackend.scala
+++ b/effects/monix/src/main/scalajvm/sttp/client3/httpclient/monix/HttpClientMonixBackend.scala
@@ -119,6 +119,17 @@ object HttpClientMonixBackend {
   ): Resource[Task, SttpBackend[Task, MonixStreams with WebSockets]] =
     Resource.make(apply(options, customizeRequest, customEncodingHandler))(_.close())
 
+  def resourceUsingClient(
+      client: HttpClient,
+      customizeRequest: HttpRequest => HttpRequest = identity,
+      customEncodingHandler: MonixEncodingHandler = PartialFunction.empty
+  )(implicit
+      s: Scheduler = Scheduler.global
+  ): Resource[Task, SttpBackend[Task, MonixStreams with WebSockets]] =
+    Resource.make(
+      Task.eval(HttpClientMonixBackend(client, closeClient = true, customizeRequest, customEncodingHandler)(s))
+    )(_.close())
+
   def usingClient(
       client: HttpClient,
       customizeRequest: HttpRequest => HttpRequest = identity,

--- a/effects/zio/src/main/scalajvm/sttp/client3/httpclient/zio/HttpClientZioBackend.scala
+++ b/effects/zio/src/main/scalajvm/sttp/client3/httpclient/zio/HttpClientZioBackend.scala
@@ -128,6 +128,15 @@ object HttpClientZioBackend {
       _.close().ignore
     )
 
+  def scopedUsingClient(
+      client: HttpClient,
+      customizeRequest: HttpRequest => HttpRequest = identity,
+      customEncodingHandler: ZioEncodingHandler = PartialFunction.empty
+  ): ZIO[Scope, Throwable, SttpBackend[Task, ZioStreams with WebSockets]] =
+    ZIO.acquireRelease(
+      ZIO.attempt(HttpClientZioBackend(client, closeClient = true, customizeRequest, customEncodingHandler))
+    )(_.close().ignore)
+
   def layer(
       options: SttpBackendOptions = SttpBackendOptions.Default,
       customizeRequest: HttpRequest => HttpRequest = identity,


### PR DESCRIPTION
Rationale:
I am trying to migrate away from the deprecated `AsyncHttpClientFs2Backend` and am struggling to reproduce the functionality with https://github.com/softwaremill/sttp/blob/b387e2f10571e49874a2a8c466537620ef639eaf/effects/fs2/src/main/scalajvm/sttp/client3/httpclient/fs2/HttpClientFs2Backend.scala#L96. 
`HttpClientFs2Backend.resource` has a default http client baked in, `HttpClientFs2Backend.usingClient` has hard-coded flag `closeClient = false`. I am missing something akin to `HttpClientFs2Backend.resourceUsingClient`, which would allow me to customize the client and at the same time get back the resource. 
