### PR TITLE
Armeria retry

### DIFF
--- a/armeria-backend/cats/src/test/scala/sttp/client3/armeria/cats/ArmeriaCatsHttpTest.scala
+++ b/armeria-backend/cats/src/test/scala/sttp/client3/armeria/cats/ArmeriaCatsHttpTest.scala
@@ -2,15 +2,10 @@ package sttp.client3.armeria.cats
 
 import cats.effect.IO
 import sttp.client3._
-import sttp.client3.impl.cats.CatsTestBase
+import sttp.client3.impl.cats.{CatsRetryTest, CatsTestBase}
 import sttp.client3.testing.HttpTest
-import sttp.client3.testing.HttpTest.endpoint
-import sttp.model.StatusCode
 
-import scala.concurrent.duration.{DurationInt, FiniteDuration}
-import scala.util.Random
-
-class ArmeriaCatsHttpTest extends HttpTest[IO] with CatsTestBase {
+class ArmeriaCatsHttpTest extends HttpTest[IO] with CatsRetryTest with CatsTestBase {
   override val backend: SttpBackend[IO, Any] = ArmeriaCatsBackend[IO]()
 
   "illegal url exceptions" - {
@@ -18,33 +13,6 @@ class ArmeriaCatsHttpTest extends HttpTest[IO] with CatsTestBase {
       basicRequest.get(uri"ps://sth.com").send(backend).toFuture().failed.map { e =>
         e shouldBe a[IllegalArgumentException]
       }
-    }
-  }
-
-  val host = "localhost"
-
-  def retry[A](
-      task: IO[A],
-      delay: FiniteDuration = 100.millis,
-      retriesLeft: Int = 5
-  ): IO[A] =
-    task
-      .onError(e => IO.delay(println(s"Received error: $e, retries left = $retriesLeft")))
-      .handleErrorWith { error =>
-        if (retriesLeft > 0)
-          IO.sleep(delay) *> retry(task, delay, retriesLeft - 1)
-        else
-          IO.raiseError[A](error)
-      }
-
-  "retry test" - {
-    "should call the HTTP server twice" in {
-      val tag = Random.nextString(10)
-      val check = backend.send(basicRequest.get(uri"$endpoint/retry?tag=$tag")).map { response =>
-        response.code shouldBe StatusCode.Ok
-      }
-
-      retry(check).toFuture()
     }
   }
 

--- a/armeria-backend/cats/src/test/scala/sttp/client3/armeria/cats/ArmeriaCatsHttpTest.scala
+++ b/armeria-backend/cats/src/test/scala/sttp/client3/armeria/cats/ArmeriaCatsHttpTest.scala
@@ -1,9 +1,19 @@
 package sttp.client3.armeria.cats
 
 import cats.effect.IO
+import org.mockserver.client.MockServerClient
+import org.mockserver.integration.ClientAndServer
+import org.mockserver.integration.ClientAndServer.startClientAndServer
+import org.mockserver.matchers.Times
+import org.mockserver.model.HttpRequest.request
+import org.mockserver.model.HttpResponse.response
+import org.scalatest.Assertion
 import sttp.client3._
 import sttp.client3.impl.cats.CatsTestBase
 import sttp.client3.testing.HttpTest
+import sttp.model.StatusCode
+
+import scala.concurrent.duration.{DurationInt, FiniteDuration}
 
 class ArmeriaCatsHttpTest extends HttpTest[IO] with CatsTestBase {
   override val backend: SttpBackend[IO, Any] = ArmeriaCatsBackend[IO]()
@@ -13,6 +23,66 @@ class ArmeriaCatsHttpTest extends HttpTest[IO] with CatsTestBase {
       basicRequest.get(uri"ps://sth.com").send(backend).toFuture().failed.map { e =>
         e shouldBe a[IllegalArgumentException]
       }
+    }
+  }
+
+  val port = 8080
+  val host = "localhost"
+
+  implicit class RetryTask[A](task: IO[A]) {
+    def retry(
+        delay: FiniteDuration = 100.millis,
+        retriesLeft: Int = 5
+    ): IO[A] =
+      task
+        .onError(e => IO.delay(println(s"Received error: $e, retries left = $retriesLeft")))
+        .handleErrorWith { error =>
+          if (retriesLeft > 0)
+            IO.sleep(delay) *> retry(delay, retriesLeft - 1)
+          else
+            IO.raiseError[A](error)
+        }
+  }
+
+  def setRespondWithCode(code: Int, howManyTimes: Int): Unit = {
+    new MockServerClient(host, port)
+      .when(
+        request()
+          .withPath("/api-test")
+          .withMethod("GET"),
+        Times.exactly(howManyTimes)
+      )
+      .respond(
+        response()
+          .withStatusCode(code)
+      )
+  }
+
+  "retry test" - {
+    "should call the HTTP server twice" in {
+      var mockServer: ClientAndServer = null
+      mockServer = startClientAndServer(port)
+      // given
+      setRespondWithCode(401, howManyTimes = 2)
+      setRespondWithCode(400, howManyTimes = 1)
+      setRespondWithCode(200, howManyTimes = 1)
+
+      // when
+      val result: IO[Response[Either[String, String]]] =
+        backend.send(basicRequest.get(uri"http://$host:$port/api-test"))
+
+      // then
+      val check: IO[Assertion] = result.map { response =>
+        response.code shouldBe StatusCode.Ok
+      }
+
+      check
+        .retry()
+        .map(e => {
+          mockServer.stop()
+          e
+        })
+        .toFuture()
     }
   }
 

--- a/armeria-backend/cats/src/test/scala/sttp/client3/armeria/cats/ArmeriaCatsHttpTest.scala
+++ b/armeria-backend/cats/src/test/scala/sttp/client3/armeria/cats/ArmeriaCatsHttpTest.scala
@@ -1,19 +1,14 @@
 package sttp.client3.armeria.cats
 
 import cats.effect.IO
-import org.mockserver.client.MockServerClient
-import org.mockserver.integration.ClientAndServer
-import org.mockserver.integration.ClientAndServer.startClientAndServer
-import org.mockserver.matchers.Times
-import org.mockserver.model.HttpRequest.request
-import org.mockserver.model.HttpResponse.response
-import org.scalatest.Assertion
 import sttp.client3._
 import sttp.client3.impl.cats.CatsTestBase
 import sttp.client3.testing.HttpTest
+import sttp.client3.testing.HttpTest.endpoint
 import sttp.model.StatusCode
 
 import scala.concurrent.duration.{DurationInt, FiniteDuration}
+import scala.util.Random
 
 class ArmeriaCatsHttpTest extends HttpTest[IO] with CatsTestBase {
   override val backend: SttpBackend[IO, Any] = ArmeriaCatsBackend[IO]()
@@ -26,63 +21,30 @@ class ArmeriaCatsHttpTest extends HttpTest[IO] with CatsTestBase {
     }
   }
 
-  val port = 8080
   val host = "localhost"
 
-  implicit class RetryTask[A](task: IO[A]) {
-    def retry(
-        delay: FiniteDuration = 100.millis,
-        retriesLeft: Int = 5
-    ): IO[A] =
-      task
-        .onError(e => IO.delay(println(s"Received error: $e, retries left = $retriesLeft")))
-        .handleErrorWith { error =>
-          if (retriesLeft > 0)
-            IO.sleep(delay) *> retry(delay, retriesLeft - 1)
-          else
-            IO.raiseError[A](error)
-        }
-  }
-
-  def setRespondWithCode(code: Int, howManyTimes: Int): Unit = {
-    new MockServerClient(host, port)
-      .when(
-        request()
-          .withPath("/api-test")
-          .withMethod("GET"),
-        Times.exactly(howManyTimes)
-      )
-      .respond(
-        response()
-          .withStatusCode(code)
-      )
-  }
+  def retry[A](
+      task: IO[A],
+      delay: FiniteDuration = 100.millis,
+      retriesLeft: Int = 5
+  ): IO[A] =
+    task
+      .onError(e => IO.delay(println(s"Received error: $e, retries left = $retriesLeft")))
+      .handleErrorWith { error =>
+        if (retriesLeft > 0)
+          IO.sleep(delay) *> retry(task, delay, retriesLeft - 1)
+        else
+          IO.raiseError[A](error)
+      }
 
   "retry test" - {
     "should call the HTTP server twice" in {
-      var mockServer: ClientAndServer = null
-      mockServer = startClientAndServer(port)
-      // given
-      setRespondWithCode(401, howManyTimes = 2)
-      setRespondWithCode(400, howManyTimes = 1)
-      setRespondWithCode(200, howManyTimes = 1)
-
-      // when
-      val result: IO[Response[Either[String, String]]] =
-        backend.send(basicRequest.get(uri"http://$host:$port/api-test"))
-
-      // then
-      val check: IO[Assertion] = result.map { response =>
+      val tag = Random.nextString(10)
+      val check = backend.send(basicRequest.get(uri"$endpoint/retry?tag=$tag")).map { response =>
         response.code shouldBe StatusCode.Ok
       }
 
-      check
-        .retry()
-        .map(e => {
-          mockServer.stop()
-          e
-        })
-        .toFuture()
+      retry(check).toFuture()
     }
   }
 

--- a/armeria-backend/src/main/scala/sttp/client3/armeria/AbstractArmeriaBackend.scala
+++ b/armeria-backend/src/main/scala/sttp/client3/armeria/AbstractArmeriaBackend.scala
@@ -59,7 +59,7 @@ abstract class AbstractArmeriaBackend[F[_], S <: Streams[S]](
   override def responseMonad: MonadError[F] = monad
 
   override def send[T, R >: SE](request: Request[T, R]): F[Response[T]] =
-    adjustExceptions(request)(execute(request))
+    monad.unit(request).flatMap(r => adjustExceptions(request)(execute(r)))
 
   private def execute[T, R >: SE](request: Request[T, R]): F[Response[T]] = {
     val captor = Clients.newContextCaptor()

--- a/async-http-client-backend/cats/src/test/scala/sttp/client3/asynchttpclient/cats/AsyncHttpClientCatsHttpTest.scala
+++ b/async-http-client-backend/cats/src/test/scala/sttp/client3/asynchttpclient/cats/AsyncHttpClientCatsHttpTest.scala
@@ -2,10 +2,10 @@ package sttp.client3.asynchttpclient.cats
 
 import cats.effect.IO
 import sttp.client3._
-import sttp.client3.impl.cats.CatsTestBase
+import sttp.client3.impl.cats.{CatsRetryTest, CatsTestBase}
 import sttp.client3.testing.HttpTest
 
-class AsyncHttpClientCatsHttpTest extends HttpTest[IO] with CatsTestBase {
+class AsyncHttpClientCatsHttpTest extends HttpTest[IO] with CatsRetryTest with CatsTestBase {
   override val backend: SttpBackend[IO, Any] = AsyncHttpClientCatsBackend[IO]().unsafeRunSync()
 
   "illegal url exceptions" - {

--- a/build.sbt
+++ b/build.sbt
@@ -743,9 +743,6 @@ lazy val armeriaCatsCe2Backend =
 
 lazy val armeriaCatsBackend =
   armeriaBackendProject("cats", includeDotty = true)
-    .settings(
-      libraryDependencies += "org.mock-server" % "mockserver-netty-no-dependencies" % "5.14.0" % Test
-    )
     .dependsOn(cats % compileAndTest)
 
 lazy val armeriaScalazBackend =

--- a/build.sbt
+++ b/build.sbt
@@ -712,7 +712,11 @@ def armeriaBackendProject(proj: String, includeDotty: Boolean = false) = {
     .settings(name := s"armeria-backend-$proj")
     .dependsOn(armeriaBackend % compileAndTest)
     .jvmPlatform(
-      scalaVersions = List(scala2_12, scala2_13) ++ (if (includeDotty) scala3 else Nil)
+      scalaVersions = List(scala2_12, scala2_13) ++ (if (includeDotty) scala3 else Nil),
+      settings = libraryDependencies ++= Seq(
+        "org.mock-server" % "mockserver-netty-no-dependencies" % "5.14.0" % Test,
+        "org.typelevel" %% "cats-effect-testing-scalatest" % "1.4.0" % Test
+      )
     )
 }
 

--- a/build.sbt
+++ b/build.sbt
@@ -705,20 +705,15 @@ lazy val armeriaBackend = (projectMatrix in file("armeria-backend"))
   .jvmPlatform(scalaVersions = List(scala2_12, scala2_13) ++ scala3)
   .dependsOn(core % compileAndTest)
 
-def armeriaBackendProject(proj: String, includeDotty: Boolean = false) = {
+def armeriaBackendProject(proj: String, includeDotty: Boolean = false) =
   ProjectMatrix(s"armeriaBackend${proj.capitalize}", file(s"armeria-backend/$proj"))
     .settings(commonJvmSettings)
     .settings(testServerSettings)
     .settings(name := s"armeria-backend-$proj")
     .dependsOn(armeriaBackend % compileAndTest)
     .jvmPlatform(
-      scalaVersions = List(scala2_12, scala2_13) ++ (if (includeDotty) scala3 else Nil),
-      settings = libraryDependencies ++= Seq(
-        "org.mock-server" % "mockserver-netty-no-dependencies" % "5.14.0" % Test,
-        "org.typelevel" %% "cats-effect-testing-scalatest" % "1.4.0" % Test
-      )
+      scalaVersions = List(scala2_12, scala2_13) ++ (if (includeDotty) scala3 else Nil)
     )
-}
 
 lazy val armeriaMonixBackend =
   armeriaBackendProject("monix", includeDotty = true)
@@ -748,6 +743,9 @@ lazy val armeriaCatsCe2Backend =
 
 lazy val armeriaCatsBackend =
   armeriaBackendProject("cats", includeDotty = true)
+    .settings(
+      libraryDependencies += "org.mock-server" % "mockserver-netty-no-dependencies" % "5.14.0" % Test
+    )
     .dependsOn(cats % compileAndTest)
 
 lazy val armeriaScalazBackend =

--- a/effects/cats/src/test/scala/sttp/client3/impl/cats/CatsRetryTest.scala
+++ b/effects/cats/src/test/scala/sttp/client3/impl/cats/CatsRetryTest.scala
@@ -1,0 +1,38 @@
+package sttp.client3.impl.cats
+
+import cats.effect.IO
+import sttp.client3._
+import sttp.client3.testing.HttpTest
+
+import sttp.client3.testing.HttpTest.endpoint
+import sttp.model.StatusCode
+
+import scala.concurrent.duration.{DurationInt, FiniteDuration}
+import scala.util.Random
+
+trait CatsRetryTest { this: HttpTest[IO] =>
+  def retry[A](
+      task: IO[A],
+      delay: FiniteDuration = 100.millis,
+      retriesLeft: Int = 5
+  ): IO[A] =
+    task
+      .onError(e => IO.delay(println(s"Received error: $e, retries left = $retriesLeft")))
+      .handleErrorWith { error =>
+        if (retriesLeft > 0)
+          IO.sleep(delay) *> retry(task, delay, retriesLeft - 1)
+        else
+          IO.raiseError[A](error)
+      }
+
+  "retry test" - {
+    "should call the HTTP server twice" in {
+      val tag = Random.nextString(10)
+      val check = backend.send(basicRequest.get(uri"$endpoint/retry?tag=$tag")).map { response =>
+        response.code shouldBe StatusCode.Ok
+      }
+
+      retry(check).toFuture()
+    }
+  }
+}

--- a/effects/cats/src/test/scala/sttp/client3/impl/cats/CatsRetryTest.scala
+++ b/effects/cats/src/test/scala/sttp/client3/impl/cats/CatsRetryTest.scala
@@ -11,7 +11,7 @@ import scala.concurrent.duration.{DurationInt, FiniteDuration}
 import scala.util.Random
 
 trait CatsRetryTest { this: HttpTest[IO] =>
-  def retry[A](task: IO[A], delay: FiniteDuration, retries: Int): IO[A] =
+  private def retry[A](task: IO[A], delay: FiniteDuration, retries: Int): IO[A] =
     task
       .onError(e => IO.delay(println(s"Received error: $e, retries left = $retries")))
       .handleErrorWith { error =>

--- a/effects/cats/src/test/scala/sttp/client3/impl/cats/CatsRetryTest.scala
+++ b/effects/cats/src/test/scala/sttp/client3/impl/cats/CatsRetryTest.scala
@@ -1,16 +1,16 @@
 package sttp.client3.impl.cats
 
 import cats.effect.IO
+import org.scalatest.freespec.AsyncFreeSpecLike
 import sttp.client3._
 import sttp.client3.testing.HttpTest
-
 import sttp.client3.testing.HttpTest.endpoint
 import sttp.model.StatusCode
 
 import scala.concurrent.duration.{DurationInt, FiniteDuration}
 import scala.util.Random
 
-trait CatsRetryTest { this: HttpTest[IO] =>
+trait CatsRetryTest extends AsyncFreeSpecLike { this: HttpTest[IO] =>
   private def retry[A](task: IO[A], delay: FiniteDuration, retries: Int): IO[A] =
     task
       .onError(e => IO.delay(println(s"Received error: $e, retries left = $retries")))

--- a/effects/cats/src/test/scalajvm/sttp/client3/httpclient/cats/HttpClientCatsHttpTest.scala
+++ b/effects/cats/src/test/scalajvm/sttp/client3/httpclient/cats/HttpClientCatsHttpTest.scala
@@ -1,9 +1,10 @@
 package sttp.client3.httpclient.cats
 
 import cats.effect.IO
+import sttp.client3.impl.cats.CatsRetryTest
 import sttp.client3.testing.HttpTest
 
-class HttpClientCatsHttpTest extends HttpTest[IO] with HttpClientCatsTestBase {
+class HttpClientCatsHttpTest extends HttpTest[IO] with CatsRetryTest with HttpClientCatsTestBase {
   override def supportsHostHeaderOverride = false
 
   override def supportsDeflateWrapperChecking = false

--- a/http4s-backend/src/test/scala/sttp/client3/http4s/Http4sHttpTest.scala
+++ b/http4s-backend/src/test/scala/sttp/client3/http4s/Http4sHttpTest.scala
@@ -3,12 +3,12 @@ package sttp.client3.http4s
 import cats.effect.IO
 import org.http4s.blaze.client.BlazeClientBuilder
 import sttp.client3.SttpBackend
-import sttp.client3.impl.cats.CatsTestBase
+import sttp.client3.impl.cats.{CatsRetryTest, CatsTestBase}
 import sttp.client3.testing.HttpTest
 
 import scala.concurrent.ExecutionContext
 
-class Http4sHttpTest extends HttpTest[IO] with CatsTestBase {
+class Http4sHttpTest extends HttpTest[IO] with CatsRetryTest with CatsTestBase {
   private val blazeClientBuilder = BlazeClientBuilder[IO](ExecutionContext.global)
 
   override val backend: SttpBackend[IO, Any] =

--- a/testing/server/src/main/scala/sttp/client3/testing/server/HttpServer.scala
+++ b/testing/server/src/main/scala/sttp/client3/testing/server/HttpServer.scala
@@ -18,7 +18,9 @@ import akka.util.ByteString
 import akka.{Done, NotUsed}
 import ch.megard.akka.http.cors.scaladsl.CorsDirectives
 import ch.megard.akka.http.cors.scaladsl.settings.CorsSettings
+
 import java.io.{ByteArrayOutputStream, InputStream, OutputStream}
+import java.util.concurrent.ConcurrentHashMap
 import scala.annotation.tailrec
 import scala.concurrent.duration._
 import scala.concurrent.{Await, Future, Promise}
@@ -49,6 +51,7 @@ private class HttpServer(port: Int, info: String => Unit) extends AutoCloseable 
   private val binaryFile = toByteArray(getClass.getResourceAsStream("/binaryfile.jpg"))
   private val compressedFile = toByteArray(getClass.getResourceAsStream("/r3.gz"))
   private val textWithSpecialCharacters = "Żółć!"
+  private val retryTestCache = new ConcurrentHashMap[String, Int]()
 
   private val serverRoutes: Route =
     pathPrefix("echo") {
@@ -401,6 +404,18 @@ private class HttpServer(port: Int, info: String => Unit) extends AutoCloseable 
           protocol = HttpProtocols.`HTTP/1.1`
         )
       )
+    } ~ pathPrefix("retry") { // #1616: calling the endpoint with the same tag will give status codes 401, 401, 400, 200, ...
+      parameter("tag") { tag =>
+        val current = Option(retryTestCache.get(tag)).getOrElse(0)
+        retryTestCache.put(tag, current + 1)
+
+        current match {
+          case 0 => complete(StatusCodes.Unauthorized, "")
+          case 1 => complete(StatusCodes.Unauthorized, "")
+          case 2 => complete(StatusCodes.BadRequest, "")
+          case _ => complete(StatusCodes.OK, "")
+        }
+      }
     } ~ pathPrefix("timeout") {
       complete {
         akka.pattern.after(2.seconds, using = actorSystem.scheduler)(


### PR DESCRIPTION
Closes #1616 
In my opinion the problem was that a part of send in `AbstractArmeriaBackend.scala` was not wrapped by F context and thus was executing only once for all the retries.