### PR TITLE
1853 ignore content encoding header if it is empty

### DIFF
--- a/armeria-backend/cats-ce2/src/test/scala/sttp/client4/armeria/cats/ArmeriaCatsHttpTest.scala
+++ b/armeria-backend/cats-ce2/src/test/scala/sttp/client4/armeria/cats/ArmeriaCatsHttpTest.scala
@@ -20,4 +20,5 @@ class ArmeriaCatsHttpTest extends HttpTest[IO] with CatsTestBase {
   override def supportsCancellation = false
   override def supportsAutoDecompressionDisabling = false
   override def supportsDeflateWrapperChecking = false // armeria hangs
+  override def supportsEmptyContentEncoding = false
 }

--- a/armeria-backend/cats/src/test/scala/sttp/client4/armeria/cats/ArmeriaCatsHttpTest.scala
+++ b/armeria-backend/cats/src/test/scala/sttp/client4/armeria/cats/ArmeriaCatsHttpTest.scala
@@ -20,4 +20,5 @@ class ArmeriaCatsHttpTest extends HttpTest[IO] with CatsRetryTest with CatsTestB
   override def supportsCancellation = false
   override def supportsAutoDecompressionDisabling = false
   override def supportsDeflateWrapperChecking = false // armeria hangs
+  override def supportsEmptyContentEncoding = false
 }

--- a/armeria-backend/fs2-ce2/src/test/scala/sttp/client4/armeria/fs2/ArmeriaFs2HttpTest.scala
+++ b/armeria-backend/fs2-ce2/src/test/scala/sttp/client4/armeria/fs2/ArmeriaFs2HttpTest.scala
@@ -12,4 +12,6 @@ class ArmeriaFs2HttpTest extends HttpTest[IO] with CatsTestBase {
   override def supportsCancellation = false
   override def supportsAutoDecompressionDisabling = false
   override def supportsDeflateWrapperChecking = false // armeria hangs
+
+  override def supportsEmptyContentEncoding = false
 }

--- a/armeria-backend/fs2/src/test/scala/sttp/client4/armeria/fs2/ArmeriaFs2HttpTest.scala
+++ b/armeria-backend/fs2/src/test/scala/sttp/client4/armeria/fs2/ArmeriaFs2HttpTest.scala
@@ -12,4 +12,5 @@ class ArmeriaFs2HttpTest extends HttpTest[IO] with CatsTestBase with TestIODispa
   override def supportsCancellation = false
   override def supportsAutoDecompressionDisabling = false
   override def supportsDeflateWrapperChecking = false // armeria hangs
+  override def supportsEmptyContentEncoding = false
 }

--- a/armeria-backend/monix/src/test/scala/sttp/client4/armeria/monix/ArmeriaMonixHttpTest.scala
+++ b/armeria-backend/monix/src/test/scala/sttp/client4/armeria/monix/ArmeriaMonixHttpTest.scala
@@ -23,4 +23,6 @@ class ArmeriaMonixHttpTest extends HttpTest[Task] {
   override def supportsAutoDecompressionDisabling = false
   override def supportsDeflateWrapperChecking = false // armeria hangs
 
+  override def supportsEmptyContentEncoding = false
+
 }

--- a/armeria-backend/scalaz/src/test/scala/sttp/client4/armeria/scalaz/ArmeriaScalazHttpTest.scala
+++ b/armeria-backend/scalaz/src/test/scala/sttp/client4/armeria/scalaz/ArmeriaScalazHttpTest.scala
@@ -14,6 +14,7 @@ class ArmeriaScalazHttpTest extends HttpTest[Task] {
   override def supportsCancellation = false
   override def supportsAutoDecompressionDisabling = false
   override def supportsDeflateWrapperChecking = false // armeria hangs
+  override def supportsEmptyContentEncoding = false
 
   override def timeoutToNone[T](t: Task[T], timeoutMillis: Int): Task[Option[T]] = t.map(Some(_))
 }

--- a/armeria-backend/src/test/scala/sttp/client4/armeria/future/ArmeriaFutureHttpTest.scala
+++ b/armeria-backend/src/test/scala/sttp/client4/armeria/future/ArmeriaFutureHttpTest.scala
@@ -14,6 +14,7 @@ class ArmeriaFutureHttpTest extends HttpTest[Future] {
   override def supportsCancellation = false
   override def supportsAutoDecompressionDisabling = false
   override def supportsDeflateWrapperChecking = false // armeria hangs
+  override def supportsEmptyContentEncoding = false
 
   override def timeoutToNone[T](t: Future[T], timeoutMillis: Int): Future[Option[T]] = t.map(Some(_))
 }

