### PR TITLE
Absorb exceptions while mapping responses with impure functions in backend stub

### DIFF
--- a/async-http-client-backend/zio/src/test/scala/sttp/client3/asynchttpclient/zio/SttpBackendStubZioTests.scala
+++ b/async-http-client-backend/zio/src/test/scala/sttp/client3/asynchttpclient/zio/SttpBackendStubZioTests.scala
@@ -3,6 +3,7 @@ package sttp.client3.asynchttpclient.zio
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
+import sttp.capabilities.Streams
 import sttp.client3._
 import sttp.client3.impl.zio._
 import sttp.client3.testing.SttpBackendStub
@@ -43,5 +44,46 @@ class SttpBackendStubZioTests extends AnyFlatSpec with Matchers with ScalaFuture
       "a"
     ))
       .map(Right(_))
+  }
+
+  it should "lift errors due to mapping with impure functions into the response monad" in {
+    val backend: SttpBackendStub[Task, Any] =
+      SttpBackendStub(new RIOMonadAsyncError[Any]).whenAnyRequest.thenRespondOk()
+
+    val error = new IllegalStateException("boom")
+
+    val r = basicRequest
+      .post(uri"http://example.org")
+      .response(asStringAlways.map[Int](_ => throw error))
+      .send(backend)
+
+    unsafeRunSyncOrThrow(r.either) match {
+      case Left(_: IllegalStateException) => succeed
+      case _                              => fail(s"Should be a failure: $r")
+    }
+  }
+
+  trait TestStreams extends Streams[TestStreams] {
+    override type BinaryStream = List[Byte]
+    override type Pipe[A, B] = A => B
+  }
+
+  object TestStreams extends TestStreams
+
+  it should "lift errors due to mapping stream with impure functions into the response monad" in {
+    val backend = SttpBackendStub[Task, TestStreams](new RIOMonadAsyncError[Any]).whenAnyRequest
+      .thenRespond(SttpBackendStub.RawStream(List(1: Byte)))
+
+    val error = new IllegalStateException("boom")
+
+    val r = basicRequest
+      .get(uri"http://example.org")
+      .response(asStreamAlways[Task, Int, TestStreams](TestStreams)(_ => throw error))
+      .send(backend)
+
+    unsafeRunSyncOrThrow(r.either) match {
+      case Left(_: IllegalStateException) => succeed
+      case _                              => fail(s"Should be a failure: $r")
+    }
   }
 }

--- a/async-http-client-backend/zio/src/test/scala/sttp/client3/asynchttpclient/zio/SttpBackendStubZioTests.scala
+++ b/async-http-client-backend/zio/src/test/scala/sttp/client3/asynchttpclient/zio/SttpBackendStubZioTests.scala
@@ -3,10 +3,9 @@ package sttp.client3.asynchttpclient.zio
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
-import sttp.capabilities.Streams
 import sttp.client3._
 import sttp.client3.impl.zio._
-import sttp.client3.testing.SttpBackendStub
+import sttp.client3.testing.{SttpBackendStub, TestStreams}
 import zio._
 
 class SttpBackendStubZioTests extends AnyFlatSpec with Matchers with ScalaFutures with ZioTestBase {
@@ -62,13 +61,6 @@ class SttpBackendStubZioTests extends AnyFlatSpec with Matchers with ScalaFuture
       case _                              => fail(s"Should be a failure: $r")
     }
   }
-
-  trait TestStreams extends Streams[TestStreams] {
-    override type BinaryStream = List[Byte]
-    override type Pipe[A, B] = A => B
-  }
-
-  object TestStreams extends TestStreams
 
   it should "lift errors due to mapping stream with impure functions into the response monad" in {
     val backend = SttpBackendStub[Task, TestStreams](new RIOMonadAsyncError[Any]).whenAnyRequest

--- a/async-http-client-backend/zio1/src/test/scala/sttp/client3/asynchttpclient/zio/SttpBackendStubZioTests.scala
+++ b/async-http-client-backend/zio1/src/test/scala/sttp/client3/asynchttpclient/zio/SttpBackendStubZioTests.scala
@@ -3,10 +3,9 @@ package sttp.client3.asynchttpclient.zio
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
-import sttp.capabilities.Streams
 import sttp.client3._
 import sttp.client3.impl.zio._
-import sttp.client3.testing.SttpBackendStub
+import sttp.client3.testing.{SttpBackendStub, TestStreams}
 import sttp.model.Method
 import zio._
 import zio.stream.ZStream
@@ -91,13 +90,6 @@ class SttpBackendStubZioTests extends AnyFlatSpec with Matchers with ScalaFuture
       case _                              => fail(s"Should be a failure: $r")
     }
   }
