### PR TITLE
Header tests in ZIO to proper classes

### DIFF
--- a/armeria-backend/zio/src/test/scala/sttp/client4/armeria/zio/ArmeriaZioHttpTest.scala
+++ b/armeria-backend/zio/src/test/scala/sttp/client4/armeria/zio/ArmeriaZioHttpTest.scala
@@ -3,7 +3,7 @@ package sttp.client4.armeria.zio
 import sttp.client4._
 import sttp.client4.impl.zio.ZioTestBase
 import sttp.client4.testing.{ConvertToFuture, HttpTest}
-import zio.Task
+import zio.{Task, ZIO}
 
 class ArmeriaZioHttpTest extends HttpTest[Task] with ZioTestBase {
 
@@ -14,4 +14,20 @@ class ArmeriaZioHttpTest extends HttpTest[Task] with ZioTestBase {
   override def supportsCancellation = false
   override def supportsAutoDecompressionDisabling = false
   override def supportsDeflateWrapperChecking = false // armeria hangs
+
+  "throw an exception instead of ZIO defect if the header value is invalid" in {
+
+    val r = basicRequest
+      .get(uri"https://example.com")
+      .header("X-Api-Key", " Я ЛЮБЛЮ БОРЩ")
+      .response(asString)
+      .send(backend)
+
+    val resultTask: Task[Any] = r.catchSomeCause {
+      case c if c.defects.nonEmpty => ZIO.fail(new Exception("Defect occurred during the operation"))
+      case _                       => ZIO.succeed("No defects occurred during the operation")
+    }
+
+    resultTask.toFuture().map(_ => succeed)
+  }
 }

--- a/armeria-backend/zio/src/test/scala/sttp/client4/armeria/zio/ArmeriaZioHttpTest.scala
+++ b/armeria-backend/zio/src/test/scala/sttp/client4/armeria/zio/ArmeriaZioHttpTest.scala
@@ -28,6 +28,6 @@ class ArmeriaZioHttpTest extends HttpTest[Task] with ZioTestBase {
       case _                       => ZIO.succeed("No defects occurred during the operation")
     }
 
-    resultTask.toFuture().map(_ => succeed)
+    convertToFuture.toFuture(resultTask).map(_ => succeed)
   }
 }

--- a/armeria-backend/zio1/src/test/scala/sttp/client4/armeria/zio/ArmeriaZioHttpTest.scala
+++ b/armeria-backend/zio1/src/test/scala/sttp/client4/armeria/zio/ArmeriaZioHttpTest.scala
@@ -3,7 +3,7 @@ package sttp.client4.armeria.zio
 import sttp.client4._
 import sttp.client4.impl.zio.ZioTestBase
 import sttp.client4.testing.{ConvertToFuture, HttpTest}
-import zio.Task
+import zio.{Task, ZIO}
 
 class ArmeriaZioHttpTest extends HttpTest[Task] with ZioTestBase {
 
@@ -14,4 +14,20 @@ class ArmeriaZioHttpTest extends HttpTest[Task] with ZioTestBase {
   override def supportsCancellation = false
   override def supportsAutoDecompressionDisabling = false
   override def supportsDeflateWrapperChecking = false // armeria hangs
+
+  "throw an exception instead of ZIO defect if the header value is invalid" in {
+
+    val r = basicRequest
+      .get(uri"https://example.com")
+      .header("X-Api-Key", " Я ЛЮБЛЮ БОРЩ")
+      .response(asString)
+      .send(backend)
+
+    val resultTask: Task[Any] = r.catchSomeCause {
+      case c if c.defects.nonEmpty => ZIO.fail(new Exception("Defect occurred during the operation"))
+      case _                       => ZIO.succeed("No defects occurred during the operation")
+    }
+
+    resultTask.toFuture().map(_ => succeed)
+  }
 }

--- a/armeria-backend/zio1/src/test/scala/sttp/client4/armeria/zio/ArmeriaZioHttpTest.scala
+++ b/armeria-backend/zio1/src/test/scala/sttp/client4/armeria/zio/ArmeriaZioHttpTest.scala
@@ -28,6 +28,6 @@ class ArmeriaZioHttpTest extends HttpTest[Task] with ZioTestBase {
       case _                       => ZIO.succeed("No defects occurred during the operation")
     }
 
-    resultTask.toFuture().map(_ => succeed)
+    convertToFuture.toFuture(resultTask).map(_ => succeed)
   }
 }

--- a/async-http-client-backend/zio/src/test/scala/sttp/client4/asynchttpclient/zio/AsyncHttpClientZioHttpTest.scala
+++ b/async-http-client-backend/zio/src/test/scala/sttp/client4/asynchttpclient/zio/AsyncHttpClientZioHttpTest.scala
@@ -3,7 +3,7 @@ package sttp.client4.asynchttpclient.zio
 import sttp.client4._
 import sttp.client4.impl.zio.ZioTestBase
 import sttp.client4.testing.{ConvertToFuture, HttpTest}
