### PR TITLE
Fix Scala-js fetch manual abort v3

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -940,7 +940,7 @@ lazy val play2Json = (projectMatrix in file("json/play2-json"))
     settings = commonJvmSettings
   )
   .jsPlatform(scalaVersions = scala2alive, settings = commonJsSettings)
-  .dependsOn(core, jsonCommon)  
+  .dependsOn(core, jsonCommon)
 
 lazy val playJson = (projectMatrix in file("json/play-json"))
   .settings(

--- a/core/src/main/scalajs/sttp/client3/FetchBackend.scala
+++ b/core/src/main/scalajs/sttp/client3/FetchBackend.scala
@@ -16,8 +16,12 @@ class FetchBackend private (fetchOptions: FetchOptions, customizeRequest: FetchR
 
   override val streams: NoStreams = NoStreams
 
-  override protected def addCancelTimeoutHook[T](result: Future[T], cancel: () => Unit): Future[T] = {
-    result.onComplete(_ => cancel())
+  override protected def addCancelTimeoutHook[T](
+      result: Future[T],
+      cancel: () => Unit,
+      cleanup: () => Unit
+  ): Future[T] = {
+    result.onComplete(_ => cleanup())
     result
   }
 

--- a/core/src/test/scala/sttp/client3/testing/streaming/StreamingTest.scala
+++ b/core/src/test/scala/sttp/client3/testing/streaming/StreamingTest.scala
@@ -1,6 +1,6 @@
 package sttp.client3.testing.streaming
 
-import org.scalatest.{ Assertion, BeforeAndAfterAll }
+import org.scalatest.{Assertion, BeforeAndAfterAll}
 import org.scalatest.freespec.AsyncFreeSpec
 import org.scalatest.matchers.should.Matchers
 import sttp.capabilities.Streams
@@ -10,7 +10,7 @@ import sttp.client3.testing.HttpTest.endpoint
 import sttp.client3.testing.streaming.StreamingTest._
 import sttp.client3.testing.{ConvertToFuture, ToFutureWrapper}
 import sttp.model.sse.ServerSentEvent
-import sttp.monad.{ FutureMonad, MonadError }
+import sttp.monad.{FutureMonad, MonadError}
 import sttp.monad.syntax._
 import scala.concurrent.Future
 
@@ -191,9 +191,8 @@ abstract class StreamingTest[F[_], S]
     val url = uri"https://httpbin.org/stream/$numChunks"
 
     implicit val monadError: MonadError[Future] = new FutureMonad
-        def retryImmediatelyOnError[A](action: => Future[A], retriesLeft: Int): Future[A] =
+    def retryImmediatelyOnError[A](action: => Future[A], retriesLeft: Int): Future[A] =
       action.handleError { case error =>
-        
         new Exception(s"Error in ${getClass.getSimpleName}, retries left = $retriesLeft", error).printStackTrace
         if (retriesLeft > 1)
           retryImmediatelyOnError(action, retriesLeft - 1)

--- a/effects/cats/src/main/scalajs/sttp/client3/impl/cats/FetchCatsBackend.scala
+++ b/effects/cats/src/main/scalajs/sttp/client3/impl/cats/FetchCatsBackend.scala
@@ -19,9 +19,10 @@ class FetchCatsBackend[F[_]: Async] private (
 
   override val streams: NoStreams = NoStreams
 
-  override protected def addCancelTimeoutHook[T](result: F[T], cancel: () => Unit): F[T] = {
+  override protected def addCancelTimeoutHook[T](result: F[T], cancel: () => Unit, cleanup: () => Unit): F[T] = {
     val doCancel = Async[F].delay(cancel())
-    result.guarantee(doCancel)
+    val doCleanup = Async[F].delay(cleanup())
+    result.onCancel(doCancel).guarantee(doCleanup)
   }
 
   override protected def handleStreamBody(s: Nothing): F[js.UndefOr[BodyInit]] = s

--- a/effects/monix/src/main/scalajs/sttp/client3/impl/monix/FetchMonixBackend.scala
+++ b/effects/monix/src/main/scalajs/sttp/client3/impl/monix/FetchMonixBackend.scala
@@ -32,9 +32,10 @@ class FetchMonixBackend private (fetchOptions: FetchOptions, customizeRequest: F
 
   override val streams: MonixStreams = MonixStreams
 
-  override protected def addCancelTimeoutHook[T](result: Task[T], cancel: () => Unit): Task[T] = {
+  override protected def addCancelTimeoutHook[T](result: Task[T], cancel: () => Unit, cleanup: () => Unit): Task[T] = {
     val doCancel = Task.delay(cancel())
-    result.doOnCancel(doCancel).doOnFinish(_ => doCancel)
+    val doCleanup = Task.delay(cleanup())
+    result.doOnCancel(doCancel).doOnFinish(_ => doCleanup)
   }
 
   override protected def handleStreamBody(s: Observable[Array[Byte]]): Task[js.UndefOr[BodyInit]] = {

--- a/effects/zio/src/main/scalajs/sttp/client3/impl/zio/FetchZioBackend.scala
+++ b/effects/zio/src/main/scalajs/sttp/client3/impl/zio/FetchZioBackend.scala
@@ -35,9 +35,10 @@ class FetchZioBackend private (fetchOptions: FetchOptions, customizeRequest: Fet
 
   override val streams: ZioStreams = ZioStreams
 
-  override protected def addCancelTimeoutHook[T](result: Task[T], cancel: () => Unit): Task[T] = {
-    val doCancel = ZIO.attempt(cancel())
-    result.onInterrupt(doCancel.catchAll(_ => ZIO.unit)).tap(_ => doCancel)
+  override protected def addCancelTimeoutHook[T](result: Task[T], cancel: () => Unit, cleanup: () => Unit): Task[T] = {
+    val doCancel = ZIO.attempt(cancel()).ignore
+    val doCleanup = ZIO.attempt(cleanup()).ignore
+    result.onInterrupt(doCancel).onExit(_ => doCleanup)
   }
 
   override protected def handleStreamBody(s: Observable[Byte]): Task[js.UndefOr[BodyInit]] = {

--- a/effects/zio1/src/main/scalajs/sttp/client3/impl/zio/FetchZioBackend.scala
+++ b/effects/zio1/src/main/scalajs/sttp/client3/impl/zio/FetchZioBackend.scala
@@ -35,9 +35,10 @@ class FetchZioBackend private (fetchOptions: FetchOptions, customizeRequest: Fet
 
   override val streams: ZioStreams = ZioStreams
 
-  override protected def addCancelTimeoutHook[T](result: Task[T], cancel: () => Unit): Task[T] = {
-    val doCancel = ZIO.effect(cancel())
-    result.onInterrupt(doCancel.catchAll(_ => ZIO.unit)).tap(_ => doCancel)
+  override protected def addCancelTimeoutHook[T](result: Task[T], cancel: () => Unit, cleanup: () => Unit): Task[T] = {
+    val doCancel = ZIO.effect(cancel()).ignore
+    val doCleanup = ZIO.effect(cleanup()).ignore
+    result.onInterrupt(doCancel).onExit(_ => doCleanup)
   }
 
   override protected def handleStreamBody(s: Observable[Byte]): Task[js.UndefOr[BodyInit]] = {


### PR DESCRIPTION
This PR implements cancellation of fetch-request when effects are interrupted. 
I tested it manually with a local project. I was unsure on how to adjust/add a unit test to validate the behaviour.

Before submitting pull request:
- [x] Check if the project compiles by running `sbt compile`
- [x] Verify docs compilation by running `sbt compileDocs`
- [ ] Check if tests pass by running `sbt test` --> could not run the tests because I don't have the required browser
- [x] Format code by running `sbt scalafmt`