### PR TITLE
[fix] Retry flaky test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,11 @@ jobs:
       if: matrix.target-platform == 'JVM'
       run: sbt -v compileDocs
     - name: Test
-      run: sbt -v "testScoped ${{ matrix.scala-version }} ${{ matrix.target-platform }}"
+      uses: nick-fields/retry@v2
+      with:
+        timeout_minutes: 45
+        max_attempts: 3
+        command: sbt -v "testScoped ${{ matrix.scala-version }} ${{ matrix.target-platform }}"
     - name: Prepare release notes
       uses: release-drafter/release-drafter@v5
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,11 +47,7 @@ jobs:
       if: matrix.target-platform == 'JVM'
       run: sbt -v compileDocs
     - name: Test
-      uses: nick-fields/retry@v2
-      with:
-        timeout_minutes: 20
-        max_attempts: 3
-        command: sbt -v "testScoped ${{ matrix.scala-version }} ${{ matrix.target-platform }}"
+      run: sbt -v "testScoped ${{ matrix.scala-version }} ${{ matrix.target-platform }}"        
     - name: Prepare release notes
       uses: release-drafter/release-drafter@v5
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
     - name: Test
       uses: nick-fields/retry@v2
       with:
-        timeout_minutes: 45
+        timeout_minutes: 20
         max_attempts: 3
         command: sbt -v "testScoped ${{ matrix.scala-version }} ${{ matrix.target-platform }}"
     - name: Prepare release notes

--- a/core/src/test/scala/sttp/client4/testing/streaming/StreamingTest.scala
+++ b/core/src/test/scala/sttp/client4/testing/streaming/StreamingTest.scala
@@ -194,7 +194,7 @@ abstract class StreamingTest[F[_], S]
     implicit val monadError: MonadError[Future] = new FutureMonad
 
     def retryImmediatelyOnError[A](action: => Future[A], retriesLeft: Int): Future[A] =
-      action.handleError { error =>
+      action.handleError { case error =>
         new Exception(s"Error in ${getClass.getSimpleName}, retries left = $retriesLeft", error).printStackTrace
         if (retriesLeft > 1)
           retryImmediatelyOnError(action, retriesLeft - 1)

--- a/core/src/test/scala/sttp/client4/testing/streaming/StreamingTest.scala
+++ b/core/src/test/scala/sttp/client4/testing/streaming/StreamingTest.scala
@@ -1,5 +1,6 @@
 package sttp.client4.testing.streaming
 
+import org.scalatest.Assertion
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.freespec.AsyncFreeSpec
 import org.scalatest.matchers.should.Matchers
@@ -10,8 +11,9 @@ import sttp.client4.testing.HttpTest.endpoint
 import sttp.client4.testing.streaming.StreamingTest._
 import sttp.client4.testing.{ConvertToFuture, ToFutureWrapper}
 import sttp.model.sse.ServerSentEvent
-import sttp.monad.MonadError
+import sttp.monad.{FutureMonad, MonadError}
 import sttp.monad.syntax._
+import scala.concurrent.Future
 
 abstract class StreamingTest[F[_], S]
     extends AsyncFreeSpec
@@ -189,6 +191,17 @@ abstract class StreamingTest[F[_], S]
     val numChunks = 100
     val url = uri"https://httpbin.org/stream/$numChunks"
 
+    implicit val monadError: MonadError[Future] = new FutureMonad
+
+    def retryImmediatelyOnError[A](action: => Future[A], retriesLeft: Int): Future[A] =
+      action.handleError { error =>
+        new Exception(s"Error in ${getClass.getSimpleName}, retries left = $retriesLeft", error).printStackTrace
+        if (retriesLeft > 1)
+          retryImmediatelyOnError(action, retriesLeft - 1)
+        else
+          action
+      }
+
     // TODO: for some reason these explicit types are needed in Dotty
     val r0: StreamRequest[streams.BinaryStream, S] = basicRequest
       // of course, you should never rely on the internet being available
@@ -197,7 +210,7 @@ abstract class StreamingTest[F[_], S]
       .get(url)
       .response(asStreamAlwaysUnsafe(streams))
 
-    r0
+    def runTest: Future[Assertion] = r0
       .send(backend)
       .toFuture()
       .flatMap { response =>
@@ -208,6 +221,7 @@ abstract class StreamingTest[F[_], S]
 
         urlRegex.findAllIn(responseBody).length shouldBe numChunks
       }
+    retryImmediatelyOnError(runTest, retriesLeft = 5)
   }
 
   "lift errors due to mapping with impure functions into the response monad" in {


### PR DESCRIPTION
This test occasionally fails, because it connects to httpbin.org

Before submitting pull request:
- [x] Check if the project compiles by running `sbt compile`
- [x] Verify docs compilation by running `sbt compileDocs`
- [x] Check if tests pass by running `sbt test`
- [x] Format code by running `sbt scalafmt`
