### PR TITLE
Add Scala Native build for jsoniter

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -815,7 +815,7 @@ lazy val jsoniter = (projectMatrix in file("json/jsoniter"))
     scalaTest
   )
   .jvmPlatform(
-    scalaVersions = scala2 ++ scala3,
+    scalaVersions = scala2alive ++ scala3,
     settings = commonJvmSettings
   )
   .jsPlatform(scalaVersions = scala2alive ++ scala3, settings = commonJsSettings)

--- a/build.sbt
+++ b/build.sbt
@@ -124,7 +124,7 @@ val circeVersion: Option[(Long, Long)] => String = {
   case _             => "0.14.1"
 }
 
-val jsoniterVersion = "2.13.3"
+val jsoniterVersion = "2.22.1"
 
 val playJsonVersion: Option[(Long, Long)] => String = {
   case Some((2, 11)) => "2.7.4"
@@ -175,7 +175,7 @@ def dependenciesFor(version: String)(deps: (Option[(Long, Long)] => ModuleID)*):
   deps.map(_.apply(CrossVersion.partialVersion(version)))
 
 lazy val projectsWithOptionalNative: Seq[ProjectReference] = {
-  val base = core.projectRefs ++ jsonCommon.projectRefs ++ upickle.projectRefs
+  val base = core.projectRefs ++ jsonCommon.projectRefs ++ upickle.projectRefs ++ jsoniter.projectRefs
   if (sys.env.isDefinedAt("STTP_NATIVE")) {
     println("[info] STTP_NATIVE defined, including sttp-native in the aggregate projects")
     base
@@ -819,6 +819,7 @@ lazy val jsoniter = (projectMatrix in file("json/jsoniter"))
     settings = commonJvmSettings
   )
   .jsPlatform(scalaVersions = scala2alive ++ scala3, settings = commonJsSettings)
+  .nativePlatform(scalaVersions = scala2alive ++ scala3, settings = commonNativeSettings)
   .dependsOn(core, jsonCommon)
 
 lazy val zioJson = (projectMatrix in file("json/zio-json"))


### PR DESCRIPTION
Resolves #1795 . This PR adds support Scala Native support for the `jsoniter` module. One caveat of this is that `jsoniter-scala` added support for SN in 2.17.4+, and these versions are not published for Scala 2.11. Are we happy to stop publishing Scala 2.11 versions of the jsoniter (JVM) module, or should we use the old version for JVM and the latest for JS / Native?

I'll create a PR to `master` to port these changes to master as well once this one has been approved
