### PR TITLE
Restore support for Scala Native in json/circe

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -825,6 +825,7 @@ lazy val circe = (projectMatrix in file("json/circe"))
     settings = commonJvmSettings
   )
   .jsPlatform(scalaVersions = scala2 ++ scala3, settings = commonJsSettings)
+  .nativePlatform(scalaVersions = scala2 ++ scala3, settings = commonNativeSettings)
   .dependsOn(core, jsonCommon)
 
 lazy val jsoniter = (projectMatrix in file("json/jsoniter"))


### PR DESCRIPTION
Circe 0.14.9 adds support for Scala Native 0.5.