### PR TITLE
[v3] Update Armeria to 1.26.4

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -726,7 +726,7 @@ lazy val armeriaBackend = (projectMatrix in file("armeria-backend"))
   .settings(testServerSettings)
   .settings(
     name := "armeria-backend",
-    libraryDependencies += "com.linecorp.armeria" % "armeria" % "1.22.1"
+    libraryDependencies += "com.linecorp.armeria" % "armeria" % "1.26.4"
   )
   .jvmPlatform(scalaVersions = scala2alive ++ scala3)
   .dependsOn(core % compileAndTest)


### PR DESCRIPTION
 Caused by security vulnerability:  https://security.snyk.io/vuln/SNYK-JAVA-COMLINECORPARMERIA-5805287