--- a/armeria-backend/zio/src/test/scala/sttp/client4/armeria/zio/ArmeriaZioHttpTest.scala
+++ b/armeria-backend/zio/src/test/scala/sttp/client4/armeria/zio/ArmeriaZioHttpTest.scala
@@ -14,4 +14,6 @@ class ArmeriaZioHttpTest extends HttpTest[Task] with ZioTestBase {
   override def supportsCancellation = false
   override def supportsAutoDecompressionDisabling = false
   override def supportsDeflateWrapperChecking = false // armeria hangs
+
+  override def supportsEmptyContentEncoding = false
 }

--- a/armeria-backend/zio1/src/test/scala/sttp/client4/armeria/zio/ArmeriaZioHttpTest.scala
+++ b/armeria-backend/zio1/src/test/scala/sttp/client4/armeria/zio/ArmeriaZioHttpTest.scala
@@ -14,4 +14,5 @@ class ArmeriaZioHttpTest extends HttpTest[Task] with ZioTestBase {
   override def supportsCancellation = false
   override def supportsAutoDecompressionDisabling = false
   override def supportsDeflateWrapperChecking = false // armeria hangs
+  override def supportsEmptyContentEncoding = false
 }

--- a/core/src/main/scalajvm/sttp/client4/httpclient/HttpClientBackend.scala
+++ b/core/src/main/scalajvm/sttp/client4/httpclient/HttpClientBackend.scala
@@ -92,7 +92,7 @@ abstract class HttpClientBackend[F[_], S, P, B](
       resBody.left
         .map { is =>
           encoding
-            .filterNot(_ => code.equals(StatusCode.NoContent) || request.autoDecompressionDisabled)
+            .filterNot(e => code.equals(StatusCode.NoContent) || request.autoDecompressionDisabled || e.isEmpty)
             .map(e => customEncodingHandler.applyOrElse((is, e), standardEncoding.tupled))
             .getOrElse(is)
         }

--- a/core/src/main/scalajvm/sttp/client4/httpurlconnection/HttpURLConnectionBackend.scala
+++ b/core/src/main/scalajvm/sttp/client4/httpurlconnection/HttpURLConnectionBackend.scala
@@ -246,7 +246,7 @@ class HttpURLConnectionBackend private (
     val headers = c.getHeaderFields.asScala.toVector
       .filter(_._1 != null)
       .flatMap { case (k, vv) => vv.asScala.map(Header(k, _)) }
-    val contentEncoding = Option(c.getHeaderField(HeaderNames.ContentEncoding))
+    val contentEncoding = Option(c.getHeaderField(HeaderNames.ContentEncoding)).filter(_.nonEmpty)
 
     val code = StatusCode(c.getResponseCode)
     val wrappedIs =

--- a/core/src/test/scala/sttp/client4/testing/HttpTest.scala
+++ b/core/src/test/scala/sttp/client4/testing/HttpTest.scala
@@ -57,6 +57,7 @@ trait HttpTest[F[_]]
   protected def supportsCancellation = true
   protected def supportsAutoDecompressionDisabling = true
   protected def supportsDeflateWrapperChecking = true
+  protected def supportsEmptyContentEncoding = false
 
   "request parsing" - {
     "Inf timeout should not throw exception" in {

--- a/okhttp-backend/src/main/scala/sttp/client4/okhttp/OkHttpBackend.scala
+++ b/okhttp-backend/src/main/scala/sttp/client4/okhttp/OkHttpBackend.scala
@@ -88,6 +88,7 @@ abstract class OkHttpBackend[F[_], S <: Streams[S], P](
           .equals(StatusCode.NoContent.code) && !request.autoDecompressionDisabled
       ) {
         encoding
+          .filterNot(_.isEmpty)
           .map(e =>
             customEncodingHandler // There is no PartialFunction.fromFunction in scala 2.12
               .orElse(EncodingHandler(standardEncoding))(res.body().byteStream() -> e)

--- a/testing/server/src/main/scala/sttp/client4/testing/server/HttpServer.scala
+++ b/testing/server/src/main/scala/sttp/client4/testing/server/HttpServer.scala
@@ -488,6 +488,12 @@ private class HttpServer(port: Int, info: String => Unit) extends AutoCloseable 
             )
           }
         }
+    } ~ path("empty_content_encoding") {
+      get {
+        respondWithHeader(RawHeader("Content-Encoding", "")) {
+          complete("OK")
+        }
+      }
     }
 
   def discardEntity(inner: Route): Route =


### PR DESCRIPTION
Before submitting pull request:
- [x] Check if the project compiles by running `sbt compile`
- [x] Verify docs compilation by running `sbt compileDocs`
- [x] Check if tests pass by running `sbt test`
- [x] Format code by running `sbt scalafmt`
