### PR TITLE
Don't close the effect system executor, if it is the one used by HttpClient. Only close thread-pool based executors.

### DIFF
--- a/core/src/main/scalajvm/sttp/client3/HttpClientBackend.scala
+++ b/core/src/main/scalajvm/sttp/client3/HttpClientBackend.scala
@@ -110,6 +110,7 @@ abstract class HttpClientBackend[F[_], S, P, B](
           .map[Unit](new function.Function[Executor, Unit] {
             override def apply(t: Executor): Unit = t match {
               case tpe: ThreadPoolExecutor => tpe.shutdown()
+              case _ => ()
             }
           })
       )

--- a/core/src/main/scalajvm/sttp/client3/HttpClientBackend.scala
+++ b/core/src/main/scalajvm/sttp/client3/HttpClientBackend.scala
@@ -17,6 +17,9 @@ import java.util.concurrent.{Executor, ThreadPoolExecutor}
 import java.util.function
 import scala.collection.JavaConverters._
 
+/** @param closeClient
+  *   If the executor underlying the client is a [[ThreadPoolExecutor]], should it be shutdown on [[close]].
+  */
 abstract class HttpClientBackend[F[_], S, P, B](
     client: HttpClient,
     closeClient: Boolean,
@@ -105,7 +108,9 @@ abstract class HttpClientBackend[F[_], S, P, B](
         client
           .executor()
           .map[Unit](new function.Function[Executor, Unit] {
-            override def apply(t: Executor): Unit = t.asInstanceOf[ThreadPoolExecutor].shutdown()
+            override def apply(t: Executor): Unit = t match {
+              case tpe: ThreadPoolExecutor => tpe.shutdown()
+            }
           })
       )
     } else {

--- a/core/src/main/scalajvm/sttp/client3/HttpClientFutureBackend.scala
+++ b/core/src/main/scalajvm/sttp/client3/HttpClientFutureBackend.scala
@@ -107,7 +107,7 @@ object HttpClientFutureBackend {
     val executor = Some(ec).collect { case executor: Executor => executor }
     HttpClientFutureBackend(
       HttpClientBackend.defaultClient(options, executor),
-      closeClient = true,
+      closeClient = executor.isEmpty,
       customizeRequest,
       customEncodingHandler
     )

--- a/effects/cats/src/main/scalajvm/sttp/client3/httpclient/cats/HttpClientCatsBackend.scala
+++ b/effects/cats/src/main/scalajvm/sttp/client3/httpclient/cats/HttpClientCatsBackend.scala
@@ -107,7 +107,7 @@ object HttpClientCatsBackend {
       Sync[F].delay(
         HttpClientCatsBackend(
           HttpClientBackend.defaultClient(options, Some(executor)),
-          closeClient = true,
+          closeClient = false, // we don't want to close the underlying executor
           customizeRequest,
           customEncodingHandler,
           dispatcher

--- a/effects/cats/src/test/scalajvm/sttp/client3/httpclient/cats/HttpClientCatsCloseTest.scala
+++ b/effects/cats/src/test/scalajvm/sttp/client3/httpclient/cats/HttpClientCatsCloseTest.scala
@@ -1,0 +1,18 @@
+package sttp.client3.httpclient.cats
+
+import cats.effect.IO
+import cats.effect.unsafe.implicits.global
+import org.scalatest.freespec.AsyncFreeSpec
+import org.scalatest.matchers.should.Matchers
+
+class HttpClientCatsCloseTest extends AsyncFreeSpec with Matchers {
+  "cats-effect" - {
+    "continue working after the backend is closed" in {
+      HttpClientCatsBackend
+        .resource[IO]()
+        .use(_ => IO.unit)
+        .flatMap(_ => IO(succeed).start.flatMap(_.joinWith(IO(fail)))) // the cats executor should still be open
+        .unsafeToFuture()
+    }
+  }
+}

--- a/effects/cats/src/test/scalajvm/sttp/client3/httpclient/cats/HttpClientCatsCloseTest.scala
+++ b/effects/cats/src/test/scalajvm/sttp/client3/httpclient/cats/HttpClientCatsCloseTest.scala
@@ -11,7 +11,7 @@ class HttpClientCatsCloseTest extends AsyncFreeSpec with Matchers {
       HttpClientCatsBackend
         .resource[IO]()
         .use(_ => IO.unit)
-        .flatMap(_ => IO(succeed).start.flatMap(_.joinWith(IO(fail)))) // the cats executor should still be open
+        .flatMap(_ => IO(succeed).start.flatMap(_.joinWith(IO(fail())))) // the cats executor should still be open
         .unsafeToFuture()
     }
   }

--- a/effects/fs2/src/main/scalajvm/sttp/client3/httpclient/fs2/HttpClientFs2Backend.scala
+++ b/effects/fs2/src/main/scalajvm/sttp/client3/httpclient/fs2/HttpClientFs2Backend.scala
@@ -117,7 +117,7 @@ object HttpClientFs2Backend {
       Sync[F].delay(
         HttpClientFs2Backend(
           HttpClientBackend.defaultClient(options, Some(executor)),
-          closeClient = true,
+          closeClient = false, // we don't want to close the underlying executor
           customizeRequest,
           customEncodingHandler,
           dispatcher

--- a/effects/monix/src/main/scalajvm/sttp/client3/httpclient/monix/HttpClientMonixBackend.scala
+++ b/effects/monix/src/main/scalajvm/sttp/client3/httpclient/monix/HttpClientMonixBackend.scala
@@ -104,7 +104,7 @@ object HttpClientMonixBackend {
     Task.eval(
       HttpClientMonixBackend(
         HttpClientBackend.defaultClient(options, Some(s)),
-        closeClient = true,
+        closeClient = false, // we don't want to close Monix's scheduler
         customizeRequest,
         customEncodingHandler
       )(s)

--- a/effects/zio/src/main/scalajvm/sttp/client3/httpclient/zio/HttpClientZioBackend.scala
+++ b/effects/zio/src/main/scalajvm/sttp/client3/httpclient/zio/HttpClientZioBackend.scala
@@ -114,7 +114,7 @@ object HttpClientZioBackend {
       ZIO.attempt(
         HttpClientZioBackend(
           HttpClientBackend.defaultClient(options, Some(executor.asJava)),
-          closeClient = true,
+          closeClient = false, // we don't want to close ZIO's executor
           customizeRequest,
           customEncodingHandler
         )

--- a/effects/zio1/src/main/scalajvm/sttp/client3/httpclient/zio/HttpClientZioBackend.scala
+++ b/effects/zio1/src/main/scalajvm/sttp/client3/httpclient/zio/HttpClientZioBackend.scala
@@ -115,7 +115,7 @@ object HttpClientZioBackend {
       Task.effect(
         HttpClientZioBackend(
           HttpClientBackend.defaultClient(options, Some(executor.asJava)),
-          closeClient = true,
+          closeClient = false, // we don't want to close ZIO's executor
           customizeRequest,
           customEncodingHandler
         )


### PR DESCRIPTION
Closes #1686