-import zio.Task
+import zio.{Task, ZIO}
 
 class AsyncHttpClientZioHttpTest extends HttpTest[Task] with ZioTestBase {
 
@@ -14,4 +14,19 @@ class AsyncHttpClientZioHttpTest extends HttpTest[Task] with ZioTestBase {
   override def throwsExceptionOnUnsupportedEncoding = false
   override def supportsAutoDecompressionDisabling = false
 
+  "throw an exception instead of ZIO defect if the header value is invalid" in {
+
+    val r = basicRequest
+      .get(uri"https://example.com")
+      .header("X-Api-Key", " Я ЛЮБЛЮ БОРЩ")
+      .response(asString)
+      .send(backend)
+
+    val resultTask: Task[Any] = r.catchSomeCause {
+      case c if c.defects.nonEmpty => ZIO.fail(new Exception("Defect occurred during the operation"))
+      case _                       => ZIO.succeed("No defects occurred during the operation")
+    }
+
+    resultTask.toFuture().map(_ => succeed)
+  }
 }

--- a/async-http-client-backend/zio/src/test/scala/sttp/client4/asynchttpclient/zio/AsyncHttpClientZioHttpTest.scala
+++ b/async-http-client-backend/zio/src/test/scala/sttp/client4/asynchttpclient/zio/AsyncHttpClientZioHttpTest.scala
@@ -27,6 +27,6 @@ class AsyncHttpClientZioHttpTest extends HttpTest[Task] with ZioTestBase {
       case _                       => ZIO.succeed("No defects occurred during the operation")
     }
 
-    resultTask.toFuture().map(_ => succeed)
+    convertToFuture.toFuture(resultTask).map(_ => succeed)
   }
 }

--- a/async-http-client-backend/zio1/src/test/scala/sttp/client4/asynchttpclient/zio/AsyncHttpClientZioHttpTest.scala
+++ b/async-http-client-backend/zio1/src/test/scala/sttp/client4/asynchttpclient/zio/AsyncHttpClientZioHttpTest.scala
@@ -3,7 +3,7 @@ package sttp.client4.asynchttpclient.zio
 import sttp.client4._
 import sttp.client4.impl.zio.ZioTestBase
 import sttp.client4.testing.{ConvertToFuture, HttpTest}
-import zio.Task
+import zio.{Task, ZIO}
 
 class AsyncHttpClientZioHttpTest extends HttpTest[Task] with ZioTestBase {
 
@@ -14,4 +14,19 @@ class AsyncHttpClientZioHttpTest extends HttpTest[Task] with ZioTestBase {
   override def throwsExceptionOnUnsupportedEncoding = false
   override def supportsAutoDecompressionDisabling = false
 
+  "throw an exception instead of ZIO defect if the header value is invalid" in {
+
+    val r = basicRequest
+      .get(uri"https://example.com")
+      .header("X-Api-Key", " Я ЛЮБЛЮ БОРЩ")
+      .response(asString)
+      .send(backend)
+
+    val resultTask: Task[Any] = r.catchSomeCause {
+      case c if c.defects.nonEmpty => ZIO.fail(new Exception("Defect occurred during the operation"))
+      case _                       => ZIO.succeed("No defects occurred during the operation")
+    }
+
+    resultTask.toFuture().map(_ => succeed)
+  }
 }

--- a/async-http-client-backend/zio1/src/test/scala/sttp/client4/asynchttpclient/zio/AsyncHttpClientZioHttpTest.scala
+++ b/async-http-client-backend/zio1/src/test/scala/sttp/client4/asynchttpclient/zio/AsyncHttpClientZioHttpTest.scala
@@ -27,6 +27,6 @@ class AsyncHttpClientZioHttpTest extends HttpTest[Task] with ZioTestBase {
       case _                       => ZIO.succeed("No defects occurred during the operation")
     }
 
-    resultTask.toFuture().map(_ => succeed)
+    convertToFuture.toFuture(resultTask).map(_ => succeed)
   }
 }

--- a/effects/zio/src/test/scalajvm/sttp/client4/httpclient/zio/BackendStubZioTests.scala
+++ b/effects/zio/src/test/scalajvm/sttp/client4/httpclient/zio/BackendStubZioTests.scala
@@ -79,21 +79,4 @@ class BackendStubZioTests extends AnyFlatSpec with Matchers with ScalaFutures wi
       case _                              => fail(s"Should be a failure: $r")
     }
   }
-
-  it should "throw an exception instead of ZIO defect if the header value is invalid" in {
-
-    val backend = for {
-      backend <- HttpClientZioBackend.scoped()
-      _ <- basicRequest
-        .get(uri"https://example.com")
-        .header("X-Api-Key", " Я ЛЮБЛЮ БОРЩ")
-        .response(asString)
-        .send(backend)
-    } yield ()
-
-    backend.catchSomeCause {
-      case c if c.defects.nonEmpty => fail("Defect occurred during the operation")
-      case _                       => ZIO.succeed("No defects occurred during the operation")
-    }
-  }
 }

