### PR TITLE
fix filtering content-type and content-length headers in HttpClientBa…

### DIFF
--- a/core/src/main/scalajvm/sttp/client4/httpclient/HttpClientBackend.scala
+++ b/core/src/main/scalajvm/sttp/client4/httpclient/HttpClientBackend.scala
@@ -83,7 +83,7 @@ abstract class HttpClientBackend[F[_], S <: Streams[S], P, B](
       bodyToHttpClient(request, builder, contentType).map { httpBody =>
         builder.method(request.method.method, httpBody)
         request.headers
-          .filterNot(h => (h.name == HeaderNames.ContentLength) || h.name == HeaderNames.ContentType)
+          .filterNot(h => h.is(HeaderNames.ContentLength) || h.is(HeaderNames.ContentType))
           .foreach(h => builder.header(h.name, h.value))
         val timeout = request.options.readTimeout
         if (timeout.isFinite) {


### PR DESCRIPTION
Before submitting pull request:
- [x] Check if the project compiles by running `sbt compile`
- [x] Verify docs compilation by running `sbt compileDocs`
- [x] Check if tests pass by running `sbt test`
- [x] Format code by running `sbt scalafmt`

## Problems
The java HttpClient prohibits to add `Content-Type` header to request, it's reason HttpClientBacked filters this header. But the check is case-sensitive. So passing `content-type` (in lower case) header occurs IllegalArgumentException.

Another problem is duplicating `content-type` header inside request if the header name passed in lowercase.

These problems might happen if an application gets these headers from an incoming HTTP request and then pass them to a new HTTP request to another service. 