### PR TITLE
Add Scala Native build for circe

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -119,9 +119,8 @@ val testServerSettings = Seq(
   })
 )
 
-val circeVersion: Option[(Long, Long)] => String = {
-  case Some((2, 11)) => "0.11.2"
-  case _             => "0.14.1"
+val circeVersion: Option[(Long, Long)] => String = { _ =>
+  "0.14.5"
 }
 
 val jsoniterVersion = "2.22.1"
@@ -175,7 +174,8 @@ def dependenciesFor(version: String)(deps: (Option[(Long, Long)] => ModuleID)*):
   deps.map(_.apply(CrossVersion.partialVersion(version)))
 
 lazy val projectsWithOptionalNative: Seq[ProjectReference] = {
-  val base = core.projectRefs ++ jsonCommon.projectRefs ++ upickle.projectRefs ++ jsoniter.projectRefs
+  val base =
+    core.projectRefs ++ jsonCommon.projectRefs ++ upickle.projectRefs ++ jsoniter.projectRefs ++ circe.projectRefs
   if (sys.env.isDefinedAt("STTP_NATIVE")) {
     println("[info] STTP_NATIVE defined, including sttp-native in the aggregate projects")
     base
@@ -799,10 +799,11 @@ lazy val circe = (projectMatrix in file("json/circe"))
     }
   )
   .jvmPlatform(
-    scalaVersions = scala2 ++ scala3,
+    scalaVersions = scala2alive ++ scala3,
     settings = commonJvmSettings
   )
   .jsPlatform(scalaVersions = scala2alive ++ scala3, settings = commonJsSettings)
+  .nativePlatform(scalaVersions = scala2alive ++ scala3, settings = commonNativeSettings)
   .dependsOn(core, jsonCommon)
 
 lazy val jsoniter = (projectMatrix in file("json/jsoniter"))


### PR DESCRIPTION
Similar to https://github.com/softwaremill/sttp/pull/1796, this adds scala native support for the circe submodule.
As is the case with jsoniter, there is no circe version that supports both scala native and 2.11, so this drops 2.11 support for the circe module.

Before submitting pull request:
- [x] Check if the project compiles by running `sbt compile`
- [x] Verify docs compilation by running `sbt compileDocs`
- [x] Check if tests pass by running `sbt test` 
  - All the `... should throw UnsupportedOperationException with reason` fails and the scala native tests hangs :sweat_smile: , but they also fail locally for the v3 branch, so hoping it's just my setup
- [x] Format code by running `sbt scalafmt`
