### PR TITLE
Use effect runtimes' executors for JDK client

### DIFF
--- a/async-http-client-backend/fs2/src/main/scala/sttp/client3/asynchttpclient/fs2/AsyncHttpClientFs2Backend.scala
+++ b/async-http-client-backend/fs2/src/main/scala/sttp/client3/asynchttpclient/fs2/AsyncHttpClientFs2Backend.scala
@@ -129,9 +129,11 @@ object AsyncHttpClientFs2Backend {
       customizeRequest: BoundRequestBuilder => BoundRequestBuilder = identity,
       webSocketBufferCapacity: Option[Int] = AsyncHttpClientBackend.DefaultWebSocketBufferCapacity
   ): Resource[F, SttpBackend[F, Fs2Streams[F] with WebSockets]] =
-    Dispatcher.parallel[F].flatMap(dispatcher =>
-      Resource.make(apply(dispatcher, options, customizeRequest, webSocketBufferCapacity))(_.close())
-    )
+    Dispatcher
+      .parallel[F]
+      .flatMap(dispatcher =>
+        Resource.make(apply(dispatcher, options, customizeRequest, webSocketBufferCapacity))(_.close())
+      )
 
   def usingConfig[F[_]: Async](
       cfg: AsyncHttpClientConfig,
@@ -155,9 +157,11 @@ object AsyncHttpClientFs2Backend {
       customizeRequest: BoundRequestBuilder => BoundRequestBuilder = identity,
       webSocketBufferCapacity: Option[Int] = AsyncHttpClientBackend.DefaultWebSocketBufferCapacity
   ): Resource[F, SttpBackend[F, Fs2Streams[F] with WebSockets]] =
-    Dispatcher.parallel[F].flatMap(dispatcher =>
-      Resource.make(usingConfig(cfg, dispatcher, customizeRequest, webSocketBufferCapacity))(_.close())
-    )
+    Dispatcher
+      .parallel[F]
+      .flatMap(dispatcher =>
+        Resource.make(usingConfig(cfg, dispatcher, customizeRequest, webSocketBufferCapacity))(_.close())
+      )
 
   /** @param updateConfig A function which updates the default configuration (created basing on `options`). */
   def usingConfigBuilder[F[_]: Async](
@@ -187,11 +191,13 @@ object AsyncHttpClientFs2Backend {
       customizeRequest: BoundRequestBuilder => BoundRequestBuilder = identity,
       webSocketBufferCapacity: Option[Int] = AsyncHttpClientBackend.DefaultWebSocketBufferCapacity
   ): Resource[F, SttpBackend[F, Fs2Streams[F] with WebSockets]] =
-    Dispatcher.parallel[F].flatMap(dispatcher =>
-      Resource.make(usingConfigBuilder(dispatcher, updateConfig, options, customizeRequest, webSocketBufferCapacity))(
-        _.close()
+    Dispatcher
+      .parallel[F]
+      .flatMap(dispatcher =>
+        Resource.make(usingConfigBuilder(dispatcher, updateConfig, options, customizeRequest, webSocketBufferCapacity))(
+          _.close()
+        )
       )
-    )
 
   def usingClient[F[_]: Async](
       client: AsyncHttpClient,

--- a/core/src/main/scalajvm/sttp/client3/HttpClientBackend.scala
+++ b/core/src/main/scalajvm/sttp/client3/HttpClientBackend.scala
@@ -124,11 +124,13 @@ object HttpClientBackend {
     }
   }
 
-  private[client3] def defaultClient(options: SttpBackendOptions): HttpClient = {
+  private[client3] def defaultClient(options: SttpBackendOptions, executor: Option[Executor]): HttpClient = {
     var clientBuilder = HttpClient
       .newBuilder()
       .followRedirects(HttpClient.Redirect.NEVER)
       .connectTimeout(JDuration.ofMillis(options.connectionTimeout.toMillis))
+
+    clientBuilder = executor.fold(clientBuilder)(clientBuilder.executor)
 
     clientBuilder = options.proxy match {
       case None => clientBuilder

--- a/core/src/main/scalajvm/sttp/client3/HttpClientBackend.scala
+++ b/core/src/main/scalajvm/sttp/client3/HttpClientBackend.scala
@@ -124,6 +124,10 @@ object HttpClientBackend {
     }
   }
 
+  // Left here for bincompat
+  private[client3] def defaultClient(options: SttpBackendOptions): HttpClient =
+    defaultClient(options, None)
+
   private[client3] def defaultClient(options: SttpBackendOptions, executor: Option[Executor]): HttpClient = {
     var clientBuilder = HttpClient
       .newBuilder()

--- a/core/src/main/scalajvm/sttp/client3/HttpClientSyncBackend.scala
+++ b/core/src/main/scalajvm/sttp/client3/HttpClientSyncBackend.scala
@@ -87,7 +87,7 @@ object HttpClientSyncBackend {
       customEncodingHandler: SyncEncodingHandler = PartialFunction.empty
   ): SttpBackend[Identity, Any] =
     HttpClientSyncBackend(
-      HttpClientBackend.defaultClient(options),
+      HttpClientBackend.defaultClient(options, None),
       closeClient = true,
       customizeRequest,
       customEncodingHandler

--- a/effects/fs2-ce2/src/main/scalajvm/sttp/client3/httpclient/fs2/HttpClientFs2Backend.scala
+++ b/effects/fs2-ce2/src/main/scalajvm/sttp/client3/httpclient/fs2/HttpClientFs2Backend.scala
@@ -112,7 +112,7 @@ object HttpClientFs2Backend {
   ): F[SttpBackend[F, Fs2Streams[F] with WebSockets]] =
     Sync[F].delay(
       HttpClientFs2Backend(
-        HttpClientBackend.defaultClient(options),
+        HttpClientBackend.defaultClient(options, None),
         blocker,
         closeClient = true,
         customizeRequest,

--- a/effects/monix/src/main/scalajvm/sttp/client3/httpclient/monix/HttpClientMonixBackend.scala
+++ b/effects/monix/src/main/scalajvm/sttp/client3/httpclient/monix/HttpClientMonixBackend.scala
@@ -103,7 +103,7 @@ object HttpClientMonixBackend {
   ): Task[SttpBackend[Task, MonixStreams with WebSockets]] =
     Task.eval(
       HttpClientMonixBackend(
-        HttpClientBackend.defaultClient(options),
+        HttpClientBackend.defaultClient(options, Some(s)),
         closeClient = true,
         customizeRequest,
         customEncodingHandler

--- a/effects/zio/src/main/scalajvm/sttp/client3/httpclient/zio/HttpClientZioBackend.scala
+++ b/effects/zio/src/main/scalajvm/sttp/client3/httpclient/zio/HttpClientZioBackend.scala
@@ -109,15 +109,18 @@ object HttpClientZioBackend {
       options: SttpBackendOptions = SttpBackendOptions.Default,
       customizeRequest: HttpRequest => HttpRequest = identity,
       customEncodingHandler: ZioEncodingHandler = PartialFunction.empty
-  ): Task[SttpBackend[Task, ZioStreams with WebSockets]] =
-    ZIO.attempt(
-      HttpClientZioBackend(
-        HttpClientBackend.defaultClient(options),
-        closeClient = true,
-        customizeRequest,
-        customEncodingHandler
+  ): Task[SttpBackend[Task, ZioStreams with WebSockets]] = {
+    ZIO.executor.flatMap(executor =>
+      ZIO.attempt(
+        HttpClientZioBackend(
+          HttpClientBackend.defaultClient(options, Some(executor.asJava)),
+          closeClient = true,
+          customizeRequest,
+          customEncodingHandler
+        )
       )
     )
+  }
 
   def scoped(
       options: SttpBackendOptions = SttpBackendOptions.Default,

--- a/effects/zio1/src/main/scalajvm/sttp/client3/httpclient/zio/HttpClientZioBackend.scala
+++ b/effects/zio1/src/main/scalajvm/sttp/client3/httpclient/zio/HttpClientZioBackend.scala
@@ -110,15 +110,18 @@ object HttpClientZioBackend {
       options: SttpBackendOptions = SttpBackendOptions.Default,
       customizeRequest: HttpRequest => HttpRequest = identity,
       customEncodingHandler: ZioEncodingHandler = PartialFunction.empty
-  ): Task[SttpBackend[Task, ZioStreams with WebSockets]] =
-    Task.effect(
-      HttpClientZioBackend(
-        HttpClientBackend.defaultClient(options),
-        closeClient = true,
-        customizeRequest,
-        customEncodingHandler
+  ): Task[SttpBackend[Task, ZioStreams with WebSockets]] = {
+    UIO.executor.flatMap(executor =>
+      Task.effect(
+        HttpClientZioBackend(
+          HttpClientBackend.defaultClient(options, Some(executor.asJava)),
+          closeClient = true,
+          customizeRequest,
+          customEncodingHandler
+        )
       )
     )
+  }
 
   def managed(
       options: SttpBackendOptions = SttpBackendOptions.Default,


### PR DESCRIPTION
The JDK HttpClient will create its own cached thread pool if no executor is given explicitly, leading to more threads that contend for scheduling. As it performs no thread blocking, it should be more efficient to use the compute pool exposed by the effect runtime (CE, Monix, ZIO, Scala global).

Prior art in http4s-jdk-client: https://github.com/http4s/http4s-jdk-http-client/pull/641

In-depth explanation of why additional thread pools are problematic: https://github.com/typelevel/cats-effect/blob/26630c04e60afe7bba43bb1506ecfc4f773ad927/docs/core/starvation-and-tuning.md

Before submitting pull request:
- [x] Check if the project compiles by running `sbt compile`
- [ ] Verify docs compilation by running `sbt compileDocs`
- [ ] Check if tests pass by running `sbt test`
- [x] Format code by running `sbt scalafmt`
