### PR TITLE
Use `-release:11` across for all JVM builds across Scala versions

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -45,6 +45,7 @@ val commonSettings = commonSmlBuildSettings ++ ossPublishSettings ++ Seq(
 )
 
 val commonJvmSettings = commonSettings ++ Seq(
+  scalacOptions += "-release:11",
   Test / testOptions += Tests.Argument("-oD") // add test timings; js build specify other options which conflict
 )
 
@@ -303,12 +304,7 @@ lazy val core = (projectMatrix in file("core"))
     scalaVersions = scala2 ++ scala3,
     settings = commonJvmSettings ++ versioningSchemeSettings ++ /*enableMimaSettings ++*/ List(
       Test / publishArtifact := true, // allow implementations outside of this repo
-      scalacOptions ++= Seq("-J--add-modules", "-Jjava.net.http"),
-      scalacOptions ++= {
-        if (scalaVersion.value == scala2_13 || scalaVersion.value == scala3.head) List("-target:jvm-11")
-        else if (scalaVersion.value == scala2_12) List("-target:jvm-1.8")
-        else Nil
-      }
+      scalacOptions ++= Seq("-J--add-modules", "-Jjava.net.http")
     )
   )
   .jsPlatform(


### PR DESCRIPTION
Followup of discussion on [this PR](https://github.com/softwaremill/sttp/pull/1796#issuecomment-1500779121).

With this PR, the `-release:11` flag is added to all JVM builds for Scala 2.12, 2.13 and 3. Note that I tried to use `-release:8` for Scala 2.12, but the code wouldn't compile because `core` uses Java 11 APIs. More info on making on making the compiler flags consistent across Scala versions [here](https://github.com/lampepfl/dotty/pull/14606)
