### PR TITLE
Add Windows support to the Curl backend

### DIFF
--- a/core/src/main/scalanative/sttp/client4/curl/internal/CCurl.scala
+++ b/core/src/main/scalanative/sttp/client4/curl/internal/CCurl.scala
@@ -3,6 +3,7 @@ package sttp.client4.curl.internal
 import sttp.client4.curl.internal.CurlCode.CurlCode
 
 import scala.scalanative.unsafe._
+import scala.scalanative.meta.LinktimeInfo.isWindows
 
 private[curl] trait Curl {}
 
@@ -10,9 +11,20 @@ private[curl] trait Mime {}
 
 private[curl] trait MimePart {}
 
-@link("curl")
+private[curl] object libcurlPlatformCompat {
+  @extern @link("libcurl") @link("crypt32")
+  private object libcurlWin64 extends CCurl
+
+  @extern @link("curl")
+  private object libcurlDefault extends CCurl
+
+  val instance: CCurl =
+    if (isWindows) libcurlWin64
+    else libcurlDefault
+}
+
 @extern
-private[curl] object CCurl {
+private[curl] trait CCurl {
   @name("curl_easy_init")
   def init: Ptr[Curl] = extern
 

--- a/core/src/main/scalanative/sttp/client4/curl/internal/package.scala
+++ b/core/src/main/scalanative/sttp/client4/curl/internal/package.scala
@@ -6,4 +6,6 @@ package object internal {
   type CurlSlist = CStruct2[CString, Ptr[_]]
   type CurlFetch = CStruct2[CString, CSize]
   val CurlZeroTerminated = -1L
+
+  private[curl] final val CCurl = libcurlPlatformCompat.instance
 }


### PR DESCRIPTION
Before submitting pull request:
- [x] Check if the project compiles by running `sbt compile`
- [x] Verify docs compilation by running `sbt compileDocs`
- [ ] Check if tests pass by running `sbt test` (I had some issues with some tests, so I'll wait for the CI, but I did check that this worked locally on Windows with sn-vcpkg)
- [x] Format code by running `sbt scalafmt`

On Windows, curl needs to be linked as `libcurl` instead of `curl`. On top of that, it requires `crypt32`.

I'm using a strategy similar to what Scala Native 0.5.0 uses to handle a similar problem with ZLib. See:

https://github.com/scala-native/scala-native/blob/12d57c527d241f6a1781ec9457492cdd6cc4a904/javalib/src/main/scala/scala/scalanative/ffi/zlib.scala#L8-L19

https://github.com/scala-native/scala-native/blob/main/javalib/src/main/scala/scala/scalanative/ffi/package.scala#L7

I was only able to test this on Windows, so please check if nothing is broken in Linux/MacOS.