### PR TITLE
Fix response.request accessible from PrometheusBackend

### DIFF
--- a/core/src/main/scalajs/sttp/client3/AbstractFetchBackend.scala
+++ b/core/src/main/scalajs/sttp/client3/AbstractFetchBackend.scala
@@ -266,6 +266,7 @@ abstract class AbstractFetchBackend[F[_], S <: Streams[S], P](
       bodyFromResponseAs
         .apply(request.response, ResponseMetadata(StatusCode.Ok, "", request.headers), Right(webSocket))
         .map(Response.ok)
+        .map(_.copy(request = request.onlyMetadata))
     }
   }
 

--- a/observability/opentelemetry-metrics-backend/src/main/scala/sttp/client3/opentelemetry/OpenTelemetryMetricsBackend.scala
+++ b/observability/opentelemetry-metrics-backend/src/main/scala/sttp/client3/opentelemetry/OpenTelemetryMetricsBackend.scala
@@ -128,7 +128,7 @@ private class OpenTelemetryMetricsListener(
   override def requestException(request: Request[_, _], tag: Option[Long], e: Exception): Unit = {
     HttpError.find(e) match {
       case Some(HttpError(body, statusCode)) =>
-        requestSuccessful(request, Response(body, statusCode), tag)
+        requestSuccessful(request, Response(body, statusCode).copy(request = request.onlyMetadata), tag)
       case _ =>
         incrementCounter(requestToFailureCounterMapper(request, e))
         recordHistogram(requestToLatencyHistogramMapper(request), tag.map(clock.millis() - _))

--- a/observability/prometheus-backend/src/main/scala/sttp/client3/prometheus/PrometheusBackend.scala
+++ b/observability/prometheus-backend/src/main/scala/sttp/client3/prometheus/PrometheusBackend.scala
@@ -185,7 +185,7 @@ class PrometheusListener(
   ): Unit = {
     HttpError.find(e) match {
       case Some(HttpError(body, statusCode)) =>
-        requestSuccessful(request, Response(body, statusCode), requestCollectors)
+        requestSuccessful(request, Response(body, statusCode).copy(request = request.onlyMetadata), requestCollectors)
       case _ =>
         requestCollectors.maybeTimer.foreach(_.observeDuration())
         requestCollectors.maybeGauge.foreach(_.dec())

--- a/observability/prometheus-backend/src/test/scala/sttp/client3/prometheus/PrometheusBackendTest.scala
+++ b/observability/prometheus-backend/src/test/scala/sttp/client3/prometheus/PrometheusBackendTest.scala
@@ -385,6 +385,39 @@ class PrometheusBackendTest
     ) shouldBe None
   }
 
+  it should "report correct host when it is extracted from the response" in {
+    // given
+    val backendStub =
+      SttpBackendStub.synchronous.whenAnyRequest.thenRespondF(_ => throw new HttpError("boom", StatusCode.BadRequest))
+
+    import sttp.client3.prometheus.PrometheusBackend.{DefaultFailureCounterName, addMethodLabel}
+
+    val HostLabel = "Host"
+    def addHostLabel[T <: BaseCollectorConfig](config: T, resp: Response[_]): config.T = {
+      val hostLabel: Option[(String, String)] = {
+        if (config.labels.map(_._1.toLowerCase).contains(HostLabel)) None
+        else Some((HostLabel, resp.request.uri.host.getOrElse("-")))
+      }
+
+      config.addLabels(hostLabel.toList)
+    }
+
+    val backend = PrometheusBackend(
+      backendStub,
+      responseToErrorCounterMapper = (req: Request[_, _], resp: Response[_]) =>
+        Some(addHostLabel(addMethodLabel(CollectorConfig(DefaultFailureCounterName), req), resp))
+    )
+
+    // when
+    assertThrows[HttpError[String]] { backend.send(basicRequest.get(uri"http://127.0.0.1/foo")) }
+
+    // then
+    getMetricValue(
+      PrometheusBackend.DefaultFailureCounterName + "_total",
+      List("method" -> "GET", HostLabel -> "127.0.0.1")
+    ) shouldBe Some(1)
+  }
+
   private[this] def getMetricValue(name: String): Option[lang.Double] =
     Option(CollectorRegistry.defaultRegistry.getSampleValue(name))
 


### PR DESCRIPTION
We had a problem in our codebase that we reported `example.com` to prometheus because we took it from response and not request.

Im not sure if we want to merge it like that. The whole existence of ExampleGet exposed in the `core` looks quite dangerous to me, but I don't feel adventurous enough to try deeper refactor.

