### PR TITLE
add 'omitAcceptEncoding' (default is false) parameter to toCurl

### DIFF
--- a/core/src/main/scala/sttp/client4/request.scala
+++ b/core/src/main/scala/sttp/client4/request.scala
@@ -30,6 +30,9 @@ trait GenericRequest[+T, -R] extends RequestBuilder[GenericRequest[T, R]] with R
 
   def toCurl: String = ToCurlConverter(this)
   def toCurl(sensitiveHeaders: Set[String]): String = ToCurlConverter(this, sensitiveHeaders)
+  def toCurl(omitAcceptEncoding: Boolean): String = ToCurlConverter(this, omitAcceptEncoding)
+  def toCurl(sensitiveHeaders: Set[String], omitAcceptEncoding: Boolean): String =
+    ToCurlConverter(this, sensitiveHeaders, omitAcceptEncoding)
 
   def toRfc2616Format: String = ToRfc2616Converter.requestToRfc2616(this)
   def toRfc2616Format(sensitiveHeaders: Set[String]): String =

--- a/core/src/test/scala/sttp/client4/ToCurlConverterTest.scala
+++ b/core/src/test/scala/sttp/client4/ToCurlConverterTest.scala
@@ -14,7 +14,13 @@ class ToCurlConverterTest extends AnyFlatSpec with Matchers with ToCurlConverter
       .get(uri"$localhost")
       .toCurl
 
-    req shouldBe "curl \\\n  --request GET \\\n  --url 'http://localhost' \\\n  --location \\\n  --max-redirs 32"
+    req shouldBe "curl \\\n  --request GET \\\n  --url 'http://localhost' \\\n  --header 'Accept-Encoding: gzip, deflate' \\\n  --location \\\n  --max-redirs 32"
+  }
+
+  it should "hide Accept-Encoding header when asked" in {
+    basicRequest.get(localhost).toCurl(omitAcceptEncoding = true) shouldNot include(
+      """--header 'Accept-Encoding: """
+    )
   }
 
   it should "convert request with method to curl" in {
@@ -42,6 +48,17 @@ class ToCurlConverterTest extends AnyFlatSpec with Matchers with ToCurlConverter
   it should "convert request with custom sensitive header" in {
     basicRequest.header("X-Auth", "xyzabc").get(localhost).toCurl(Set("X-Auth")) should include(
       """--header 'X-Auth: ***'"""
+    )
+  }
+
+  it should "not hide Accept-Encoding header when converting request with custom sensitive header" in {
+    basicRequest.header("X-Auth", "xyzabc").get(localhost).toCurl(Set("X-Auth")) should include(
+      """--header 'Accept-Encoding: """
+    )
+  }
+  it should "hide Accept-Encoding header when asked when converting request with custom sensitive header" in {
+    basicRequest.header("X-Auth", "xyzabc").get(localhost).toCurl(Set("X-Auth"), omitAcceptEncoding = true) shouldNot include(
+      """--header 'Accept-Encoding: """
     )
   }
 

--- a/docs/requests/basics.md
+++ b/docs/requests/basics.md
@@ -67,4 +67,4 @@ For example:
 basicRequest.get(uri"http://httpbin.org/ip").toCurl
 ```
 
-Note that the `Accept-Encoding` header, which is added by default to all requests (`Accept-Encoding: gzip, deflate`) is filtered out from the generated command, so that when running a request from the command line, the result has higher chance of being human-readable, and not compressed.
+Note that the `Accept-Encoding` header, which is added by default to all requests (`Accept-Encoding: gzip, deflate`), can make curl warn that _binary output can mess up your terminal_, when running generated command from the command line. It can be omitted by setting `omitAcceptEncoding = true` when calling `.toCurl` method.


### PR DESCRIPTION
Align behaviour with browsers' as they do not omit this header.

Closes #1807

Before submitting pull request:
- [x] Check if the project compiles by running `sbt compile`
- [x] Verify docs compilation by running `sbt compileDocs`
- [x] Check if tests pass by running `sbt test`
- [x] Format code by running `sbt scalafmt`
