### PR TITLE
http4s: remove blaze dependency

### DIFF
--- a/armeria-backend/zio/src/main/scala/sttp/client3/armeria/zio/ArmeriaZioBackend.scala
+++ b/armeria-backend/zio/src/main/scala/sttp/client3/armeria/zio/ArmeriaZioBackend.scala
@@ -1,6 +1,9 @@
 package sttp.client3.armeria.zio
 
-import _root_.zio.interop.reactivestreams.{publisherToStream => publisherToZioStream, streamToPublisher => zioStreamToPublisher}
+import _root_.zio.interop.reactivestreams.{
+  publisherToStream => publisherToZioStream,
+  streamToPublisher => zioStreamToPublisher
+}
 import _root_.zio.{Chunk, Task, _}
 import com.linecorp.armeria.client.WebClient
 import com.linecorp.armeria.common.HttpData

--- a/armeria-backend/zio1/src/main/scala/sttp/client3/armeria/zio/ArmeriaZioBackend.scala
+++ b/armeria-backend/zio1/src/main/scala/sttp/client3/armeria/zio/ArmeriaZioBackend.scala
@@ -12,7 +12,10 @@ import sttp.monad.MonadAsyncError
 import zio.{Chunk, Task}
 import zio.stream.Stream
 import _root_.zio._
-import _root_.zio.interop.reactivestreams.{publisherToStream => publisherToZioStream, streamToPublisher => zioStreamToPublisher}
+import _root_.zio.interop.reactivestreams.{
+  publisherToStream => publisherToZioStream,
+  streamToPublisher => zioStreamToPublisher
+}
 import sttp.client3.armeria.ArmeriaWebClient.newClient
 
 private final class ArmeriaZioBackend(runtime: Runtime[Any], client: WebClient, closeFactory: Boolean)

--- a/build.sbt
+++ b/build.sbt
@@ -662,7 +662,7 @@ lazy val http4sCe2Backend = (projectMatrix in file("http4s-ce2-backend"))
     name := "http4s-ce2-backend",
     libraryDependencies ++= Seq(
       "org.http4s" %% "http4s-client" % http4s_ce2_version,
-      "org.http4s" %% "http4s-blaze-client" % http4s_ce2_version % Optional
+      "org.http4s" %% "http4s-blaze-client" % http4s_ce2_version % Test
     )
   )
   .jvmPlatform(scalaVersions = scala2alive)
@@ -675,7 +675,7 @@ lazy val http4sBackend = (projectMatrix in file("http4s-backend"))
     name := "http4s-backend",
     libraryDependencies ++= Seq(
       "org.http4s" %% "http4s-client" % http4s_ce3_version,
-      "org.http4s" %% "http4s-blaze-client" % "0.23.13" % Optional
+      "org.http4s" %% "http4s-blaze-client" % "0.23.13" % Test
     ),
     evictionErrorLevel := Level.Info
   )

