### PR TITLE
[forward-port] All backends write headers as UTF-8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,11 +15,6 @@ jobs:
       matrix:
         scala-version: [ "2.12", "2.13", "3" ]
         target-platform: [ "JVM", "JS", "Native" ]
-        exclude:
-          - scala-version: "2.11"
-            target-platform: "JS"
-          - scala-version: "2.11"
-            target-platform: "Native"
     steps:
     - name: Checkout
       uses: actions/checkout@v2

--- a/async-http-client-backend/cats-ce2/src/test/scala/sttp/client4/asynchttpclient/cats/AsyncHttpClientCatsHttpTest.scala
+++ b/async-http-client-backend/cats-ce2/src/test/scala/sttp/client4/asynchttpclient/cats/AsyncHttpClientCatsHttpTest.scala
@@ -15,6 +15,4 @@ class AsyncHttpClientCatsHttpTest extends AsyncHttpClientHttpTest[IO] with CatsT
       }
     }
   }
-
-  override def supportsResponseAsInputStream = false
 }

--- a/async-http-client-backend/cats-ce2/src/test/scala/sttp/client4/asynchttpclient/cats/AsyncHttpClientCatsHttpTest.scala
+++ b/async-http-client-backend/cats-ce2/src/test/scala/sttp/client4/asynchttpclient/cats/AsyncHttpClientCatsHttpTest.scala
@@ -5,7 +5,7 @@ import sttp.client4._
 import sttp.client4.impl.cats.CatsTestBase
 import sttp.client4.testing.HttpTest
 
-class AsyncHttpClientCatsHttpTest extends HttpTest[IO] with CatsTestBase {
+class AsyncHttpClientCatsHttpTest extends AsyncHttpClientHttpTest[IO] with CatsTestBase {
   override val backend: Backend[IO] = AsyncHttpClientCatsBackend[IO]().unsafeRunSync()
 
   "illegal url exceptions" - {

--- a/async-http-client-backend/cats-ce2/src/test/scala/sttp/client4/asynchttpclient/cats/AsyncHttpClientCatsHttpTest.scala
+++ b/async-http-client-backend/cats-ce2/src/test/scala/sttp/client4/asynchttpclient/cats/AsyncHttpClientCatsHttpTest.scala
@@ -2,8 +2,8 @@ package sttp.client4.asynchttpclient.cats
 
 import cats.effect.IO
 import sttp.client4._
+import sttp.client4.asynchttpclient.AsyncHttpClientHttpTest
 import sttp.client4.impl.cats.CatsTestBase
-import sttp.client4.testing.HttpTest
 
 class AsyncHttpClientCatsHttpTest extends AsyncHttpClientHttpTest[IO] with CatsTestBase {
   override val backend: Backend[IO] = AsyncHttpClientCatsBackend[IO]().unsafeRunSync()
@@ -16,7 +16,5 @@ class AsyncHttpClientCatsHttpTest extends AsyncHttpClientHttpTest[IO] with CatsT
     }
   }
 
-  override def throwsExceptionOnUnsupportedEncoding = false
-  override def supportsAutoDecompressionDisabling = false
   override def supportsResponseAsInputStream = false
 }

--- a/async-http-client-backend/cats/src/test/scala/sttp/client4/asynchttpclient/cats/AsyncHttpClientCatsHttpTest.scala
+++ b/async-http-client-backend/cats/src/test/scala/sttp/client4/asynchttpclient/cats/AsyncHttpClientCatsHttpTest.scala
@@ -15,6 +15,4 @@ class AsyncHttpClientCatsHttpTest extends AsyncHttpClientHttpTest[IO] with CatsR
       }
     }
   }
-
-  override def supportsResponseAsInputStream = false
 }

--- a/async-http-client-backend/cats/src/test/scala/sttp/client4/asynchttpclient/cats/AsyncHttpClientCatsHttpTest.scala
+++ b/async-http-client-backend/cats/src/test/scala/sttp/client4/asynchttpclient/cats/AsyncHttpClientCatsHttpTest.scala
@@ -2,8 +2,8 @@ package sttp.client4.asynchttpclient.cats
 
 import cats.effect.IO
 import sttp.client4._
+import sttp.client4.asynchttpclient.AsyncHttpClientHttpTest
 import sttp.client4.impl.cats.{CatsRetryTest, CatsTestBase}
-import sttp.client4.testing.HttpTest
 
 class AsyncHttpClientCatsHttpTest extends AsyncHttpClientHttpTest[IO] with CatsRetryTest with CatsTestBase {
   override val backend: Backend[IO] = AsyncHttpClientCatsBackend[IO]().unsafeRunSync()
@@ -16,7 +16,5 @@ class AsyncHttpClientCatsHttpTest extends AsyncHttpClientHttpTest[IO] with CatsR
     }
   }
 