-
-  trait TestStreams extends Streams[TestStreams] {
-    override type BinaryStream = List[Byte]
-    override type Pipe[A, B] = A => B
-  }
-
-  object TestStreams extends TestStreams
 
   it should "lift errors due to mapping stream with impure functions into the response monad" in {
     val backend = SttpBackendStub[Task, TestStreams](new RIOMonadAsyncError[Any]).whenAnyRequest

--- a/async-http-client-backend/zio1/src/test/scala/sttp/client3/asynchttpclient/zio/SttpBackendStubZioTests.scala
+++ b/async-http-client-backend/zio1/src/test/scala/sttp/client3/asynchttpclient/zio/SttpBackendStubZioTests.scala
@@ -3,6 +3,7 @@ package sttp.client3.asynchttpclient.zio
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
+import sttp.capabilities.Streams
 import sttp.client3._
 import sttp.client3.impl.zio._
 import sttp.client3.testing.SttpBackendStub
@@ -72,5 +73,46 @@ class SttpBackendStubZioTests extends AnyFlatSpec with Matchers with ScalaFuture
     } yield resp).provideLayer(AsyncHttpClientZioBackend.stubLayer)
 
     runtime.unsafeRun(effect).map(_.body).toList shouldBe List(Right("a"), Right("b"), Right("c"), Right("a"))
+  }
+
+  it should "lift errors due to mapping with impure functions into the response monad" in {
+    val backend: SttpBackendStub[Task, Any] =
+      SttpBackendStub(new RIOMonadAsyncError[Any]).whenAnyRequest.thenRespondOk()
+
+    val error = new IllegalStateException("boom")
+
+    val r = basicRequest
+      .post(uri"http://example.org")
+      .response(asStringAlways.map[Int](_ => throw error))
+      .send(backend)
+
+    runtime.unsafeRun(r.either) match {
+      case Left(_: IllegalStateException) => succeed
+      case _                              => fail(s"Should be a failure: $r")
+    }
+  }
+
+  trait TestStreams extends Streams[TestStreams] {
+    override type BinaryStream = List[Byte]
+    override type Pipe[A, B] = A => B
+  }
+
+  object TestStreams extends TestStreams
+
+  it should "lift errors due to mapping stream with impure functions into the response monad" in {
+    val backend = SttpBackendStub[Task, TestStreams](new RIOMonadAsyncError[Any]).whenAnyRequest
+      .thenRespond(SttpBackendStub.RawStream(List(1: Byte)))
+
+    val error = new IllegalStateException("boom")
+
+    val r = basicRequest
+      .get(uri"http://example.org")
+      .response(asStreamAlways[Task, Int, TestStreams](TestStreams)(_ => throw error))
+      .send(backend)
+
+    runtime.unsafeRun(r.either) match {
+      case Left(_: IllegalStateException) => succeed
+      case _                              => fail(s"Should be a failure: $r")
+    }
   }
 }

--- a/core/src/test/scala/sttp/client3/testing/HttpTest.scala
+++ b/core/src/test/scala/sttp/client3/testing/HttpTest.scala
@@ -171,7 +171,7 @@ trait HttpTest[F[_]]
         }
     }
 