--- a/effects/zio/src/test/scalajvm/sttp/client4/httpclient/zio/HttpClientZioHttpTest.scala
+++ b/effects/zio/src/test/scalajvm/sttp/client4/httpclient/zio/HttpClientZioHttpTest.scala
@@ -3,7 +3,7 @@ package sttp.client4.httpclient.zio
 import sttp.client4._
 import sttp.client4.impl.zio.ZioTestBase
 import sttp.client4.testing.{ConvertToFuture, HttpTest}
-import zio.Task
+import zio.{Task, ZIO}
 
 class HttpClientZioHttpTest extends HttpTest[Task] with ZioTestBase {
   override val backend: Backend[Task] =
@@ -11,4 +11,20 @@ class HttpClientZioHttpTest extends HttpTest[Task] with ZioTestBase {
   override implicit val convertToFuture: ConvertToFuture[Task] = convertZioTaskToFuture
 
   override def supportsHostHeaderOverride = false
+
+  "throw an exception instead of ZIO defect if the header value is invalid" in {
+
+    val r = basicRequest
+      .get(uri"https://example.com")
+      .header("X-Api-Key", " Я ЛЮБЛЮ БОРЩ")
+      .response(asString)
+      .send(backend)
+
+    val resultTask: Task[Any] = r.catchSomeCause {
+      case c if c.defects.nonEmpty => ZIO.fail(new Exception("Defect occurred during the operation"))
+      case _                       => ZIO.succeed("No defects occurred during the operation")
+    }
+
+    resultTask.toFuture().map(_ => succeed)
+  }
 }

--- a/effects/zio/src/test/scalajvm/sttp/client4/httpclient/zio/HttpClientZioHttpTest.scala
+++ b/effects/zio/src/test/scalajvm/sttp/client4/httpclient/zio/HttpClientZioHttpTest.scala
@@ -25,6 +25,6 @@ class HttpClientZioHttpTest extends HttpTest[Task] with ZioTestBase {
       case _                       => ZIO.succeed("No defects occurred during the operation")
     }
 
-    resultTask.toFuture().map(_ => succeed)
+    convertToFuture.toFuture(resultTask).map(_ => succeed)
   }
 }

--- a/effects/zio1/src/test/scalajvm/sttp/client4/httpclient/zio/HttpClientZioHttpTest.scala
+++ b/effects/zio1/src/test/scalajvm/sttp/client4/httpclient/zio/HttpClientZioHttpTest.scala
@@ -3,7 +3,7 @@ package sttp.client4.httpclient.zio
 import sttp.client4._
 import sttp.client4.impl.zio.ZioTestBase
 import sttp.client4.testing.{ConvertToFuture, HttpTest}
-import zio.Task
+import zio.{Task, ZIO}
 
 class HttpClientZioHttpTest extends HttpTest[Task] with ZioTestBase {
   override val backend: Backend[Task] =
@@ -18,5 +18,21 @@ class HttpClientZioHttpTest extends HttpTest[Task] with ZioTestBase {
       send(request).provideLayer(HttpClientZioBackend.layer())
       succeed
     }
+  }
+
+  "throw an exception instead of ZIO defect if the header value is invalid" in {
+
+    val r = basicRequest
+      .get(uri"https://example.com")
+      .header("X-Api-Key", " Я ЛЮБЛЮ БОРЩ")
+      .response(asString)
+      .send(backend)
+
+    val resultTask: Task[Any] = r.catchSomeCause {
+      case c if c.defects.nonEmpty => ZIO.fail(new Exception("Defect occurred during the operation"))
+      case _                       => ZIO.succeed("No defects occurred during the operation")
+    }
+
+    resultTask.toFuture().map(_ => succeed)
   }
 }

--- a/effects/zio1/src/test/scalajvm/sttp/client4/httpclient/zio/HttpClientZioHttpTest.scala
+++ b/effects/zio1/src/test/scalajvm/sttp/client4/httpclient/zio/HttpClientZioHttpTest.scala
@@ -33,6 +33,6 @@ class HttpClientZioHttpTest extends HttpTest[Task] with ZioTestBase {
       case _                       => ZIO.succeed("No defects occurred during the operation")
     }
 
-    resultTask.toFuture().map(_ => succeed)
+    convertToFuture.toFuture(resultTask).map(_ => succeed)
   }
 }


### PR DESCRIPTION
The goal of PR is to move the header validation test from the BackendStubZioTest to the proper ClientZioHttpTest test classes, including the following:

Armenia backend
Async backend
Effects module.

Before submitting pull request:
- [x] Check if the project compiles by running `sbt compile`
- [x] Verify docs compilation by running `sbt compileDocs`
- [ ] Check if tests pass by running `sbt test`
- [ ] Format code by running `sbt scalafmt`
