### PR TITLE
make HttpError and DeserializationException covariant to follow variance of ResponseException

### DIFF
--- a/core/src/main/scala/sttp/client4/ResponseException.scala
+++ b/core/src/main/scala/sttp/client4/ResponseException.scala
@@ -5,9 +5,9 @@ import sttp.model.StatusCode
 import scala.annotation.tailrec
 
 sealed abstract class ResponseException[+HE, +DE](error: String) extends Exception(error)
-case class HttpError[HE](body: HE, statusCode: StatusCode)
+case class HttpError[+HE](body: HE, statusCode: StatusCode)
     extends ResponseException[HE, Nothing](s"statusCode: $statusCode, response: $body")
-case class DeserializationException[DE: ShowError](body: String, error: DE)
+case class DeserializationException[+DE: ShowError](body: String, error: DE)
     extends ResponseException[Nothing, DE](implicitly[ShowError[DE]].show(error))
 
 object HttpError {


### PR DESCRIPTION
`HttpError` and `DeserializationException` being invariant stops me from doing something like this in scala3:
```scala3
def refine(e: ResponseException[Exception, ?]): Option[HttpError[Exception]] = e match {
  case httpError @ HttpError(_, _) => Some(httpError)
  case _ => None
}
```
in scala 3 you get this:
```
Found: (httpError : sttp. client4.HttpError[HE$1]) Required: sttp. client4.HttpError[Exception]  where: HE$1 is a type in method refine with bounds <: Exception
```
here `httpError` is of boundaries `<: Exception` which is not allowed by invariance of `HttpError`. The reason, why it is working in scala2 is some sort of type inference loophole in pattern matching, it infers `httpError` as `HttpError[Exception]`, this is wrong because we can do:
```scala3
case class MyException() extends Exception
val error: ResponseException[Exception, ?] = HttpError(MyException(), ???)
```
For me it seems only logical to make both `HttpError` and `DeserializationException` covariant to follow covariance of `ResponseException`. It doesn't look like invariance of those two were intentional, it's just that scala2 allowed this invariances to slip through.

Before submitting pull request:
- [x] Check if the project compiles by running `sbt compile`
- [x] Verify docs compilation by running `sbt compileDocs`
- [x] Check if tests pass by running `sbt test`
- [x] Format code by running `sbt scalafmt`
