### PR TITLE
1853 Ignore content encoding header if it is empty

### DIFF
--- a/core/src/test/scala/sttp/client4/testing/HttpTest.scala
+++ b/core/src/test/scala/sttp/client4/testing/HttpTest.scala
@@ -57,7 +57,7 @@ trait HttpTest[F[_]]
   protected def supportsCancellation = true
   protected def supportsAutoDecompressionDisabling = true
   protected def supportsDeflateWrapperChecking = true
-  protected def supportsEmptyContentEncoding = false
+  protected def supportsEmptyContentEncoding = true
 
   "request parsing" - {
     "Inf timeout should not throw exception" in {

--- a/core/src/test/scala/sttp/client4/testing/HttpTest.scala
+++ b/core/src/test/scala/sttp/client4/testing/HttpTest.scala
@@ -322,6 +322,16 @@ trait HttpTest[F[_]]
           }
       }
     }
+
+    if (supportsEmptyContentEncoding) {
+      "a request process correctly" in {
+        val req = basicRequest
+          .get(uri"$endpoint/empty_content_encoding")
+          .response(asString)
+
+        Future(req.send(backend)).flatMap(_.toFuture()).map(_.code shouldBe StatusCode.Ok)
+      }
+    }
   }
 
   "errors" - {


### PR DESCRIPTION
[Issue: 1853](https://github.com/softwaremill/sttp/issues/1853)
[PR: 1879](https://github.com/softwaremill/sttp/pull/1879)
[PR: 1855](https://github.com/softwaremill/sttp/pull/1855)
