### PR TITLE
Fix native on ARM (Macs)

### DIFF
--- a/core/src/main/resources/scala-native/ffi.c
+++ b/core/src/main/resources/scala-native/ffi.c
@@ -1,7 +1,9 @@
-#include <curl/curl.h>
+#if defined(STTP_CURL_FFI)
+#include <curl/curl.h> 
 
 int sttp_curl_setopt_int(CURL *curl, CURLoption opt, int arg) {return curl_easy_setopt(curl, opt, arg); }
 int sttp_curl_setopt_long(CURL *curl, CURLoption opt, long arg) {return curl_easy_setopt(curl, opt, arg); }
 int sttp_curl_setopt_pointer(CURL *curl, CURLoption opt, void* arg) {return curl_easy_setopt(curl, opt, arg); }
 
 int sttp_curl_getinfo_pointer(CURL *curl, CURLINFO info, void* arg) {return curl_easy_getinfo(curl, info, arg); }
+#endif

--- a/core/src/main/resources/scala-native/ffi.c
+++ b/core/src/main/resources/scala-native/ffi.c
@@ -1,0 +1,7 @@
+#include <curl/curl.h>
+
+int sttp_curl_setopt_int(CURL *curl, CURLoption opt, int arg) {return curl_easy_setopt(curl, opt, arg); }
+int sttp_curl_setopt_long(CURL *curl, CURLoption opt, long arg) {return curl_easy_setopt(curl, opt, arg); }
+int sttp_curl_setopt_pointer(CURL *curl, CURLoption opt, void* arg) {return curl_easy_setopt(curl, opt, arg); }
+
+int sttp_curl_getinfo_pointer(CURL *curl, CURLINFO info, void* arg) {return curl_easy_getinfo(curl, info, arg); }