-    "lift errors due to mapping with impure functions into the reponse monad" in {
+    "lift errors due to mapping with impure functions into the response monad" in {
       implicit val monadError: MonadError[F] = backend.responseMonad
 
       val error = new IllegalStateException("boom")

--- a/core/src/test/scala/sttp/client3/testing/SttpBackendStubTests.scala
+++ b/core/src/test/scala/sttp/client3/testing/SttpBackendStubTests.scala
@@ -6,7 +6,7 @@ import java.util.concurrent.TimeoutException
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
-import sttp.capabilities.{Streams, WebSockets}
+import sttp.capabilities.WebSockets
 import sttp.client3._
 import sttp.client3.internal._
 import sttp.client3.monad.IdMonad
@@ -315,12 +315,6 @@ class SttpBackendStubTests extends AnyFlatSpec with Matchers with ScalaFutures {
 
     frame shouldBe Success(Right(WebSocketFrame.text("hello")))
   }
-
-  trait TestStreams extends Streams[TestStreams] {
-    override type BinaryStream = List[Byte]
-    override type Pipe[A, B] = A => B
-  }
-  object TestStreams extends TestStreams
 
   it should "return a stream, given a stream, for a unsafe stream request" in {
     val backend: SttpBackend[Identity, TestStreams] = SttpBackendStub[Identity, TestStreams](IdMonad).whenAnyRequest

--- a/core/src/test/scala/sttp/client3/testing/TestStreams.scala
+++ b/core/src/test/scala/sttp/client3/testing/TestStreams.scala
@@ -1,0 +1,10 @@
+package sttp.client3.testing
+
+import sttp.capabilities.Streams
+
+trait TestStreams extends Streams[TestStreams] {
+  override type BinaryStream = List[Byte]
+  override type Pipe[A, B] = A => B
+}
+
+object TestStreams extends TestStreams

--- a/core/src/test/scala/sttp/client3/testing/streaming/StreamingTest.scala
+++ b/core/src/test/scala/sttp/client3/testing/streaming/StreamingTest.scala
@@ -197,7 +197,7 @@ abstract class StreamingTest[F[_], S]
       }
   }
 
-  "lift errors due to mapping with impure functions into the reponse monad" in {
+  "lift errors due to mapping with impure functions into the response monad" in {
     implicit val monadError: MonadError[F] = backend.responseMonad
 
     val error = new IllegalStateException("boom")

--- a/effects/zio/src/test/scalajvm/sttp/client3/httpclient/zio/SttpBackendStubZioTests.scala
+++ b/effects/zio/src/test/scalajvm/sttp/client3/httpclient/zio/SttpBackendStubZioTests.scala
@@ -3,6 +3,7 @@ package sttp.client3.httpclient.zio
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
+import sttp.capabilities.Streams
 import sttp.client3._
 import sttp.client3.impl.zio._
 import sttp.client3.testing.SttpBackendStub
@@ -43,5 +44,46 @@ class SttpBackendStubZioTests extends AnyFlatSpec with Matchers with ScalaFuture
       "a"
     ))
       .map(Right(_))
+  }
+
+  it should "lift errors due to mapping with impure functions into the response monad" in {
+    val backend: SttpBackendStub[Task, Any] =
+      SttpBackendStub(new RIOMonadAsyncError[Any]).whenAnyRequest.thenRespondOk()
+
+    val error = new IllegalStateException("boom")
+
+    val r = basicRequest
+      .post(uri"http://example.org")
+      .response(asStringAlways.map[Int](_ => throw error))
+      .send(backend)
+
+    unsafeRunSyncOrThrow(r.either) match {
+      case Left(_: IllegalStateException) => succeed
+      case _                              => fail(s"Should be a failure: $r")
+    }
+  }
+
+  trait TestStreams extends Streams[TestStreams] {
+    override type BinaryStream = List[Byte]
+    override type Pipe[A, B] = A => B
+  }
+
+  object TestStreams extends TestStreams
+
+  it should "lift errors due to mapping stream with impure functions into the response monad" in {
+    val backend = SttpBackendStub[Task, TestStreams](new RIOMonadAsyncError[Any]).whenAnyRequest
+      .thenRespond(SttpBackendStub.RawStream(List(1: Byte)))
+
+    val error = new IllegalStateException("boom")
+
+    val r = basicRequest
+      .get(uri"http://example.org")
+      .response(asStreamAlways[Task, Int, TestStreams](TestStreams)(_ => throw error))
+      .send(backend)
+
+    unsafeRunSyncOrThrow(r.either) match {
+      case Left(_: IllegalStateException) => succeed
+      case _                              => fail(s"Should be a failure: $r")
+    }
   }
 }

--- a/effects/zio/src/test/scalajvm/sttp/client3/httpclient/zio/SttpBackendStubZioTests.scala
+++ b/effects/zio/src/test/scalajvm/sttp/client3/httpclient/zio/SttpBackendStubZioTests.scala
@@ -3,10 +3,9 @@ package sttp.client3.httpclient.zio
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
-import sttp.capabilities.Streams
 import sttp.client3._
 import sttp.client3.impl.zio._
-import sttp.client3.testing.SttpBackendStub
+import sttp.client3.testing.{SttpBackendStub, TestStreams}
 import zio.{Task, ZIO}
 
 class SttpBackendStubZioTests extends AnyFlatSpec with Matchers with ScalaFutures with ZioTestBase {
@@ -62,13 +61,6 @@ class SttpBackendStubZioTests extends AnyFlatSpec with Matchers with ScalaFuture
       case _                              => fail(s"Should be a failure: $r")
     }
   }
