### PR TITLE
Add scala3 support for spray json

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -897,7 +897,7 @@ lazy val sprayJson = (projectMatrix in file("json/spray-json"))
     ),
     scalaTest
   )
-  .jvmPlatform(scalaVersions = scala2)
+  .jvmPlatform(scalaVersions = scala2 ++ scala3)
   .dependsOn(core, jsonCommon)
 
 lazy val play29Json = (projectMatrix in file("json/play29-json"))


### PR DESCRIPTION
Before submitting pull request:
- [x] Check if the project compiles by running `sbt compile`
- [x] Verify docs compilation by running `sbt compileDocs`
- [ ] Check if tests pass by running `sbt test`
- [ ] Format code by running `sbt scalafmt`

Tests could not complete because of OOM issues. Just ran this with standard settings on an M3 Macbook. Any common tips or tricks used here? 

Running sbtformat yielded format changed for files i did not touch. 
```
modified:   core/src/main/scala/sttp/client4/testing/ResponseStub.scala
	modified:   observability/opentelemetry-metrics-backend/src/main/scala/sttp/client4/opentelemetry/OpenTelemetryMetricsBackend.scala
	modified:   observability/opentelemetry-metrics-backend/src/main/scala/sttp/client4/opentelemetry/OpenTelemetryMetricsConfig.scala
	modified:   observability/prometheus-backend/src/main/scala/sttp/client4/prometheus/PrometheusBackend.scala
```