### PR TITLE
Change deprecated import with `lib` to `dep` for scala-cli

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -23,7 +23,7 @@ The basic dependency which provides the API, together with a synchronous and `Fu
 Add the following directive to the top of your scala file to add the core sttp dependency:
 
 ```
-//> using lib "com.softwaremill.sttp.client4::core:@VERSION@"
+//> using dep "com.softwaremill.sttp.client4::core:@VERSION@"
 ```
 
 ## Using Ammonite


### PR DESCRIPTION
Before submitting pull request:
- [ ] Check if the project compiles by running `sbt compile`
- [ ] Verify docs compilation by running `sbt compileDocs`
- [ ] Check if tests pass by running `sbt test`
- [ ] Format code by running `sbt scalafmt`