-
-  trait TestStreams extends Streams[TestStreams] {
-    override type BinaryStream = List[Byte]
-    override type Pipe[A, B] = A => B
-  }
-
-  object TestStreams extends TestStreams
 
   it should "lift errors due to mapping stream with impure functions into the response monad" in {
     val backend = SttpBackendStub[Task, TestStreams](new RIOMonadAsyncError[Any]).whenAnyRequest

--- a/effects/zio1/src/test/scalajvm/sttp/client3/httpclient/zio/SttpBackendStubZioTests.scala
+++ b/effects/zio1/src/test/scalajvm/sttp/client3/httpclient/zio/SttpBackendStubZioTests.scala
@@ -3,10 +3,9 @@ package sttp.client3.httpclient.zio
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
-import sttp.capabilities.Streams
 import sttp.client3._
 import sttp.client3.impl.zio._
-import sttp.client3.testing.SttpBackendStub
+import sttp.client3.testing.{SttpBackendStub, TestStreams}
 import sttp.model.Method
 import zio.stream.ZStream
 import zio.{Task, ZIO}
@@ -91,13 +90,6 @@ class SttpBackendStubZioTests extends AnyFlatSpec with Matchers with ScalaFuture
       case _                              => fail(s"Should be a failure: $r")
     }
   }
-
-  trait TestStreams extends Streams[TestStreams] {
-    override type BinaryStream = List[Byte]
-    override type Pipe[A, B] = A => B
-  }
-
-  object TestStreams extends TestStreams
 
   it should "lift errors due to mapping stream with impure functions into the response monad" in {
     val backend = SttpBackendStub[Task, TestStreams](new RIOMonadAsyncError[Any]).whenAnyRequest

--- a/effects/zio1/src/test/scalajvm/sttp/client3/httpclient/zio/SttpBackendStubZioTests.scala
+++ b/effects/zio1/src/test/scalajvm/sttp/client3/httpclient/zio/SttpBackendStubZioTests.scala
@@ -3,6 +3,7 @@ package sttp.client3.httpclient.zio
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
+import sttp.capabilities.Streams
 import sttp.client3._
 import sttp.client3.impl.zio._
 import sttp.client3.testing.SttpBackendStub
@@ -72,5 +73,46 @@ class SttpBackendStubZioTests extends AnyFlatSpec with Matchers with ScalaFuture
     } yield resp).provideCustomLayer(HttpClientZioBackend.stubLayer)
 
     runtime.unsafeRun(effect).map(_.body).toList shouldBe List(Right("a"), Right("b"), Right("c"), Right("a"))
+  }
+
+  it should "lift errors due to mapping with impure functions into the response monad" in {
+    val backend: SttpBackendStub[Task, Any] =
+      SttpBackendStub(new RIOMonadAsyncError[Any]).whenAnyRequest.thenRespondOk()
+
+    val error = new IllegalStateException("boom")
+
+    val r = basicRequest
+      .post(uri"http://example.org")
+      .response(asStringAlways.map[Int](_ => throw error))
+      .send(backend)
+
+    runtime.unsafeRun(r.either) match {
+      case Left(_: IllegalStateException) => succeed
+      case _                              => fail(s"Should be a failure: $r")
+    }
+  }
+
+  trait TestStreams extends Streams[TestStreams] {
+    override type BinaryStream = List[Byte]
+    override type Pipe[A, B] = A => B
+  }
+
+  object TestStreams extends TestStreams
+
+  it should "lift errors due to mapping stream with impure functions into the response monad" in {
+    val backend = SttpBackendStub[Task, TestStreams](new RIOMonadAsyncError[Any]).whenAnyRequest
+      .thenRespond(SttpBackendStub.RawStream(List(1: Byte)))
+
+    val error = new IllegalStateException("boom")
+
+    val r = basicRequest
+      .get(uri"http://example.org")
+      .response(asStreamAlways[Task, Int, TestStreams](TestStreams)(_ => throw error))
+      .send(backend)
+
+    runtime.unsafeRun(r.either) match {
+      case Left(_: IllegalStateException) => succeed
+      case _                              => fail(s"Should be a failure: $r")
+    }
   }
 }


### PR DESCRIPTION
Before submitting pull request:
- [x] Check if the project compiles by running `sbt compile`
- [x] Verify docs compilation by running `sbt compileDocs`
- [x] Check if tests pass by running `sbt test`
- [x] Format code by running `sbt scalafmt`

In #1552, it was ensured that throwing functions used in mapped responses were correctly handled in effect systems with an error channel (namely, zio)

This pr replicates this behavior in `SttpBackendStub`, otherwise the stub does not behave as real backends.