--- a/core/src/main/scalanative/sttp/client4/curl/internal/CCurl.scala
+++ b/core/src/main/scalanative/sttp/client4/curl/internal/CCurl.scala
@@ -25,23 +25,29 @@ private[curl] object libcurlPlatformCompat {
 
 @extern
 private[curl] trait CCurl {
+  @name("sttp_curl_setopt_int")
+  def setoptInt(handle: Ptr[Curl], option: CInt, parameter: Int): CInt = extern
+
+  @name("sttp_curl_setopt_long")
+  def setoptLong(handle: Ptr[Curl], option: CInt, parameter: Long): CInt = extern
+
+  @name("sttp_curl_setopt_pointer")
+  def setoptPtr(handle: Ptr[Curl], option: CInt, parameter: Ptr[_]): CInt = extern
+
+
+  @name("sttp_curl_getinfo_pointer")
+  def getInfo(handle: Ptr[Curl], info: CInt, parameter: Ptr[_]): CInt = extern
+
+
   @name("curl_easy_init")
   def init: Ptr[Curl] = extern
 
   @name("curl_easy_cleanup")
   def cleanup(handle: Ptr[Curl]): Unit = extern
 
-  @name("curl_easy_setopt")
-  def setopt(handle: Ptr[Curl], option: CInt, parameter: Ptr[_]): CInt = extern
-
-  @name("curl_easy_setopt")
-  def setopt(handle: Ptr[Curl], option: CInt, parameter: CVarArgList): CInt = extern
-
   @name("curl_easy_perform")
   def perform(easy_handle: Ptr[Curl]): CInt = extern
 
-  @name("curl_easy_getinfo")
-  def getInfo(handle: Ptr[Curl], info: CInt, parameter: Ptr[_]): CInt = extern
 
   @name("curl_mime_init")
   def mimeInit(easy: Ptr[Curl]): Ptr[Mime] = extern

--- a/core/src/main/scalanative/sttp/client4/curl/internal/CCurl.scala
+++ b/core/src/main/scalanative/sttp/client4/curl/internal/CCurl.scala
@@ -12,10 +12,10 @@ private[curl] trait Mime {}
 private[curl] trait MimePart {}
 
 private[curl] object libcurlPlatformCompat {
-  @extern @link("libcurl") @link("crypt32")
+  @extern @link("libcurl") @link("crypt32") @define("STTP_CURL_FFI")
   private object libcurlWin64 extends CCurl
 
-  @extern @link("curl")
+  @extern @link("curl") @define("STTP_CURL_FFI")
   private object libcurlDefault extends CCurl
 
   val instance: CCurl =
@@ -34,10 +34,8 @@ private[curl] trait CCurl {
   @name("sttp_curl_setopt_pointer")
   def setoptPtr(handle: Ptr[Curl], option: CInt, parameter: Ptr[_]): CInt = extern
 
-
   @name("sttp_curl_getinfo_pointer")
   def getInfo(handle: Ptr[Curl], info: CInt, parameter: Ptr[_]): CInt = extern
-
 
   @name("curl_easy_init")
   def init: Ptr[Curl] = extern
@@ -47,7 +45,6 @@ private[curl] trait CCurl {
 
   @name("curl_easy_perform")
   def perform(easy_handle: Ptr[Curl]): CInt = extern
-
 
   @name("curl_mime_init")
   def mimeInit(easy: Ptr[Curl]): Ptr[Mime] = extern

--- a/core/src/main/scalanative/sttp/client4/curl/internal/CurlApi.scala
+++ b/core/src/main/scalanative/sttp/client4/curl/internal/CurlApi.scala
@@ -7,6 +7,7 @@ import sttp.client4.curl.internal.CurlOption.CurlOption
 import scala.scalanative.runtime.Boxes
 import scala.scalanative.unsafe.{Ptr, _}
 import scala.scalanative.unsigned._
+import java.nio.charset.StandardCharsets
 
 private[client4] object CurlApi {
   type CurlHandle = Ptr[Curl]
@@ -22,27 +23,28 @@ private[client4] object CurlApi {
   implicit class CurlHandleOps(handle: CurlHandle) {
     def mime: MimeHandle = CCurl.mimeInit(handle)
 
-    def perform: CurlCode = CurlCode(CCurl.perform(handle))
+    def perform: CurlCode = 
+      CurlCode(CCurl.perform(handle))
 
     def cleanup(): Unit = CCurl.cleanup(handle)
 
     def option(option: CurlOption, parameter: String)(implicit z: Zone): CurlCode =
-      setopt(handle, option, toCString(parameter))
+      CurlCode(CCurl.setoptPtr(handle, option.id, toCString(parameter, StandardCharsets.UTF_8)))
 
     def option(option: CurlOption, parameter: Long)(implicit z: Zone): CurlCode =
-      setopt(handle, option, parameter)
+      CurlCode(CCurl.setoptLong(handle, option.id, parameter))
 
     def option(option: CurlOption, parameter: Int)(implicit z: Zone): CurlCode =
-      setopt(handle, option, parameter)
+      CurlCode(CCurl.setoptInt(handle, option.id, parameter))
 
     def option(option: CurlOption, parameter: Boolean)(implicit z: Zone): CurlCode =
-      setopt(handle, option, if (parameter) 1L else 0L)
+      CurlCode(CCurl.setoptInt(handle, option.id, if (parameter) 1 else 0))
 
     def option(option: CurlOption, parameter: Ptr[_]): CurlCode =
-      setopt(handle, option, parameter)
+      CurlCode(CCurl.setoptPtr(handle, option.id, parameter))
 
     def option[FuncPtr <: CFuncPtr](option: CurlOption, parameter: FuncPtr)(implicit z: Zone): CurlCode =
-      setopt(handle, option, Boxes.boxToPtr[Byte](Boxes.unboxToCFuncPtr0(parameter)))
+      CurlCode(CCurl.setoptPtr(handle, option.id, Boxes.boxToPtr[Byte](Boxes.unboxToCFuncPtr0(parameter))))
 
     def info(curlInfo: CurlInfo, parameter: Long)(implicit z: Zone): CurlCode = {
       val lPtr = alloc[Long](sizeof[Long])
@@ -51,17 +53,11 @@ private[client4] object CurlApi {
     }
 
     def info(curlInfo: CurlInfo, parameter: String)(implicit z: Zone): CurlCode =
-      getInfo(handle, curlInfo, toCString(parameter))
+      getInfo(handle, curlInfo, toCString(parameter, StandardCharsets.UTF_8))
 
     def info(curlInfo: CurlInfo, parameter: Ptr[_]): CurlCode =
       getInfo(handle, curlInfo, parameter)
-  }
-
-  private def setopt(handle: CurlHandle, option: CurlOption, parameter: Ptr[_]): CurlCode =
-    CurlCode(CCurl.setopt(handle, option.id, parameter))
-
-  private def setopt(handle: CurlHandle, option: CurlOption, parameter: CVarArg)(implicit z: Zone): CurlCode =
-    CurlCode(CCurl.setopt(handle, option.id, toCVarArgList(Seq(parameter))))
+  }    
 
   private def getInfo(handle: CurlHandle, curlInfo: CurlInfo, parameter: Ptr[_]): CurlCode =
     CurlCode(CCurl.getInfo(handle, curlInfo.id, parameter))

--- a/core/src/main/scalanative/sttp/client4/curl/internal/CurlApi.scala
+++ b/core/src/main/scalanative/sttp/client4/curl/internal/CurlApi.scala
@@ -4,7 +4,6 @@ import sttp.client4.curl.internal.CurlCode.CurlCode
 import sttp.client4.curl.internal.CurlInfo.CurlInfo
 import sttp.client4.curl.internal.CurlOption.CurlOption
 
-import scala.scalanative.runtime.Boxes
 import scala.scalanative.unsafe.{Ptr, _}
 import scala.scalanative.unsigned._
 import java.nio.charset.StandardCharsets
@@ -23,28 +22,28 @@ private[client4] object CurlApi {
   implicit class CurlHandleOps(handle: CurlHandle) {
     def mime: MimeHandle = CCurl.mimeInit(handle)
 
-    def perform: CurlCode = 
+    def perform: CurlCode =
       CurlCode(CCurl.perform(handle))
 
     def cleanup(): Unit = CCurl.cleanup(handle)
 
     def option(option: CurlOption, parameter: String)(implicit z: Zone): CurlCode =
-      CurlCode(CCurl.setoptPtr(handle, option.id, toCString(parameter, StandardCharsets.UTF_8)))
+      this.option(option, toCString(parameter, StandardCharsets.UTF_8))
 
-    def option(option: CurlOption, parameter: Long)(implicit z: Zone): CurlCode =
+    def option(option: CurlOption, parameter: Long): CurlCode =
       CurlCode(CCurl.setoptLong(handle, option.id, parameter))
 
-    def option(option: CurlOption, parameter: Int)(implicit z: Zone): CurlCode =
+    def option(option: CurlOption, parameter: Int): CurlCode =
       CurlCode(CCurl.setoptInt(handle, option.id, parameter))
 
-    def option(option: CurlOption, parameter: Boolean)(implicit z: Zone): CurlCode =
-      CurlCode(CCurl.setoptInt(handle, option.id, if (parameter) 1 else 0))
+    def option(option: CurlOption, parameter: Boolean): CurlCode =
+      this.option(option, if (parameter) 1 else 0)
 
     def option(option: CurlOption, parameter: Ptr[_]): CurlCode =
       CurlCode(CCurl.setoptPtr(handle, option.id, parameter))
 
-    def option[FuncPtr <: CFuncPtr](option: CurlOption, parameter: FuncPtr)(implicit z: Zone): CurlCode =
-      CurlCode(CCurl.setoptPtr(handle, option.id, Boxes.boxToPtr[Byte](Boxes.unboxToCFuncPtr0(parameter))))
+    def option(option: CurlOption, parameter: CFuncPtr): CurlCode =
+      this.option(option, CFuncPtr.toPtr(parameter))
 
     def info(curlInfo: CurlInfo, parameter: Long)(implicit z: Zone): CurlCode = {
       val lPtr = alloc[Long](sizeof[Long])
@@ -57,7 +56,7 @@ private[client4] object CurlApi {
 
     def info(curlInfo: CurlInfo, parameter: Ptr[_]): CurlCode =
       getInfo(handle, curlInfo, parameter)
-  }    
+  }
 
   private def getInfo(handle: CurlHandle, curlInfo: CurlInfo, parameter: Ptr[_]): CurlCode =
     CurlCode(CCurl.getInfo(handle, curlInfo.id, parameter))

--- a/core/src/test/scalanative/sttp/client4/testing/SyncHttpTest.scala
+++ b/core/src/test/scalanative/sttp/client4/testing/SyncHttpTest.scala
@@ -388,7 +388,8 @@ trait SyncHttpTest
         .get(uri"$endpoint/timeout")
         .readTimeout(200.milliseconds)
         .response(asString)
-      req.send(backend)
+      val caught = intercept[RuntimeException] { req.send(backend) }
+      caught.getMessage should include("TIMEDOUT")
     }
 
     "not fail if read timeout is big enough" in {


### PR DESCRIPTION
Fix #1668

Something was going wrong with the way libcurl exposes API functions with varargs, and how scala native was calling them on ARM Macs. So I added an interface in between. (thanks @WojciechMazur)