### PR TITLE
Remove sttpClientTag

### DIFF
--- a/async-http-client-backend/zio/src/main/scala/sttp/client3/asynchttpclient/zio/package.scala
+++ b/async-http-client-backend/zio/src/main/scala/sttp/client3/asynchttpclient/zio/package.scala
@@ -1,12 +1,14 @@
 package sttp.client3.asynchttpclient
 
 import _root_.zio._
-import sttp.capabilities.Effect
+import sttp.capabilities.{Effect, WebSockets}
 import sttp.capabilities.zio.ZioStreams
 import sttp.client3._
 import sttp.client3.impl.zio.ExtendEnv
 
 package object zio {
+
+  type ZioWebSocketsStreams = ZioStreams & WebSockets
 
   /** Type alias to be used as the sttp ZIO service (mainly in ZIO environment). */
   type SttpClient = SttpBackend[Task, ZioStreams]

--- a/effects/zio/src/main/scalajvm/sttp/client3/httpclient/zio/HttpClientZioBackend.scala
+++ b/effects/zio/src/main/scalajvm/sttp/client3/httpclient/zio/HttpClientZioBackend.scala
@@ -33,7 +33,7 @@ class HttpClientZioBackend private (
 ) extends HttpClientAsyncBackend[
       Task,
       ZioStreams,
-      ZioStreams with WebSockets,
+      ZioWebSocketsStreams,
       Publisher[ju.List[ByteBuffer]],
       ZioStreams.BinaryStream
     ](
@@ -101,7 +101,7 @@ object HttpClientZioBackend {
       closeClient: Boolean,
       customizeRequest: HttpRequest => HttpRequest,
       customEncodingHandler: ZioEncodingHandler
-  ): SttpBackend[Task, ZioStreams with WebSockets] =
+  ): SttpBackend[Task, ZioWebSocketsStreams] =
     new FollowRedirectsBackend(
       new HttpClientZioBackend(
         client,
@@ -115,7 +115,7 @@ object HttpClientZioBackend {
       options: SttpBackendOptions = SttpBackendOptions.Default,
       customizeRequest: HttpRequest => HttpRequest = identity,
       customEncodingHandler: ZioEncodingHandler = PartialFunction.empty
-  ): Task[SttpBackend[Task, ZioStreams with WebSockets]] = {
+  ): Task[SttpBackend[Task, ZioWebSocketsStreams]] = {
     ZIO.executor.flatMap(executor =>
       ZIO.attempt(
         HttpClientZioBackend(
@@ -132,7 +132,7 @@ object HttpClientZioBackend {
       options: SttpBackendOptions = SttpBackendOptions.Default,
       customizeRequest: HttpRequest => HttpRequest = identity,
       customEncodingHandler: ZioEncodingHandler = PartialFunction.empty
-  ): ZIO[Scope, Throwable, SttpBackend[Task, ZioStreams with WebSockets]] =
+  ): ZIO[Scope, Throwable, SttpBackend[Task, ZioWebSocketsStreams]] =
     ZIO.acquireRelease(apply(options, customizeRequest, customEncodingHandler))(
       _.close().ignore
     )
@@ -141,7 +141,7 @@ object HttpClientZioBackend {
       client: HttpClient,
       customizeRequest: HttpRequest => HttpRequest = identity,
       customEncodingHandler: ZioEncodingHandler = PartialFunction.empty
-  ): ZIO[Scope, Throwable, SttpBackend[Task, ZioStreams with WebSockets]] =
+  ): ZIO[Scope, Throwable, SttpBackend[Task, ZioWebSocketsStreams]] =
     ZIO.acquireRelease(
       ZIO.attempt(HttpClientZioBackend(client, closeClient = true, customizeRequest, customEncodingHandler))
     )(_.close().ignore)
@@ -166,7 +166,7 @@ object HttpClientZioBackend {
       client: HttpClient,
       customizeRequest: HttpRequest => HttpRequest = identity,
       customEncodingHandler: ZioEncodingHandler = PartialFunction.empty
-  ): SttpBackend[Task, ZioStreams with WebSockets] =
+  ): SttpBackend[Task, ZioWebSocketsStreams] =
     HttpClientZioBackend(
       client,
       closeClient = false,
@@ -198,5 +198,5 @@ object HttpClientZioBackend {
     *
     * See [[SttpBackendStub]] for details on how to configure stub responses.
     */
-  def stub: SttpBackendStub[Task, ZioStreams with WebSockets] = SttpBackendStub(new RIOMonadAsyncError[Any])
+  def stub: SttpBackendStub[Task, ZioWebSocketsStreams] = SttpBackendStub(new RIOMonadAsyncError[Any])
 }

--- a/effects/zio/src/main/scalajvm/sttp/client3/httpclient/zio/package.scala
+++ b/effects/zio/src/main/scalajvm/sttp/client3/httpclient/zio/package.scala
@@ -8,12 +8,10 @@ import sttp.client3.impl.zio.ExtendEnv
 
 package object zio {
 
-  /** Type alias to be used as the sttp ZIO service (mainly in ZIO environment). */
-  type SttpClient = SttpBackend[Task, ZioStreams & WebSockets]
+  type ZioWebSocketsStreams = ZioStreams & WebSockets
 
-  // work-around for "You must not use an intersection type, yet have provided SttpBackend[Task, ZioStreams & WebSockets]", #2244
-  implicit val sttpClientTag: Tag[SttpClient] =
-    Tag.materialize[SttpBackend[Task, ZioStreams]].asInstanceOf[Tag[SttpClient]]
+  /** Type alias to be used as the sttp ZIO service (mainly in ZIO environment). */
+  type SttpClient = SttpBackend[Task, ZioWebSocketsStreams]
 
   /** Sends the request. Only requests for which the method & URI are specified can be sent.
     *
@@ -28,7 +26,7 @@ package object zio {
     * Known exceptions are converted to one of `SttpClientException`. Other exceptions are kept unchanged.
     */
   def send[T](
-      request: Request[T, Effect[Task] with ZioStreams with WebSockets]
+      request: Request[T, Effect[Task] with ZioWebSocketsStreams]
   ): ZIO[SttpClient, Throwable, Response[T]] =
     ZIO.serviceWithZIO[SttpClient](_.send(request))
 
@@ -36,7 +34,7 @@ package object zio {
     * websockets or resource-safe streaming) to use an `R` environment.
     */
   def sendR[T, R](
-      request: Request[T, Effect[RIO[R, *]] with ZioStreams with WebSockets]
+      request: Request[T, Effect[RIO[R, *]] with ZioWebSocketsStreams]
   ): ZIO[SttpClient with R, Throwable, Response[T]] =
     ZIO.serviceWithZIO[SttpClient](_.extendEnv[R].send(request))
 }

--- a/examples/src/main/scala/sttp/client3/examples/GetAndParseJsonZioCirce.scala
+++ b/examples/src/main/scala/sttp/client3/examples/GetAndParseJsonZioCirce.scala
@@ -20,5 +20,6 @@ object GetAndParseJsonZioCirce extends ZIOAppDefault {
       _ <- Console.printLine(s"Got response code: ${response.code}")
       _ <- Console.printLine(response.body.toString)
     } yield ()
-  }.provideLayer(HttpClientZioBackend.layer())
+  }.provideLayer(ZLayer.debug("additional layer") ++ HttpClientZioBackend.layer())
+
 }


### PR DESCRIPTION
Resolves https://github.com/softwaremill/sttp/issues/2311

Add a type  `ZioWebSocketsStreams`  to help capturing the type tag of  `ZioStreams with WebSockets`  [here](https://github.com/zio/zio/blob/series/2.x/core/shared/src/main/scala/zio/ZEnvironment.scala#L126)

Before submitting pull request:
- [x] Check if the project compiles by running `sbt compile`
- [x] Verify docs compilation by running `sbt compileDocs`
- [x] Check if tests pass by running `sbt test`
- [x] Format code by running `sbt scalafmt`
