### PR TITLE
Improve proxy authentication preventing NPE and allow Basic Authentication

### DIFF
--- a/core/src/main/scalajvm/sttp/client3/HttpClientAsyncBackend.scala
+++ b/core/src/main/scalajvm/sttp/client3/HttpClientAsyncBackend.scala
@@ -54,7 +54,12 @@ abstract class HttpClientAsyncBackend[F[_], S, P, BH, B](
 
         val consumer = toJavaBiConsumer((t: HttpResponse[BH], u: Throwable) => {
           if (t != null) {
-            try success(readResponse(t, Left(bodyHandlerBodyToBody(t.body())), request))
+            // sometimes body returned by HttpClient can be null, we handle this by returning empty body to prevent NPE
+            val body = Option(t.body())
+              .map(bodyHandlerBodyToBody)
+              .getOrElse(emptyBody())
+
+            try success(readResponse(t, Left(body), request))
             catch {
               case e: Exception => error(e)
             }

--- a/core/src/main/scalajvm/sttp/client3/HttpClientBackend.scala
+++ b/core/src/main/scalajvm/sttp/client3/HttpClientBackend.scala
@@ -16,7 +16,7 @@ import java.net.{Authenticator, PasswordAuthentication}
 import java.time.{Duration => JDuration}
 import java.util.concurrent.{Executor, ThreadPoolExecutor}
 import java.util.function
-import scala.jdk.CollectionConverters._
+import scala.collection.JavaConverters._
 
 /** @param closeClient
   *   If the executor underlying the client is a [[ThreadPoolExecutor]], should it be shutdown on [[close]].

--- a/core/src/main/scalajvm/sttp/client3/HttpClientBackend.scala
+++ b/core/src/main/scalajvm/sttp/client3/HttpClientBackend.scala
@@ -10,12 +10,13 @@ import sttp.monad.MonadError
 import sttp.monad.syntax._
 import sttp.ws.WebSocket
 
+import java.net.Authenticator.RequestorType
 import java.net.http.{HttpClient, HttpRequest, HttpResponse}
 import java.net.{Authenticator, PasswordAuthentication}
 import java.time.{Duration => JDuration}
 import java.util.concurrent.{Executor, ThreadPoolExecutor}
 import java.util.function
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 
 /** @param closeClient
   *   If the executor underlying the client is a [[ThreadPoolExecutor]], should it be shutdown on [[close]].
@@ -123,10 +124,12 @@ abstract class HttpClientBackend[F[_], S, P, B](
 object HttpClientBackend {
 
   type EncodingHandler[B] = PartialFunction[(B, String), B]
-  // TODO not sure if it works
+
   private class ProxyAuthenticator(auth: SttpBackendOptions.ProxyAuth) extends Authenticator {
     override def getPasswordAuthentication: PasswordAuthentication = {
-      new PasswordAuthentication(auth.username, auth.password.toCharArray)
+      if (getRequestorType == RequestorType.PROXY) {
+        new PasswordAuthentication(auth.username, auth.password.toCharArray)
+      } else null
     }
   }
 

--- a/docs/conf/proxy.md
+++ b/docs/conf/proxy.md
@@ -31,6 +31,17 @@ import sttp.client3._
 SttpBackendOptions.httpProxy("some.host", 8080, "username", "password")
 ```
 
+If your backend implements `HttpClientBackend` and your proxy server requires Basic authentication, you will need to enable it by setting
+the `jdk.http.auth.tunneling.disabledSchemes` system property to an empty string (`""`). This can be done by
+calling `System.setProperty("jdk.http.auth.tunneling.disabledSchemes", "")` before creating the backend.
+
+```scala mdoc:compile-only 
+System.setProperty("jdk.http.auth.tunneling.disabledSchemes", "")
+```
+
+Please be aware that enabling Basic authentication for HTTP tunneling can expose your credentials to interception, so it
+should only be done if you understand the risks and your network is secure.
+
 ## Ignoring and allowing specific hosts
 
 There are two additional settings that can be provided to via `SttpBackendOptions`:

--- a/docs/conf/proxy.md
+++ b/docs/conf/proxy.md
@@ -31,7 +31,7 @@ import sttp.client3._
 SttpBackendOptions.httpProxy("some.host", 8080, "username", "password")
 ```
 
-If your backend implements `HttpClientBackend` and your proxy server requires Basic authentication, you will need to enable it by 
+if you use a HttpClient-based backend (e.g. `HttpClientBackend`) and your proxy server requires Basic authentication, you will need to enable it by 
 removing Basic from the `jdk.http.auth.tunneling.disabledSchemes` networking property, or by setting a system property of the same name to "".
 
 ```scala mdoc:compile-only 

--- a/docs/conf/proxy.md
+++ b/docs/conf/proxy.md
@@ -31,16 +31,15 @@ import sttp.client3._
 SttpBackendOptions.httpProxy("some.host", 8080, "username", "password")
 ```
 
-If your backend implements `HttpClientBackend` and your proxy server requires Basic authentication, you will need to enable it by setting
-the `jdk.http.auth.tunneling.disabledSchemes` system property to an empty string (`""`). This can be done by
-calling `System.setProperty("jdk.http.auth.tunneling.disabledSchemes", "")` before creating the backend.
+If your backend implements `HttpClientBackend` and your proxy server requires Basic authentication, you will need to enable it by 
+removing Basic from the `jdk.http.auth.tunneling.disabledSchemes` networking property, or by setting a system property of the same name to "".
 
 ```scala mdoc:compile-only 
 System.setProperty("jdk.http.auth.tunneling.disabledSchemes", "")
 ```
 
 Please be aware that enabling Basic authentication for HTTP tunneling can expose your credentials to interception, so it
-should only be done if you understand the risks and your network is secure.
+should only be done if you understand the risks and your network is secure. This behaviour is described in https://www.oracle.com/java/technologies/javase/8u111-relnotes.html.
 
 ## Ignoring and allowing specific hosts
 


### PR DESCRIPTION
This PR addresses the problem described in https://github.com/softwaremill/sttp/issues/2050, where requests sent by `HttpClientBackend` to a proxy requiring Basic authentication were failing due to [JDK's default settings](https://www.oracle.com/java/technologies/javase/8u111-relnotes.html), resulting in a 407 response and a null body, leading to errors. By removing `Basic` from `jdk.http.auth.tunneling.disabledSchemes`, we now allow `HttpClient` to use proxy authentication successfully. This behaviour has been documented to guide users on enabling Basic authentication for HTTP tunneling and inform them about security flaws.

Additionally, to avoid NPE from null response bodies, we return empty stream.



