### PR TITLE
Fix multipartFile in JVM SttpExtensions

### DIFF
--- a/core/src/main/scalajvm/sttp/client4/SttpExtensions.scala
+++ b/core/src/main/scalajvm/sttp/client4/SttpExtensions.scala
@@ -27,7 +27,7 @@ trait SttpExtensions {
     *
     * File name will be set to the name of the file.
     */
-  def multipartFile(name: String, data: Path): Part[BasicBody] = multipartSttpFile(name, SttpFile.fromPath(data))
+  def multipartFile(name: String, data: Path): Part[BasicBodyPart] = multipartSttpFile(name, SttpFile.fromPath(data))
 }
 
 object SttpExtensions {


### PR DESCRIPTION
The mutlipart request wants a `Part[BasicBodyPart]`.

Before submitting pull request:
- [ ] Check if the project compiles by running `sbt compile`
- [ ] Verify docs compilation by running `sbt compileDocs`
- [ ] Check if tests pass by running `sbt test`
- [ ] Format code by running `sbt scalafmt`