-  override def throwsExceptionOnUnsupportedEncoding = false
-  override def supportsAutoDecompressionDisabling = false
   override def supportsResponseAsInputStream = false
 }

--- a/async-http-client-backend/cats/src/test/scala/sttp/client4/asynchttpclient/cats/AsyncHttpClientCatsHttpTest.scala
+++ b/async-http-client-backend/cats/src/test/scala/sttp/client4/asynchttpclient/cats/AsyncHttpClientCatsHttpTest.scala
@@ -5,7 +5,7 @@ import sttp.client4._
 import sttp.client4.impl.cats.{CatsRetryTest, CatsTestBase}
 import sttp.client4.testing.HttpTest
 
-class AsyncHttpClientCatsHttpTest extends HttpTest[IO] with CatsRetryTest with CatsTestBase {
+class AsyncHttpClientCatsHttpTest extends AsyncHttpClientHttpTest[IO] with CatsRetryTest with CatsTestBase {
   override val backend: Backend[IO] = AsyncHttpClientCatsBackend[IO]().unsafeRunSync()
 
   "illegal url exceptions" - {

--- a/async-http-client-backend/fs2-ce2/src/test/scala/sttp/client4/asynchttpclient/fs2/AsyncHttpClientFs2HttpTest.scala
+++ b/async-http-client-backend/fs2-ce2/src/test/scala/sttp/client4/asynchttpclient/fs2/AsyncHttpClientFs2HttpTest.scala
@@ -7,7 +7,7 @@ import sttp.client4.testing.HttpTest
 
 import scala.concurrent.ExecutionContext.global
 
-class AsyncHttpClientFs2HttpTest extends HttpTest[IO] with CatsTestBase {
+class AsyncHttpClientFs2HttpTest extends AsyncHttpClientHttpTest[IO] with CatsTestBase {
   override val backend: Backend[IO] =
     AsyncHttpClientFs2Backend[IO](Blocker.liftExecutionContext(global)).unsafeRunSync()
 

--- a/async-http-client-backend/fs2-ce2/src/test/scala/sttp/client4/asynchttpclient/fs2/AsyncHttpClientFs2HttpTest.scala
+++ b/async-http-client-backend/fs2-ce2/src/test/scala/sttp/client4/asynchttpclient/fs2/AsyncHttpClientFs2HttpTest.scala
@@ -2,8 +2,8 @@ package sttp.client4.asynchttpclient.fs2
 
 import cats.effect.{Blocker, IO}
 import sttp.client4.Backend
+import sttp.client4.asynchttpclient.AsyncHttpClientHttpTest
 import sttp.client4.impl.cats.CatsTestBase
-import sttp.client4.testing.HttpTest
 
 import scala.concurrent.ExecutionContext.global
 
@@ -11,7 +11,5 @@ class AsyncHttpClientFs2HttpTest extends AsyncHttpClientHttpTest[IO] with CatsTe
   override val backend: Backend[IO] =
     AsyncHttpClientFs2Backend[IO](Blocker.liftExecutionContext(global)).unsafeRunSync()
 
-  override def throwsExceptionOnUnsupportedEncoding = false
-  override def supportsAutoDecompressionDisabling = false
   override def supportsResponseAsInputStream = false
 }

--- a/async-http-client-backend/fs2-ce2/src/test/scala/sttp/client4/asynchttpclient/fs2/AsyncHttpClientFs2HttpTest.scala
+++ b/async-http-client-backend/fs2-ce2/src/test/scala/sttp/client4/asynchttpclient/fs2/AsyncHttpClientFs2HttpTest.scala
@@ -10,6 +10,4 @@ import scala.concurrent.ExecutionContext.global
 class AsyncHttpClientFs2HttpTest extends AsyncHttpClientHttpTest[IO] with CatsTestBase {
   override val backend: Backend[IO] =
     AsyncHttpClientFs2Backend[IO](Blocker.liftExecutionContext(global)).unsafeRunSync()
-
-  override def supportsResponseAsInputStream = false
 }

--- a/async-http-client-backend/fs2/src/test/scala/sttp/client4/asynchttpclient/fs2/AsyncHttpClientFs2HttpTest.scala
+++ b/async-http-client-backend/fs2/src/test/scala/sttp/client4/asynchttpclient/fs2/AsyncHttpClientFs2HttpTest.scala
@@ -11,5 +11,4 @@ class AsyncHttpClientFs2HttpTest extends AsyncHttpClientHttpTest[IO] with TestIO
 
   // for some unknown reason this single test fails using the fs2 implementation
   override def supportsConnectionRefusedTest = false
-  override def supportsResponseAsInputStream = false
 }

--- a/async-http-client-backend/fs2/src/test/scala/sttp/client4/asynchttpclient/fs2/AsyncHttpClientFs2HttpTest.scala
+++ b/async-http-client-backend/fs2/src/test/scala/sttp/client4/asynchttpclient/fs2/AsyncHttpClientFs2HttpTest.scala
@@ -2,16 +2,14 @@ package sttp.client4.asynchttpclient.fs2
 
 import cats.effect.IO
 import sttp.client4.Backend
+import sttp.client4.asynchttpclient.AsyncHttpClientHttpTest
 import sttp.client4.impl.cats.{CatsTestBase, TestIODispatcher}
-import sttp.client4.testing.HttpTest
 
 class AsyncHttpClientFs2HttpTest extends AsyncHttpClientHttpTest[IO] with TestIODispatcher with CatsTestBase {
   override val backend: Backend[IO] =
     AsyncHttpClientFs2Backend[IO](dispatcher = dispatcher).unsafeRunSync()
 
-  override def throwsExceptionOnUnsupportedEncoding = false
   // for some unknown reason this single test fails using the fs2 implementation
   override def supportsConnectionRefusedTest = false
-  override def supportsAutoDecompressionDisabling = false
   override def supportsResponseAsInputStream = false
 }

--- a/async-http-client-backend/fs2/src/test/scala/sttp/client4/asynchttpclient/fs2/AsyncHttpClientFs2HttpTest.scala
+++ b/async-http-client-backend/fs2/src/test/scala/sttp/client4/asynchttpclient/fs2/AsyncHttpClientFs2HttpTest.scala
@@ -5,7 +5,7 @@ import sttp.client4.Backend
 import sttp.client4.impl.cats.{CatsTestBase, TestIODispatcher}
 import sttp.client4.testing.HttpTest
 
-class AsyncHttpClientFs2HttpTest extends HttpTest[IO] with TestIODispatcher with CatsTestBase {
+class AsyncHttpClientFs2HttpTest extends AsyncHttpClientHttpTest[IO] with TestIODispatcher with CatsTestBase {
   override val backend: Backend[IO] =
     AsyncHttpClientFs2Backend[IO](dispatcher = dispatcher).unsafeRunSync()
 

--- a/async-http-client-backend/future/src/test/scala/sttp/client4/asynchttpclient/future/AsyncHttpClientFutureHttpTest.scala
+++ b/async-http-client-backend/future/src/test/scala/sttp/client4/asynchttpclient/future/AsyncHttpClientFutureHttpTest.scala
@@ -13,5 +13,4 @@ class AsyncHttpClientFutureHttpTest extends AsyncHttpClientHttpTest[Future] {
 
   override def supportsCancellation: Boolean = false
   override def timeoutToNone[T](t: Future[T], timeoutMillis: Int): Future[Option[T]] = t.map(Some(_))
-  override def supportsResponseAsInputStream = false
 }

--- a/async-http-client-backend/future/src/test/scala/sttp/client4/asynchttpclient/future/AsyncHttpClientFutureHttpTest.scala
+++ b/async-http-client-backend/future/src/test/scala/sttp/client4/asynchttpclient/future/AsyncHttpClientFutureHttpTest.scala
@@ -2,7 +2,7 @@ package sttp.client4.asynchttpclient.future
 
 import sttp.client4.Backend
 import sttp.client4.asynchttpclient.AsyncHttpClientHttpTest
-import sttp.client4.testing.{ConvertToFuture, HttpTest}
+import sttp.client4.testing.ConvertToFuture
 
 import scala.concurrent.Future
 
@@ -11,10 +11,7 @@ class AsyncHttpClientFutureHttpTest extends AsyncHttpClientHttpTest[Future] {
   override val backend: Backend[Future] = AsyncHttpClientFutureBackend()
   override implicit val convertToFuture: ConvertToFuture[Future] = ConvertToFuture.future
 
-  override def throwsExceptionOnUnsupportedEncoding = false
-
   override def supportsCancellation: Boolean = false
   override def timeoutToNone[T](t: Future[T], timeoutMillis: Int): Future[Option[T]] = t.map(Some(_))
-  override def supportsAutoDecompressionDisabling = false
   override def supportsResponseAsInputStream = false
 }

--- a/async-http-client-backend/future/src/test/scala/sttp/client4/asynchttpclient/future/AsyncHttpClientFutureHttpTest.scala
+++ b/async-http-client-backend/future/src/test/scala/sttp/client4/asynchttpclient/future/AsyncHttpClientFutureHttpTest.scala
@@ -1,11 +1,12 @@
 package sttp.client4.asynchttpclient.future
 
 import sttp.client4.Backend
+import sttp.client4.asynchttpclient.AsyncHttpClientHttpTest
 import sttp.client4.testing.{ConvertToFuture, HttpTest}
 
 import scala.concurrent.Future
 
-class AsyncHttpClientFutureHttpTest extends HttpTest[Future] {
+class AsyncHttpClientFutureHttpTest extends AsyncHttpClientHttpTest[Future] {
 
   override val backend: Backend[Future] = AsyncHttpClientFutureBackend()
   override implicit val convertToFuture: ConvertToFuture[Future] = ConvertToFuture.future

--- a/async-http-client-backend/monix/src/test/scala/sttp/client4/asynchttpclient/monix/AsyncHttpClientMonixHttpTest.scala
+++ b/async-http-client-backend/monix/src/test/scala/sttp/client4/asynchttpclient/monix/AsyncHttpClientMonixHttpTest.scala
@@ -20,6 +20,4 @@ class AsyncHttpClientMonixHttpTest extends AsyncHttpClientHttpTest[Task] {
       .onErrorRecover { case _: TimeoutException =>
         None
       }
-
-  override def supportsResponseAsInputStream = false
 }

--- a/async-http-client-backend/monix/src/test/scala/sttp/client4/asynchttpclient/monix/AsyncHttpClientMonixHttpTest.scala
+++ b/async-http-client-backend/monix/src/test/scala/sttp/client4/asynchttpclient/monix/AsyncHttpClientMonixHttpTest.scala
@@ -6,11 +6,12 @@ import monix.eval.Task
 import sttp.client4._
 import sttp.client4.impl.monix.convertMonixTaskToFuture
 import sttp.client4.testing.{ConvertToFuture, HttpTest}
+import sttp.client4.asynchttpclient.AsyncHttpClientHttpTest
 import monix.execution.Scheduler.Implicits.global
 
 import scala.concurrent.duration._
 
-class AsyncHttpClientMonixHttpTest extends HttpTest[Task] {
+class AsyncHttpClientMonixHttpTest extends AsyncHttpClientHttpTest[Task] {
   override val backend: Backend[Task] = AsyncHttpClientMonixBackend().runSyncUnsafe()
   override implicit val convertToFuture: ConvertToFuture[Task] = convertMonixTaskToFuture
 

--- a/async-http-client-backend/monix/src/test/scala/sttp/client4/asynchttpclient/monix/AsyncHttpClientMonixHttpTest.scala
+++ b/async-http-client-backend/monix/src/test/scala/sttp/client4/asynchttpclient/monix/AsyncHttpClientMonixHttpTest.scala
@@ -1,14 +1,13 @@
 package sttp.client4.asynchttpclient.monix
 
-import java.util.concurrent.TimeoutException
-
 import monix.eval.Task
-import sttp.client4._
-import sttp.client4.impl.monix.convertMonixTaskToFuture
-import sttp.client4.testing.{ConvertToFuture, HttpTest}
-import sttp.client4.asynchttpclient.AsyncHttpClientHttpTest
 import monix.execution.Scheduler.Implicits.global
+import sttp.client4._
+import sttp.client4.asynchttpclient.AsyncHttpClientHttpTest
+import sttp.client4.impl.monix.convertMonixTaskToFuture
+import sttp.client4.testing.ConvertToFuture
 
+import java.util.concurrent.TimeoutException
 import scala.concurrent.duration._
 
 class AsyncHttpClientMonixHttpTest extends AsyncHttpClientHttpTest[Task] {
@@ -22,7 +21,5 @@ class AsyncHttpClientMonixHttpTest extends AsyncHttpClientHttpTest[Task] {
         None
       }
 
-  override def throwsExceptionOnUnsupportedEncoding = false
-  override def supportsAutoDecompressionDisabling = false
   override def supportsResponseAsInputStream = false
 }

--- a/async-http-client-backend/scalaz/src/test/scala/sttp/client4/asynchttpclient/scalaz/AsyncHttpClientScalazHttpTest.scala
+++ b/async-http-client-backend/scalaz/src/test/scala/sttp/client4/asynchttpclient/scalaz/AsyncHttpClientScalazHttpTest.scala
@@ -13,5 +13,4 @@ class AsyncHttpClientScalazHttpTest extends AsyncHttpClientHttpTest[Task] {
 
   override def supportsCancellation: Boolean = false
   override def timeoutToNone[T](t: Task[T], timeoutMillis: Int): Task[Option[T]] = t.map(Some(_))
-  override def supportsResponseAsInputStream = false
 }

--- a/async-http-client-backend/scalaz/src/test/scala/sttp/client4/asynchttpclient/scalaz/AsyncHttpClientScalazHttpTest.scala
+++ b/async-http-client-backend/scalaz/src/test/scala/sttp/client4/asynchttpclient/scalaz/AsyncHttpClientScalazHttpTest.scala
@@ -2,19 +2,16 @@ package sttp.client4.asynchttpclient.scalaz
 
 import scalaz.concurrent.Task
 import sttp.client4.Backend
-import sttp.client3.asynchttpclient.AsyncHttpClientHttpTest
+import sttp.client4.asynchttpclient.AsyncHttpClientHttpTest
 import sttp.client4.impl.scalaz.convertScalazTaskToFuture
-import sttp.client4.testing.{ConvertToFuture, HttpTest}
+import sttp.client4.testing.ConvertToFuture
 
 class AsyncHttpClientScalazHttpTest extends AsyncHttpClientHttpTest[Task] {
 
   override val backend: Backend[Task] = AsyncHttpClientScalazBackend().unsafePerformSync
   override implicit val convertToFuture: ConvertToFuture[Task] = convertScalazTaskToFuture
 
-  override def throwsExceptionOnUnsupportedEncoding = false
-
   override def supportsCancellation: Boolean = false
   override def timeoutToNone[T](t: Task[T], timeoutMillis: Int): Task[Option[T]] = t.map(Some(_))
-  override def supportsAutoDecompressionDisabling = false
   override def supportsResponseAsInputStream = false
 }

--- a/async-http-client-backend/scalaz/src/test/scala/sttp/client4/asynchttpclient/scalaz/AsyncHttpClientScalazHttpTest.scala
+++ b/async-http-client-backend/scalaz/src/test/scala/sttp/client4/asynchttpclient/scalaz/AsyncHttpClientScalazHttpTest.scala
@@ -2,10 +2,11 @@ package sttp.client4.asynchttpclient.scalaz
 
 import scalaz.concurrent.Task
 import sttp.client4.Backend
+import sttp.client3.asynchttpclient.AsyncHttpClientHttpTest
 import sttp.client4.impl.scalaz.convertScalazTaskToFuture
 import sttp.client4.testing.{ConvertToFuture, HttpTest}
 
-class AsyncHttpClientScalazHttpTest extends HttpTest[Task] {
+class AsyncHttpClientScalazHttpTest extends AsyncHttpClientHttpTest[Task] {
 
   override val backend: Backend[Task] = AsyncHttpClientScalazBackend().unsafePerformSync
   override implicit val convertToFuture: ConvertToFuture[Task] = convertScalazTaskToFuture

--- a/async-http-client-backend/src/test/scala/sttp/client4/asynchttpclient/AsyncHttpClientHttpTest.scala
+++ b/async-http-client-backend/src/test/scala/sttp/client4/asynchttpclient/AsyncHttpClientHttpTest.scala
@@ -3,5 +3,7 @@ package sttp.client4.asynchttpclient
 import sttp.client4.testing.HttpTest
 
 abstract class AsyncHttpClientHttpTest[F[_]] extends HttpTest[F] {
+  override protected def throwsExceptionOnUnsupportedEncoding = false
+  override protected def supportsAutoDecompressionDisabling = false
   override protected def supportsNonAsciiHeaderValues = false
 }

--- a/async-http-client-backend/src/test/scala/sttp/client4/asynchttpclient/AsyncHttpClientHttpTest.scala
+++ b/async-http-client-backend/src/test/scala/sttp/client4/asynchttpclient/AsyncHttpClientHttpTest.scala
@@ -1,0 +1,7 @@
+package sttp.client4.asynchttpclient
+
+import sttp.client4.testing.HttpTest
+
+abstract class AsyncHttpClientHttpTest[F[_]] extends HttpTest[F] {
+  override protected def supportsNonAsciiHeaderValues = false
+}

--- a/async-http-client-backend/src/test/scala/sttp/client4/asynchttpclient/AsyncHttpClientHttpTest.scala
+++ b/async-http-client-backend/src/test/scala/sttp/client4/asynchttpclient/AsyncHttpClientHttpTest.scala
@@ -6,4 +6,5 @@ abstract class AsyncHttpClientHttpTest[F[_]] extends HttpTest[F] {
   override protected def throwsExceptionOnUnsupportedEncoding = false
   override protected def supportsAutoDecompressionDisabling = false
   override protected def supportsNonAsciiHeaderValues = false
+  override protected def supportsResponseAsInputStream = false
 }

--- a/async-http-client-backend/zio/src/test/scala/sttp/client4/asynchttpclient/zio/AsyncHttpClientZioHttpTest.scala
+++ b/async-http-client-backend/zio/src/test/scala/sttp/client4/asynchttpclient/zio/AsyncHttpClientZioHttpTest.scala
@@ -1,19 +1,16 @@
 package sttp.client4.asynchttpclient.zio
 
 import sttp.client4._
+import sttp.client4.asynchttpclient.AsyncHttpClientHttpTest
 import sttp.client4.impl.zio.ZioTestBase
 import sttp.client4.testing.{ConvertToFuture, HttpTest}
 import zio.{Task, ZIO}
 
-class AsyncHttpClientZioHttpTest extends HttpTest[Task] with ZioTestBase {
+class AsyncHttpClientZioHttpTest extends AsyncHttpClientHttpTest[Task] with ZioTestBase {
 
   override val backend: Backend[Task] =
     unsafeRunSyncOrThrow(AsyncHttpClientZioBackend())
   override implicit val convertToFuture: ConvertToFuture[Task] = convertZioTaskToFuture
-
-  override def throwsExceptionOnUnsupportedEncoding = false
-  override def supportsAutoDecompressionDisabling = false
-  override def supportsResponseAsInputStream = false
 
   "throw an exception instead of ZIO defect if the header value is invalid" in {
 

--- a/async-http-client-backend/zio1/src/test/scala/sttp/client4/asynchttpclient/zio/AsyncHttpClientZioHttpTest.scala
+++ b/async-http-client-backend/zio1/src/test/scala/sttp/client4/asynchttpclient/zio/AsyncHttpClientZioHttpTest.scala
@@ -1,19 +1,16 @@
 package sttp.client4.asynchttpclient.zio
 
 import sttp.client4._
+import sttp.client4.asynchttpclient.AsyncHttpClientHttpTest
 import sttp.client4.impl.zio.ZioTestBase
-import sttp.client4.testing.{ConvertToFuture, HttpTest}
+import sttp.client4.testing.ConvertToFuture
 import zio.{Task, ZIO}
 
-class AsyncHttpClientZioHttpTest extends HttpTest[Task] with ZioTestBase {
+class AsyncHttpClientZioHttpTest extends AsyncHttpClientHttpTest[Task] with ZioTestBase {
 
   override val backend: Backend[Task] =
     runtime.unsafeRun(AsyncHttpClientZioBackend())
   override implicit val convertToFuture: ConvertToFuture[Task] = convertZioTaskToFuture
-
-  override def throwsExceptionOnUnsupportedEncoding = false
-  override def supportsAutoDecompressionDisabling = false
-  override def supportsResponseAsInputStream = false
 
   "throw an exception instead of ZIO defect if the header value is invalid" in {
 

--- a/build.sbt
+++ b/build.sbt
@@ -648,7 +648,7 @@ def okhttpBackendProject(proj: String, includeDotty: Boolean) =
     .settings(testServerSettings)
     .settings(name := s"okhttp-backend-$proj")
     .jvmPlatform(scalaVersions = scala2 ++ (if (includeDotty) scala3 else Nil))
-    .dependsOn(okhttpBackend)
+    .dependsOn(okhttpBackend % compileAndTest)
 
 lazy val okhttpMonixBackend =
   okhttpBackendProject("monix", includeDotty = true)

--- a/core/src/main/scalajvm/sttp/client4/httpurlconnection/HttpURLConnectionBackend.scala
+++ b/core/src/main/scalajvm/sttp/client4/httpurlconnection/HttpURLConnectionBackend.scala
@@ -214,8 +214,9 @@ class HttpURLConnectionBackend private (
 
     val os = c.getOutputStream
     def writeMeta(s: String): Unit = {
-      os.write(s.getBytes(Utf8))
-      total += s.getBytes(Utf8).length.toLong
+      val utf8Bytes = s.getBytes(Utf8)
+      os.write(utf8Bytes)
+      total += utf8Bytes.length.toLong
     }
 
     partsWithHeaders.foreach { case (headers, p) =>

--- a/core/src/main/scalajvm/sttp/client4/httpurlconnection/HttpURLConnectionBackend.scala
+++ b/core/src/main/scalajvm/sttp/client4/httpurlconnection/HttpURLConnectionBackend.scala
@@ -193,7 +193,7 @@ class HttpURLConnectionBackend private (
           case FileBody(b, _)        => Some(b.toFile.length())
         }
 
-        val headersLen = headers.getBytes(Iso88591).length
+        val headersLen = headers.getBytes(Utf8).length
 
         bodyLen.map(bl => dashesLen + boundaryLen + crLfLen + headersLen + crLfLen + crLfLen + bl + crLfLen)
       }
@@ -214,8 +214,8 @@ class HttpURLConnectionBackend private (
 
     val os = c.getOutputStream
     def writeMeta(s: String): Unit = {
-      os.write(s.getBytes(Iso88591))
-      total += s.getBytes(Iso88591).length.toLong
+      os.write(s.getBytes(Utf8))
+      total += s.getBytes(Utf8).length.toLong
     }
 
     partsWithHeaders.foreach { case (headers, p) =>

--- a/core/src/test/scala/sttp/client4/testing/HttpTest.scala
+++ b/core/src/test/scala/sttp/client4/testing/HttpTest.scala
@@ -472,6 +472,11 @@ trait HttpTest[F[_]]
         req.send(backend).toFuture().map(resp => resp.body should be("p1=v1 (f1), p2=v2 (f2)"))
       }
 
+      "send a multipart message with non-ascii filenames" in {
+        val req = mp.multipartBody(multipart("p1", "v1").fileName("fó1"), multipart("p2", "v2").fileName("fó2"))
+        req.send(backend).toFuture().map { resp => resp.body should be("p1=v1 (fó1), p2=v2 (fó2)") }
+      }
+
       "send a multipart message with binary data and filename" in {
         val binaryPart =
           multipart("p1", "v1".getBytes)

--- a/core/src/test/scala/sttp/client4/testing/HttpTest.scala
+++ b/core/src/test/scala/sttp/client4/testing/HttpTest.scala
@@ -58,6 +58,7 @@ trait HttpTest[F[_]]
   protected def supportsAutoDecompressionDisabling = true
   protected def supportsDeflateWrapperChecking = true
   protected def supportsEmptyContentEncoding = true
+  protected def supportsNonAsciiHeaderValues = true
 
   "request parsing" - {
     "Inf timeout should not throw exception" in {
@@ -472,9 +473,11 @@ trait HttpTest[F[_]]
         req.send(backend).toFuture().map(resp => resp.body should be("p1=v1 (f1), p2=v2 (f2)"))
       }
 
-      "send a multipart message with non-ascii filenames" in {
-        val req = mp.multipartBody(multipart("p1", "v1").fileName("fó1"), multipart("p2", "v2").fileName("fó2"))
-        req.send(backend).toFuture().map { resp => resp.body should be("p1=v1 (fó1), p2=v2 (fó2)") }
+      if(supportsNonAsciiHeaderValues) {
+        "send a multipart message with non-ascii filenames" in {
+          val req = mp.multipartBody(multipart("p1", "v1").fileName("fó1"), multipart("p2", "v2").fileName("fó2"))
+          req.send(backend).toFuture().map { resp => resp.body should be("p1=v1 (fó1), p2=v2 (fó2)") }
+        }
       }
 
       "send a multipart message with binary data and filename" in {

--- a/okhttp-backend/monix/src/test/scala/sttp/client4/okhttp/monix/OkHttpMonixHttpTest.scala
+++ b/okhttp-backend/monix/src/test/scala/sttp/client4/okhttp/monix/OkHttpMonixHttpTest.scala
@@ -1,24 +1,22 @@
 package sttp.client4.okhttp.monix
 
-import java.util.concurrent.TimeoutException
-
 import monix.eval.Task
 import monix.execution.Scheduler.Implicits.global
 import sttp.capabilities.monix.MonixStreams
 import sttp.client4.StreamBackend
 import sttp.client4.impl.monix.convertMonixTaskToFuture
-import sttp.client4.testing.{ConvertToFuture, HttpTest}
+import sttp.client4.okhttp.OkHttpHttpTest
+import sttp.client4.testing.ConvertToFuture
 
-import scala.concurrent.duration.DurationInt
+import java.util.concurrent.TimeoutException
+import scala.concurrent.duration._
 
-class OkHttpMonixHttpTest extends HttpTest[Task] {
+class OkHttpMonixHttpTest extends OkHttpHttpTest[Task] {
 
   override val backend: StreamBackend[Task, MonixStreams] = OkHttpMonixBackend().runSyncUnsafe()
   override implicit val convertToFuture: ConvertToFuture[Task] = convertMonixTaskToFuture
 
   override def supportsDeflateWrapperChecking = false
-
-  override def supportsNonAsciiHeaderValues = false
 
   override def timeoutToNone[T](t: Task[T], timeoutMillis: Int): Task[Option[T]] =
     t.map(Some(_))

--- a/okhttp-backend/monix/src/test/scala/sttp/client4/okhttp/monix/OkHttpMonixHttpTest.scala
+++ b/okhttp-backend/monix/src/test/scala/sttp/client4/okhttp/monix/OkHttpMonixHttpTest.scala
@@ -18,6 +18,8 @@ class OkHttpMonixHttpTest extends HttpTest[Task] {
 
   override def supportsDeflateWrapperChecking = false
 
+  override def supportsNonAsciiHeaderValues = false
+
   override def timeoutToNone[T](t: Task[T], timeoutMillis: Int): Task[Option[T]] =
     t.map(Some(_))
       .timeout(timeoutMillis.milliseconds)

--- a/okhttp-backend/monix/src/test/scala/sttp/client4/okhttp/monix/OkHttpMonixHttpTest.scala
+++ b/okhttp-backend/monix/src/test/scala/sttp/client4/okhttp/monix/OkHttpMonixHttpTest.scala
@@ -16,8 +16,6 @@ class OkHttpMonixHttpTest extends OkHttpHttpTest[Task] {
   override val backend: StreamBackend[Task, MonixStreams] = OkHttpMonixBackend().runSyncUnsafe()
   override implicit val convertToFuture: ConvertToFuture[Task] = convertMonixTaskToFuture
 
-  override def supportsDeflateWrapperChecking = false
-
   override def timeoutToNone[T](t: Task[T], timeoutMillis: Int): Task[Option[T]] =
     t.map(Some(_))
       .timeout(timeoutMillis.milliseconds)

--- a/okhttp-backend/src/test/scala/sttp/client4/okhttp/OkHttpFutureHttpTest.scala
+++ b/okhttp-backend/src/test/scala/sttp/client4/okhttp/OkHttpFutureHttpTest.scala
@@ -12,5 +12,4 @@ class OkHttpFutureHttpTest extends OkHttpHttpTest[Future] {
 
   override def supportsCancellation: Boolean = false
   override def timeoutToNone[T](t: Future[T], timeoutMillis: Int): Future[Option[T]] = t.map(Some(_))
-  override def supportsDeflateWrapperChecking = false
 }

--- a/okhttp-backend/src/test/scala/sttp/client4/okhttp/OkHttpFutureHttpTest.scala
+++ b/okhttp-backend/src/test/scala/sttp/client4/okhttp/OkHttpFutureHttpTest.scala
@@ -5,7 +5,7 @@ import sttp.client4.testing.{ConvertToFuture, HttpTest}
 
 import scala.concurrent.Future
 
-class OkHttpFutureHttpTest extends HttpTest[Future] {
+class OkHttpFutureHttpTest extends OkHttpHttpTest[Future] {
 
   override val backend: WebSocketBackend[Future] = OkHttpFutureBackend()
   override implicit val convertToFuture: ConvertToFuture[Future] = ConvertToFuture.future

--- a/okhttp-backend/src/test/scala/sttp/client4/okhttp/OkHttpHttpTest.scala
+++ b/okhttp-backend/src/test/scala/sttp/client4/okhttp/OkHttpHttpTest.scala
@@ -3,5 +3,6 @@ package sttp.client4.okhttp
 import sttp.client4.testing.HttpTest
 
 abstract class OkHttpHttpTest[F[_]] extends HttpTest[F] {
+  override protected def supportsDeflateWrapperChecking = false
   override protected def supportsNonAsciiHeaderValues = false
 }

--- a/okhttp-backend/src/test/scala/sttp/client4/okhttp/OkHttpHttpTest.scala
+++ b/okhttp-backend/src/test/scala/sttp/client4/okhttp/OkHttpHttpTest.scala
@@ -1,0 +1,7 @@
+package sttp.client4.okhttp
+
+import sttp.client4.testing.HttpTest
+
+abstract class OkHttpHttpTest[F[_]] extends HttpTest[F] {
+  override protected def supportsNonAsciiHeaderValues = false
+}

--- a/okhttp-backend/src/test/scala/sttp/client4/okhttp/OkHttpSyncHttpTest.scala
+++ b/okhttp-backend/src/test/scala/sttp/client4/okhttp/OkHttpSyncHttpTest.scala
@@ -10,5 +10,4 @@ class OkHttpSyncHttpTest extends OkHttpHttpTest[Identity] {
 
   override def supportsCancellation: Boolean = false
   override def timeoutToNone[T](t: Identity[T], timeoutMillis: Int): Identity[Option[T]] = Some(t)
-  override def supportsDeflateWrapperChecking = false
 }

--- a/okhttp-backend/src/test/scala/sttp/client4/okhttp/OkHttpSyncHttpTest.scala
+++ b/okhttp-backend/src/test/scala/sttp/client4/okhttp/OkHttpSyncHttpTest.scala
@@ -3,7 +3,7 @@ package sttp.client4.okhttp
 import sttp.client4.testing.{ConvertToFuture, HttpTest}
 import sttp.client4.{Identity, WebSocketBackend}
 
-class OkHttpSyncHttpTest extends HttpTest[Identity] {
+class OkHttpSyncHttpTest extends OkHttpHttpTest[Identity] {
   override val backend: WebSocketBackend[Identity] = OkHttpSyncBackend()
 
   override implicit val convertToFuture: ConvertToFuture[Identity] = ConvertToFuture.id


### PR DESCRIPTION
Closes https://github.com/softwaremill/sttp-model/issues/317/

Forward port of #2108 