### PR TITLE
Make AbstractCurlBackend async friendly

### DIFF
--- a/core/src/main/scalanative/sttp/client4/curl/AbstractCurlBackend.scala
+++ b/core/src/main/scalanative/sttp/client4/curl/AbstractCurlBackend.scala
@@ -59,7 +59,9 @@ abstract class AbstractCurlBackend[F[_]](_monad: MonadError[F], verbose: Boolean
   }
 
   private object Context {
-    def apply[T](body: Context => F[T]): F[T] = {
+
+    /** Create a new context and evaluates the body with it. Closes the context at the end. */
+    def evaluateUsing[T](body: Context => F[T]): F[T] = {
       implicit val ctx = new Context()
       body(ctx).ensure(monad.unit(ctx.close()))
     }
@@ -97,7 +99,7 @@ abstract class AbstractCurlBackend[F[_]](_monad: MonadError[F], verbose: Boolean
         }
       }
 
-      Context(ctx => perform(ctx))
+      Context.evaluateUsing(ctx => perform(ctx))
     }
 
   private def adjustExceptions[T](request: GenericRequest[_, _])(t: => F[T]): F[T] =

--- a/core/src/main/scalanative/sttp/client4/curl/AbstractCurlBackend.scala
+++ b/core/src/main/scalanative/sttp/client4/curl/AbstractCurlBackend.scala
@@ -29,7 +29,7 @@ abstract class AbstractCurlBackend[F[_]](_monad: MonadError[F], verbose: Boolean
   protected def performCurl(c: CurlHandle): F[CurlCode]
 
   /** Same as [[performCurl]], but also checks and throws runtime exceptions on bad [[CurlCode]]s. */
-  final def perform(c: CurlHandle) = performCurl(c).flatMap(lift)
+  private final def perform(c: CurlHandle) = performCurl(c).flatMap(lift)
 
   type R = Any with Effect[F]
 

--- a/core/src/main/scalanative/sttp/client4/curl/CurlBackends.scala
+++ b/core/src/main/scalanative/sttp/client4/curl/CurlBackends.scala
@@ -9,13 +9,13 @@ import scala.util.Try
 
 // Curl supports redirects, but it doesn't store the history, so using FollowRedirectsBackend is more convenient
 
-private class CurlBackend(verbose: Boolean) extends AbstractCurlBackend(IdMonad, verbose) with SyncBackend {}
+private class CurlBackend(verbose: Boolean) extends AbstractSyncCurlBackend(IdMonad, verbose) with SyncBackend {}
 
 object CurlBackend {
   def apply(verbose: Boolean = false): SyncBackend = FollowRedirectsBackend(new CurlBackend(verbose))
 }
 
-private class CurlTryBackend(verbose: Boolean) extends AbstractCurlBackend(TryMonad, verbose) with Backend[Try] {}
+private class CurlTryBackend(verbose: Boolean) extends AbstractSyncCurlBackend(TryMonad, verbose) with Backend[Try] {}
 
 object CurlTryBackend {
   def apply(verbose: Boolean = false): Backend[Try] = FollowRedirectsBackend(new CurlTryBackend(verbose))


### PR DESCRIPTION
Just some structural changes to make implementing an async Curl backend (e.g. with `curl_multi_*`) possible as
a subclass of `AbstractCurlBackend`.
Mainly:
- Make header lists per-request.
- Allow a customizable `CurlHandle -> F[CurlCode]` method, `performCurl`. This can be done with `curl_multi_*`
  instead of just `curl_easy_perform`. Also seems to be the only thing needed to be changed.

We might have to change `curl.option` calls as well, if we want to properly handle them as monadic calls.

Before submitting pull request:
- [x] Check if the project compiles by running `sbt compile`
- [x] Verify docs compilation by running `sbt compileDocs`
- [ ] Check if tests pass by running `sbt test`
- [x] Format code by running `sbt scalafmt`

