### PR TITLE
Upgraded circe to 0.14.6

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -120,7 +120,7 @@ val testServerSettings = Seq(
 )
 
 val circeVersion: Option[(Long, Long)] => String = { _ =>
-  "0.14.5"
+  "0.14.6"
 }
 
 val jsoniterVersion = "2.22.1"

--- a/pekko-http-backend/src/main/scala/sttp/client3/pekkohttp/PekkoHttpBackend.scala
+++ b/pekko-http-backend/src/main/scala/sttp/client3/pekkohttp/PekkoHttpBackend.scala
@@ -46,9 +46,9 @@ class PekkoHttpBackend private (
     .withUpdatedConnectionSettings(_.withConnectingTimeout(opts.connectionTimeout))
 
   override def send[T, R >: PE](r: Request[T, R]): Future[Response[T]] =
-  adjustExceptions(r) {
-    if (r.isWebSocket) sendWebSocket(r) else sendRegular(r)
-  }
+    adjustExceptions(r) {
+      if (r.isWebSocket) sendWebSocket(r) else sendRegular(r)
+    }
 
   private def sendRegular[T, R >: PE](r: Request[T, R]): Future[Response[T]] =
     Future


### PR DESCRIPTION
Upgrading the circe versions to the latest version 0.14.6. This addresses issue #1994

Minor formatting change by `sbt scalafmt` for a file I did not change.

I could not get the `sbt test` command to run without running out of memory. Tests seemed to be passing before running out of memory. The command `sbt rootJVM/test` mentioned in the readme also ran out of memory. 

Before submitting pull request:
- [X] Check if the project compiles by running `sbt compile`
- [X] Verify docs compilation by running `sbt compileDocs`
- [ ] Check if tests pass by running `sbt test`
- [X] Format code by running `sbt scalafmt`
