### PR TITLE
feat: adding full logging options to log settings

### DIFF
--- a/core/src/main/scala/sttp/client4/requestBuilder.scala
+++ b/core/src/main/scala/sttp/client4/requestBuilder.scala
@@ -309,6 +309,11 @@ trait PartialRequestBuilder[+PR <: PartialRequestBuilder[PR, R], +R]
     this.tag(loggingOptionsTagKey, loggingOptions)
   }
 
+  def logSettings(
+      loggingOptions: Option[LoggingOptions]
+  ): PR =
+    this.tag(loggingOptionsTagKey, loggingOptions)
+
   def loggingOptions: Option[LoggingOptions] = tag(loggingOptionsTagKey).asInstanceOf[Option[LoggingOptions]]
 
   def show(


### PR DESCRIPTION
## Description

There are use cases (e.g. when building a library on top of sttp) where it is useful to pass all logging options as a single parameter to the end user to specify. This PR adds a `.logSettings` method that takes an `Option[LoggingOptions]` parameter, instead of the individual logging options parameters (e.g. `logRequestBody`, etc.).

Before submitting pull request:
- [x] Check if the project compiles by running `sbt compile`
- [x] Verify docs compilation by running `sbt compileDocs`
- [x] Check if tests pass by running `sbt test`
- [x] Format code by running `sbt scalafmt`