--- a/docs/backends/http4s.md
+++ b/docs/backends/http4s.md
@@ -8,24 +8,13 @@ This backend is based on [http4s](https://http4s.org) (client) and is **asynchro
 "com.softwaremill.sttp.client3" %% "http4s-ce2-backend" % "@VERSION@" // for cats-effect 2.x & http4s 0.21.x
 ```
 
-The backend can be created in a couple of ways, e.g.:
-
-```scala mdoc:compile-only
-import cats.effect._
-import sttp.capabilities.fs2.Fs2Streams
-import sttp.client3._
-import sttp.client3.http4s._
-
-Http4sBackend.usingDefaultBlazeClientBuilder[IO](): Resource[IO, SttpBackend[IO, Fs2Streams[IO]]]
-```
-
 Sending a request is a non-blocking, lazily-evaluated operation and results in a wrapped response. There's a transitive dependency on `http4s`. 
 
 There are also [other cats-effect-based backends](catseffect.md), which don't depend on http4s. 
 
 Please note that: 
 
-* the backend contains an **optional** dependency on `http4s-blaze-client`, to provide the `Http4sBackend.usingBlazeClientBuilder` and `Http4sBackend.usingDefaultBlazeClientBuilder` methods. This makes the client usable with other http4s client implementations, without the need to depend on blaze.
+* you have to build up your own `Client[F]` by either using _Blaze_, _Ember_ or something else
 * the backend does not support `SttpBackendOptions`, that is specifying proxy settings (proxies are not implemented in http4s, see [this issue](https://github.com/http4s/http4s/issues/251)), as well as configuring the connect timeout 
 * the backend does not support the `RequestT.options.readTimeout` option
 

--- a/http4s-backend/src/test/scala/sttp/client3/http4s/Http4sHttpStreamingTest.scala
+++ b/http4s-backend/src/test/scala/sttp/client3/http4s/Http4sHttpStreamingTest.scala
@@ -10,8 +10,8 @@ import sttp.capabilities.fs2.Fs2Streams
 
 class Http4sHttpStreamingTest extends Fs2StreamingTest {
 
-  private val blazeClientBuilder = BlazeClientBuilder[IO](ExecutionContext.global)
+  private val blazeClientBuilder = BlazeClientBuilder[IO]
   override val backend: SttpBackend[IO, Fs2Streams[IO]] =
-    Http4sBackend.usingBlazeClientBuilder(blazeClientBuilder).allocated.unsafeRunSync()._1
+    blazeClientBuilder.resource.map(c => Http4sBackend.usingClient(c)).allocated.unsafeRunSync()._1
 
 }

--- a/http4s-backend/src/test/scala/sttp/client3/http4s/Http4sHttpTest.scala
+++ b/http4s-backend/src/test/scala/sttp/client3/http4s/Http4sHttpTest.scala
@@ -9,10 +9,10 @@ import sttp.client3.testing.HttpTest
 import scala.concurrent.ExecutionContext
 
 class Http4sHttpTest extends HttpTest[IO] with CatsRetryTest with CatsTestBase {
-  private val blazeClientBuilder = BlazeClientBuilder[IO](ExecutionContext.global)
+  private val blazeClientBuilder = BlazeClientBuilder[IO]
 
   override val backend: SttpBackend[IO, Any] =
-    Http4sBackend.usingBlazeClientBuilder(blazeClientBuilder).allocated.unsafeRunSync()._1
+    blazeClientBuilder.resource.map(c => Http4sBackend.usingClient(c)).allocated.unsafeRunSync()._1
 
   override protected def supportsRequestTimeout = false
   override protected def supportsCustomMultipartContentType = false

--- a/http4s-ce2-backend/src/main/scala/sttp/client3/http4s/Http4sBackend.scala
+++ b/http4s-ce2-backend/src/main/scala/sttp/client3/http4s/Http4sBackend.scala
@@ -11,7 +11,6 @@ import fs2.{Chunk, Stream}
 import org.http4s.{ContentCoding, EntityBody, Status, Request => Http4sRequest}
 import org.http4s
 import org.http4s.client.Client
-import org.http4s.blaze.client.BlazeClientBuilder
 import org.http4s.headers.`Content-Encoding`
 import org.typelevel.ci.CIString
 import sttp.capabilities.fs2.Fs2Streams
@@ -291,28 +290,6 @@ object Http4sBackend {
   ): SttpBackend[F, Fs2Streams[F]] =
     new FollowRedirectsBackend[F, Fs2Streams[F]](
       new Http4sBackend[F](client, blocker, customizeRequest, customEncodingHandler)
-    )
-
-  def usingBlazeClientBuilder[F[_]: ConcurrentEffect: ContextShift](
-      blazeClientBuilder: BlazeClientBuilder[F],
-      blocker: Blocker,
-      customizeRequest: Http4sRequest[F] => Http4sRequest[F] = identity[Http4sRequest[F]] _,
-      customEncodingHandler: EncodingHandler[F] = PartialFunction.empty
-  ): Resource[F, SttpBackend[F, Fs2Streams[F]]] = {
-    blazeClientBuilder.resource.map(c => usingClient(c, blocker, customizeRequest, customEncodingHandler))
-  }
-
-  def usingDefaultBlazeClientBuilder[F[_]: ConcurrentEffect: ContextShift](
-      blocker: Blocker,
-      clientExecutionContext: ExecutionContext = ExecutionContext.global,
-      customizeRequest: Http4sRequest[F] => Http4sRequest[F] = identity[Http4sRequest[F]] _,
-      customEncodingHandler: EncodingHandler[F] = PartialFunction.empty
-  ): Resource[F, SttpBackend[F, Fs2Streams[F]]] =
-    usingBlazeClientBuilder(
-      BlazeClientBuilder[F](clientExecutionContext),
-      blocker,
-      customizeRequest,
-      customEncodingHandler
     )
 
   /** Create a stub backend for testing, which uses the `F` response wrapper, and supports `Stream[F, Byte]` streaming.

--- a/http4s-ce2-backend/src/test/scala/sttp/client3/http4s/Http4sHttpStreamingTest.scala
+++ b/http4s-ce2-backend/src/test/scala/sttp/client3/http4s/Http4sHttpStreamingTest.scala
@@ -12,6 +12,6 @@ class Http4sHttpStreamingTest extends Fs2StreamingTest {
 
   private val blazeClientBuilder = BlazeClientBuilder[IO](ExecutionContext.global)
   override val backend: SttpBackend[IO, Fs2Streams[IO]] =
-    Http4sBackend.usingBlazeClientBuilder(blazeClientBuilder, blocker).allocated.unsafeRunSync()._1
+    blazeClientBuilder.resource.map(c => Http4sBackend.usingClient(c, blocker)).allocated.unsafeRunSync()._1
 
 }

--- a/http4s-ce2-backend/src/test/scala/sttp/client3/http4s/Http4sHttpTest.scala
+++ b/http4s-ce2-backend/src/test/scala/sttp/client3/http4s/Http4sHttpTest.scala
@@ -12,7 +12,7 @@ class Http4sHttpTest extends HttpTest[IO] with CatsTestBase {
   private val blazeClientBuilder = BlazeClientBuilder[IO](ExecutionContext.global)
 
   override val backend: SttpBackend[IO, Any] =
-    Http4sBackend.usingBlazeClientBuilder(blazeClientBuilder, blocker).allocated.unsafeRunSync()._1
+    blazeClientBuilder.resource.map(c => Http4sBackend.usingClient(c, blocker)).allocated.unsafeRunSync()._1
 
   override protected def supportsRequestTimeout = false
   override protected def supportsCustomMultipartContentType = false


### PR DESCRIPTION
I've set the `http4s-blaze-client` to `Test` as the docs now suggest that _Ember_ is the official client. It shouldn't be too hard to build a `Client[F]` your self. Ember uses keyed-pool which in turn will support otel4s which allows you track close connection pool metrics. As well Ember will provide a scala native version for which support can be added later.

I guess this will break MiMA?

Before submitting pull request:
- [x] Check if the project compiles by running `sbt compile`
- [x] Verify docs compilation by running `sbt compileDocs`
- [x] Check if tests pass by running `sbt test`
- [x] Format code by running `sbt scalafmt`
