### PR TITLE
Add native to circe module

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -780,6 +780,7 @@ lazy val circe = (projectMatrix in file("json/circe"))
     settings = commonJvmSettings
   )
   .jsPlatform(scalaVersions = scala2 ++ scala3, settings = commonJsSettings)
+  .nativePlatform(scalaVersions = scala2 ++ scala3, settings = commonNativeSettings)
   .dependsOn(core, jsonCommon)
 
 lazy val jsoniter = (projectMatrix in file("json/jsoniter"))


### PR DESCRIPTION
Adds Scala Native to the Circe module

Before submitting pull request:
- [x] Check if the project compiles by running `sbt compile`
- [x] Verify docs compilation by running `sbt compileDocs`
- [x] Check if tests pass by running `sbt test`
- [x] Format code by running `sbt scalafmt`
