### PR TITLE
add generic type to FetchCatsBackend stub method

### DIFF
--- a/effects/cats-ce2/src/main/scalajs/sttp/client3/impl/cats/FetchCatsBackend.scala
+++ b/effects/cats-ce2/src/main/scalajs/sttp/client3/impl/cats/FetchCatsBackend.scala
@@ -48,5 +48,5 @@ object FetchCatsBackend {
     *
     * See [[SttpBackendStub]] for details on how to configure stub responses.
     */
-  def stub[F[_]: Concurrent: ContextShift]: SttpBackendStub[F, Any] = SttpBackendStub(new CatsMonadAsyncError)
+  def stub[F[_]: Concurrent: ContextShift, P]: SttpBackendStub[F, P] = SttpBackendStub(new CatsMonadAsyncError)
 }

--- a/effects/cats-ce2/src/main/scalajs/sttp/client3/impl/cats/FetchCatsBackend.scala
+++ b/effects/cats-ce2/src/main/scalajs/sttp/client3/impl/cats/FetchCatsBackend.scala
@@ -48,5 +48,5 @@ object FetchCatsBackend {
     *
     * See [[SttpBackendStub]] for details on how to configure stub responses.
     */
-  def stub[F[_]: Concurrent: ContextShift, P]: SttpBackendStub[F, P] = SttpBackendStub(new CatsMonadAsyncError)
+  def stub[F[_]: Concurrent: ContextShift]: SttpBackendStub[F, WebSockets] = SttpBackendStub(new CatsMonadAsyncError)
 }

--- a/effects/cats/src/main/scalajs/sttp/client3/impl/cats/FetchCatsBackend.scala
+++ b/effects/cats/src/main/scalajs/sttp/client3/impl/cats/FetchCatsBackend.scala
@@ -48,5 +48,5 @@ object FetchCatsBackend {
     *
     * See [[SttpBackendStub]] for details on how to configure stub responses.
     */
-  def stub[F[_]: Async, P]: SttpBackendStub[F, P] = SttpBackendStub(new CatsMonadAsyncError)
+  def stub[F[_]: Async, P]: SttpBackendStub[F, WebSockets] = SttpBackendStub(new CatsMonadAsyncError)
 }

--- a/effects/cats/src/main/scalajs/sttp/client3/impl/cats/FetchCatsBackend.scala
+++ b/effects/cats/src/main/scalajs/sttp/client3/impl/cats/FetchCatsBackend.scala
@@ -48,5 +48,5 @@ object FetchCatsBackend {
     *
     * See [[SttpBackendStub]] for details on how to configure stub responses.
     */
-  def stub[F[_]: Async, P]: SttpBackendStub[F, WebSockets] = SttpBackendStub(new CatsMonadAsyncError)
+  def stub[F[_]: Async]: SttpBackendStub[F, WebSockets] = SttpBackendStub(new CatsMonadAsyncError)
 }

--- a/effects/cats/src/main/scalajs/sttp/client3/impl/cats/FetchCatsBackend.scala
+++ b/effects/cats/src/main/scalajs/sttp/client3/impl/cats/FetchCatsBackend.scala
@@ -48,5 +48,5 @@ object FetchCatsBackend {
     *
     * See [[SttpBackendStub]] for details on how to configure stub responses.
     */
-  def stub[F[_]: Async]: SttpBackendStub[F, Any] = SttpBackendStub(new CatsMonadAsyncError)
+  def stub[F[_]: Async, P]: SttpBackendStub[F, P] = SttpBackendStub(new CatsMonadAsyncError)
 }


### PR DESCRIPTION
Before submitting pull request:
- [x] Check if the project compiles by running `sbt compile`
- [x] Verify docs compilation by running `sbt compileDocs`
- [x] Check if tests pass by running `sbt test`
- [x] Format code by running `sbt scalafmt`

This PR adds a generic type to stub method in FetchCatsBackend companion object. 
Reasoning for this change is, when you have `SttpBackend` defined as a dependency like this

```scala
 val catsBackend: SttpBackend[IO, capabilities.WebSockets] = FetchCatsBackend[IO]()
```

it is not possible to mock it using this code

```scala
val stubedBackend: SttpBackendStub[IO, Any] = FetchCatsBackend.stub[IO]
```

adding a type resolves this issue 😃 

```scala
val stubedBackend: SttpBackendStub[IO, WebSockets] = FetchCatsBackend.stub[IO, WebSockets]
```



