### PR TITLE
Improve usability of response specifications

### DIFF
--- a/async-http-client-backend/zio/src/test/scala/sttp/client4/asynchttpclient/zio/AsyncHttpClientZioHttpTest.scala
+++ b/async-http-client-backend/zio/src/test/scala/sttp/client4/asynchttpclient/zio/AsyncHttpClientZioHttpTest.scala
@@ -3,8 +3,9 @@ package sttp.client4.asynchttpclient.zio
 import sttp.client4._
 import sttp.client4.asynchttpclient.AsyncHttpClientHttpTest
 import sttp.client4.impl.zio.ZioTestBase
-import sttp.client4.testing.{ConvertToFuture, HttpTest}
-import zio.{Task, ZIO}
+import sttp.client4.testing.ConvertToFuture
+import zio.Task
+import zio.ZIO
 
 class AsyncHttpClientZioHttpTest extends AsyncHttpClientHttpTest[Task] with ZioTestBase {
 

--- a/build.sbt
+++ b/build.sbt
@@ -800,7 +800,8 @@ lazy val armeriaZioBackend =
 //----- json
 lazy val jsonCommon = (projectMatrix in (file("json/common")))
   .settings(
-    name := "json-common"
+    name := "json-common",
+    scalaTest
   )
   .jvmPlatform(
     scalaVersions = scala2 ++ scala3,
@@ -826,7 +827,7 @@ lazy val circe = (projectMatrix in file("json/circe"))
   )
   .jsPlatform(scalaVersions = scala2 ++ scala3, settings = commonJsSettings)
   .nativePlatform(scalaVersions = scala2 ++ scala3, settings = commonNativeSettings)
-  .dependsOn(core, jsonCommon)
+  .dependsOn(core, jsonCommon % compileAndTest)
 
 lazy val jsoniter = (projectMatrix in file("json/jsoniter"))
   .settings(
@@ -842,7 +843,7 @@ lazy val jsoniter = (projectMatrix in file("json/jsoniter"))
     settings = commonJvmSettings
   )
   .jsPlatform(scalaVersions = scala2 ++ scala3, settings = commonJsSettings)
-  .dependsOn(core, jsonCommon)
+  .dependsOn(core, jsonCommon % compileAndTest)
 
 lazy val zioJson = (projectMatrix in file("json/zio-json"))
   .settings(
@@ -858,7 +859,7 @@ lazy val zioJson = (projectMatrix in file("json/zio-json"))
     settings = commonJvmSettings
   )
   .jsPlatform(scalaVersions = scala2 ++ scala3, settings = commonJsSettings)
-  .dependsOn(core, jsonCommon)
+  .dependsOn(core, jsonCommon % compileAndTest)
 
 lazy val zio1Json = (projectMatrix in file("json/zio1-json"))
   .settings(
@@ -874,7 +875,7 @@ lazy val zio1Json = (projectMatrix in file("json/zio1-json"))
     settings = commonJvmSettings
   )
   .jsPlatform(scalaVersions = scala2 ++ scala3, settings = commonJsSettings)
-  .dependsOn(core, jsonCommon)
+  .dependsOn(core, jsonCommon % compileAndTest)
 
 lazy val tethysJson = (projectMatrix in file("json/tethys-json"))
   .settings(
@@ -890,7 +891,7 @@ lazy val tethysJson = (projectMatrix in file("json/tethys-json"))
     scalaVersions = scala2 ++ scala3,
     settings = commonJvmSettings
   )
-  .dependsOn(core, jsonCommon)
+  .dependsOn(core, jsonCommon % compileAndTest)
 
 lazy val upickle = (projectMatrix in file("json/upickle"))
   .settings(
@@ -908,7 +909,7 @@ lazy val upickle = (projectMatrix in file("json/upickle"))
   )
   .jsPlatform(scalaVersions = scala2 ++ scala3, settings = commonJsSettings)
   .nativePlatform(scalaVersions = scala2 ++ scala3, settings = commonNativeSettings)
-  .dependsOn(core, jsonCommon)
+  .dependsOn(core, jsonCommon % compileAndTest)
 
 lazy val json4sVersion = "4.0.7"
 
@@ -923,7 +924,7 @@ lazy val json4s = (projectMatrix in file("json/json4s"))
     scalaTest
   )
   .jvmPlatform(scalaVersions = scala2 ++ scala3)
-  .dependsOn(core, jsonCommon)
+  .dependsOn(core, jsonCommon % compileAndTest)
 
 lazy val sprayJson = (projectMatrix in file("json/spray-json"))
   .settings(commonJvmSettings)
@@ -935,7 +936,7 @@ lazy val sprayJson = (projectMatrix in file("json/spray-json"))
     scalaTest
   )
   .jvmPlatform(scalaVersions = scala2 ++ scala3)
-  .dependsOn(core, jsonCommon)
+  .dependsOn(core, jsonCommon % compileAndTest)
 
 lazy val play29Json = (projectMatrix in file("json/play29-json"))
   .settings(
@@ -952,7 +953,7 @@ lazy val play29Json = (projectMatrix in file("json/play29-json"))
     settings = commonJvmSettings
   )
   .jsPlatform(scalaVersions = scala2, settings = commonJsSettings)
-  .dependsOn(core, jsonCommon)
+  .dependsOn(core, jsonCommon % compileAndTest)
 
 lazy val playJson = (projectMatrix in file("json/play-json"))
   .settings(
@@ -967,7 +968,7 @@ lazy val playJson = (projectMatrix in file("json/play-json"))
     settings = commonJvmSettings
   )
   .jsPlatform(scalaVersions = scala2 ++ scala3, settings = commonJsSettings)
-  .dependsOn(core, jsonCommon)
+  .dependsOn(core, jsonCommon % compileAndTest)
 
 lazy val prometheusBackend = (projectMatrix in file("observability/prometheus-backend"))
   .settings(commonJvmSettings)

--- a/core/src/main/scala/sttp/client4/ResponseAs.scala
+++ b/core/src/main/scala/sttp/client4/ResponseAs.scala
@@ -13,15 +13,17 @@ import scala.util.{Failure, Success, Try}
 /** Describes how the response body of a request should be handled. A number of `as<Type>` helper methods are available
   * as part of [[SttpApi]] and when importing `sttp.client4._`. These methods yield specific implementations of this
   * trait, which can then be set on a [[Request]], [[StreamRequest]], [[WebSocketRequest]] or
-  * [[WebSocketStreamRequest]], depending on the response type.
+  * [[WebSocketStreamRequest]].
   *
   * @tparam T
-  *   Target type as which the response will be read.
+  *   Target type as which the response will be deserialized.
   * @tparam R
   *   The backend capabilities required by the response description. This might be `Any` (no requirements),
   *   [[sttp.capabilities.Effect]] (the backend must support the given effect type), [[sttp.capabilities.Streams]] (the
   *   ability to send and receive streaming bodies) or [[sttp.capabilities.WebSockets]] (the ability to handle websocket
   *   requests).
+  * @see
+  *   [[ResponseAs]]
   */
 trait ResponseAsDelegate[+T, -R] {
   def delegate: GenericResponseAs[T, R]
@@ -35,10 +37,10 @@ trait ResponseAsDelegate[+T, -R] {
   * status code. Responses can also be handled depending on the response metadata. Finally, two response body
   * descriptions can be combined (with some restrictions).
   *
-  * A number of `as<Type>` helper methods are available as part of [[SttpApi]] and when importing `sttp.client4._`.
+  * A number of `as<Type>` helper methods are available as part of [[SttpApi]] and when importing `sttp.client4.*`.
   *
   * @tparam T
-  *   Target type as which the response will be read.
+  *   Target type as which the response will be read/deserialized.
   */
 case class ResponseAs[+T](delegate: GenericResponseAs[T, Any]) extends ResponseAsDelegate[T, Any] {
 
@@ -89,7 +91,7 @@ case class ResponseAs[+T](delegate: GenericResponseAs[T, Any]) extends ResponseA
     }
 
   /** If the type to which the response body should be deserialized is an `Either[ResponseException[HE, DE], B]`, either
-    * throws /returns a failed effect with the [[DeserializationException]], returns the deserialized body from the
+    * throws / returns a failed effect with the [[DeserializationException]], returns the deserialized body from the
     * [[HttpError]], or the deserialized successful body `B`.
     */
   def orFailDeserialization[HE, DE, B](implicit
@@ -180,12 +182,14 @@ object ResponseAs {
   * [[ResponseMetadata]], that is the headers and status code.
   *
   * A number of `asStream[Type]` helper methods are available as part of [[SttpApi]] and when importing
-  * `sttp.client4._`.
+  * `sttp.client4.*`.
   *
   * @tparam T
-  *   Target type as which the response will be read.
+  *   Target type as which the response will be read/deserialized.
   * @tparam S
   *   The type of stream, used to receive the response body bodies.
+  * @see
+  *   [[ResponseAs]]
   */
 case class StreamResponseAs[+T, S](delegate: GenericResponseAs[T, S]) extends ResponseAsDelegate[T, S] {
   def map[T2](f: T => T2): StreamResponseAs[T2, S] =
@@ -202,10 +206,12 @@ case class StreamResponseAs[+T, S](delegate: GenericResponseAs[T, S]) extends Re
   * [[ResponseMetadata]], that is the headers and status code. Responses can also be handled depending on the response
   * metadata.
   *
-  * A number of `asWebSocket` helper methods are available as part of [[SttpApi]] and when importing `sttp.client4._`.
+  * A number of `asWebSocket` helper methods are available as part of [[SttpApi]] and when importing `sttp.client4.*`.
   *
   * @tparam T
-  *   Target type as which the response will be read.
+  *   Target type as which the response will be read/deserialized.
+  * @see
+  *   [[ResponseAs]]
   */
 case class WebSocketResponseAs[F[_], +T](delegate: GenericResponseAs[T, Effect[F] with WebSockets])
     extends ResponseAsDelegate[T, Effect[F] with WebSockets] {
@@ -223,10 +229,12 @@ case class WebSocketResponseAs[F[_], +T](delegate: GenericResponseAs[T, Effect[F
   * [[ResponseMetadata]], that is the headers and status code. Responses can also be handled depending on the response
   * metadata.
   *
-  * A number of `asWebSocket` helper methods are available as part of [[SttpApi]] and when importing `sttp.client4._`.
+  * A number of `asWebSocket` helper methods are available as part of [[SttpApi]] and when importing `sttp.client4.*`.
   *
   * @tparam T
-  *   Target type as which the response will be read.
+  *   Target type as which the response will be read/deserialized.
+  * @see
+  *   [[ResponseAs]]
   */
 case class WebSocketStreamResponseAs[+T, S](delegate: GenericResponseAs[T, S with WebSockets])
     extends ResponseAsDelegate[T, S with WebSockets] {

--- a/core/src/main/scala/sttp/client4/ResponseAs.scala
+++ b/core/src/main/scala/sttp/client4/ResponseAs.scala
@@ -79,7 +79,7 @@ case class ResponseAs[+T](delegate: GenericResponseAs[T, Any]) extends ResponseA
     *     yet an exception)
     *   - in case of `B`, returns the value directly
     */
-  def getRight[A, B](implicit tIsEither: T <:< Either[A, B]): ResponseAs[B] =
+  def orFail[A, B](implicit tIsEither: T <:< Either[A, B]): ResponseAs[B] =
     mapWithMetadata { case (t, meta) =>
       (t: Either[A, B]) match {
         case Left(a: Exception) => throw a
@@ -89,10 +89,10 @@ case class ResponseAs[+T](delegate: GenericResponseAs[T, Any]) extends ResponseA
     }
 
   /** If the type to which the response body should be deserialized is an `Either[ResponseException[HE, DE], B]`, either
-    * throws the [[DeserializationException]], returns the deserialized body from the [[HttpError]], or the deserialized
-    * successful body `B`.
+    * throws /returns a failed effect with the [[DeserializationException]], returns the deserialized body from the
+    * [[HttpError]], or the deserialized successful body `B`.
     */
-  def getEither[HE, DE, B](implicit
+  def orFailDeserialization[HE, DE, B](implicit
       tIsEither: T <:< Either[ResponseException[HE, DE], B]
   ): ResponseAs[Either[HE, B]] = map { t =>
     (t: Either[ResponseException[HE, DE], B]) match {

--- a/core/src/main/scala/sttp/client4/ResponseException.scala
+++ b/core/src/main/scala/sttp/client4/ResponseException.scala
@@ -4,6 +4,15 @@ import sttp.model.StatusCode
 
 import scala.annotation.tailrec
 
+/** Used to represent errors, that might occur when handling the response body. Either:
+  *   - a [[HttpError]], when the response code is different than the expected one; desrialization is not attempted
+  *   - a [[DeserializationException]], when there's an error during deserialization
+  *
+  * @tparam HE
+  *   The type of the body to which the response is read, when the resposne code is different than the expected one
+  * @tparam DE
+  *   A deserialization-library-specific error type, describing the deserialization error in more detail
+  */
 sealed abstract class ResponseException[+HE, +DE](error: String) extends Exception(error)
 case class HttpError[+HE](body: HE, statusCode: StatusCode)
     extends ResponseException[HE, Nothing](s"statusCode: $statusCode, response: $body")

--- a/core/src/main/scala/sttp/client4/SttpApi.scala
+++ b/core/src/main/scala/sttp/client4/SttpApi.scala
@@ -97,10 +97,10 @@ trait SttpApi extends SttpExtensions with UriInterpolator {
     * effect. Use the `utf-8` charset by default, unless specified otherwise in the response headers.
     *
     * @see
-    *   the [[ResponseAs.orFail]] method can be used to convert any response description which returns an `Either` into
+    *   the [[ResponseAs#orFail]] method can be used to convert any response description which returns an `Either` into
     *   an exception-throwing variant.
     */
-  def asStringOrFail: ResponseAs[String] = asString.orFail
+  def asStringOrFail: ResponseAs[String] = asString.orFail.showAs("as string or fail")
 
   /** Reads the response as either a string (for non-2xx responses), or otherwise as an array of bytes (without any
     * processing). The entire response is loaded into memory.
@@ -116,10 +116,10 @@ trait SttpApi extends SttpExtensions with UriInterpolator {
     * [[HttpError]] / returns a failed effect.
     *
     * @see
-    *   the [[ResponseAs.orFail]] method can be used to convert any response description which returns an `Either` into
+    *   the [[ResponseAs#orFail]] method can be used to convert any response description which returns an `Either` into
     *   an exception-throwing variant.
     */
-  def asByteArrayOrFail: ResponseAs[Array[Byte]] = asByteArray.orFail
+  def asByteArrayOrFail: ResponseAs[Array[Byte]] = asByteArray.orFail.showAs("as byte array or fail")
 
   /** Deserializes the response as either a string (for non-2xx responses), or otherwise as form parameters. Uses the
     * `utf-8` charset by default, unless specified otherwise in the response headers.
@@ -149,10 +149,10 @@ trait SttpApi extends SttpExtensions with UriInterpolator {
     * returns a failed effect. Uses the `utf-8` charset by default, unless specified otherwise in the response headers.
     *
     * @see
-    *   the [[ResponseAs.orFail]] method can be used to convert any response description which returns an `Either` into
+    *   the [[ResponseAs#orFail]] method can be used to convert any response description which returns an `Either` into
     *   an exception-throwing variant.
     */
-  def asParamsOrFail: ResponseAs[String] = asString.orFail
+  def asParamsOrFail: ResponseAs[String] = asString.orFail.showAs("as params or fail")
 
   private[client4] def asSttpFile(file: SttpFile): ResponseAs[SttpFile] = ResponseAs(ResponseAsFile(file))
 
@@ -287,12 +287,12 @@ trait SttpApi extends SttpExtensions with UriInterpolator {
     * A non-blocking, asynchronous streaming implementation must be provided as the [[Streams]] parameter.
     *
     * @see
-    *   the [[ResponseAs.orFail]] method can be used to convert any response description which returns an `Either` into
+    *   the [[ResponseAs#orFail]] method can be used to convert any response description which returns an `Either` into
     *   an exception-throwing variant.
     */
   def asStreamOrFail[F[_], T, S](s: Streams[S])(
       f: s.BinaryStream => F[T]
-  ): StreamResponseAs[T, S with Effect[F]] = asStream(s)(f).orFail
+  ): StreamResponseAs[T, S with Effect[F]] = asStream(s)(f).orFail.showAs("as stream or fail")
 
   /** Handles the response body by either reading a string (for non-2xx responses), or otherwise providing a stream with
     * the response's data, along with the response metadata, to `f`. The effect type used by `f` must be compatible with

--- a/core/src/main/scala/sttp/client4/SttpApi.scala
+++ b/core/src/main/scala/sttp/client4/SttpApi.scala
@@ -53,8 +53,10 @@ trait SttpApi extends SttpExtensions with UriInterpolator {
   val basicRequest: PartialRequest[Either[String, String]] =
     emptyRequest.acceptEncoding("gzip, deflate")
 
-  /** A starting request which always reads the response body as a string, regardless of the status code. */
-  val quickRequest: PartialRequest[String] = basicRequest.response(asStringAlways)
+  /** A starting request which always reads the response body as a string, if the response code is successfull (2xx),
+    * and fails (throws an exception, or returns a failed effect) otherwise.
+    */
+  val quickRequest: PartialRequest[String] = basicRequest.response(asStringOrFail)
 
   // response descriptions
 

--- a/core/src/main/scala/sttp/client4/SttpApi.scala
+++ b/core/src/main/scala/sttp/client4/SttpApi.scala
@@ -38,11 +38,17 @@ trait SttpApi extends SttpExtensions with UriInterpolator {
       AttributeMap.Empty
     )
 
-  /** A starting request, with the following modification comparing to [[emptyRequest]]: `Accept-Encoding` is set to
-    * `gzip, deflate` (compression/decompression is handled automatically by the library).
+  /** A starting request, with the `Accept-Encoding` header set to `gzip, deflate` (compression/decompression is handled
+    * automatically by the library).
     *
     * Reads the response body as an `Either[String, String]`, where `Left` is used if the status code is non-2xx, and
     * `Right` otherwise.
+    *
+    * @see
+    *   [[emptyRequest]] for a starting request which has no headers set
+    * @see
+    *   [[quickRequest]] for a starting request which always reads the response body as a [[String]], without the
+    *   [[Either]] wrapper
     */
   val basicRequest: PartialRequest[Either[String, String]] =
     emptyRequest.acceptEncoding("gzip, deflate")
@@ -50,17 +56,24 @@ trait SttpApi extends SttpExtensions with UriInterpolator {
   /** A starting request which always reads the response body as a string, regardless of the status code. */
   val quickRequest: PartialRequest[String] = basicRequest.response(asStringAlways)
 
-  // response specifications
+  // response descriptions
 
+  /** Ignores (discards) the response. */
   def ignore: ResponseAs[Unit] = ResponseAs(IgnoreResponse)
 
-  /** Use the `utf-8` charset by default, unless specified otherwise in the response headers. */
+  /** Reads the response as an `Either[String, String]`, where `Left` is used if the status code is non-2xx, and `Right`
+    * otherwise. Uses the `utf-8` charset by default, unless specified otherwise in the response headers.
+    */
   def asString: ResponseAs[Either[String, String]] = asString(Utf8)
 
-  /** Use the `utf-8` charset by default, unless specified otherwise in the response headers. */
+  /** Reads the response as a `String`, regardless of the status code. Use the `utf-8` charset by default, unless
+    * specified otherwise in the response headers.
+    */
   def asStringAlways: ResponseAs[String] = asStringAlways(Utf8)
 
-  /** Use the given charset by default, unless specified otherwise in the response headers. */
+  /** Reads the response as an `Either[String, String]`, where `Left` is used if the status code is non-2xx, and `Right`
+    * otherwise. Uses the given charset by default, unless specified otherwise in the response headers.
+    */
   def asString(charset: String): ResponseAs[Either[String, String]] =
     asStringAlways(charset)
       .mapWithMetadata { (s, m) =>
@@ -68,6 +81,9 @@ trait SttpApi extends SttpExtensions with UriInterpolator {
       }
       .showAs("either(as string, as string)")
 
+  /** Reads the response as a `String`, regardless of the status code. Uses the given charset by default, unless
+    * specified otherwise in the response headers.
+    */
   def asStringAlways(charset: String): ResponseAs[String] =
     asByteArrayAlways
       .mapWithMetadata { (bytes, metadata) =>
@@ -77,21 +93,35 @@ trait SttpApi extends SttpExtensions with UriInterpolator {
       }
       .showAs("as string")
 
+  /** Reads the response as either a string (for non-2xx responses), or othweise as an array of bytes (without any
+    * processing). The entire response is loaded into memory.
+    */
   def asByteArray: ResponseAs[Either[String, Array[Byte]]] = asEither(asStringAlways, asByteArrayAlways)
 
+  /** Reads the response as an array of bytes, without any processing, regardless of the status code. The entire
+    * response is loaded into memory.
+    */
   def asByteArrayAlways: ResponseAs[Array[Byte]] = ResponseAs(ResponseAsByteArray)
 
-  /** Use the `utf-8` charset by default, unless specified otherwise in the response headers. */
+  /** Deserializes the response as either a string (for non-2xx responses), or otherwise as form parameters. Uses the
+    * `utf-8` charset by default, unless specified otherwise in the response headers.
+    */
   def asParams: ResponseAs[Either[String, Seq[(String, String)]]] = asParams(Utf8)
 
-  /** Use the `utf-8` charset by default, unless specified otherwise in the response headers. */
+  /** Deserializes the response as form parameters, regardless of the status code. Uses the `utf-8` charset by default,
+    * unless specified otherwise in the response headers.
+    */
   def asParamsAlways: ResponseAs[Seq[(String, String)]] = asParamsAlways(Utf8)
 
-  /** Use the given charset by default, unless specified otherwise in the response headers. */
+  /** Deserializes the response as either a string (for non-2xx responses), or otherwise as form parameters. Uses the
+    * given charset by default, unless specified otherwise in the response headers.
+    */
   def asParams(charset: String): ResponseAs[Either[String, Seq[(String, String)]]] =
     asEither(asStringAlways, asParamsAlways(charset)).showAs("either(as string, as params)")
 
-  /** Use the given charset by default, unless specified otherwise in the response headers. */
+  /** Deserializes the response as form parameters, regardless of the status code. Uses the given charset by default,
+    * unless specified otherwise in the response headers.
+    */
   def asParamsAlways(charset: String): ResponseAs[Seq[(String, String)]] = {
     val charset2 = sanitizeCharset(charset)
     asStringAlways(charset2).map(GenericResponseAs.parseParams(_, charset2)).showAs("as params")
@@ -99,17 +129,21 @@ trait SttpApi extends SttpExtensions with UriInterpolator {
 
   private[client4] def asSttpFile(file: SttpFile): ResponseAs[SttpFile] = ResponseAs(ResponseAsFile(file))
 
+  /** Uses the [[ResponseAs]] description that matches the condition (using the response's metadata).
+    *
+    * This allows using different response description basing on the status code, for example. If none of the conditions
+    * match, the default response handling description is used.
+    */
   def fromMetadata[T](default: ResponseAs[T], conditions: ConditionalResponseAs[ResponseAs[T]]*): ResponseAs[T] =
     ResponseAs(ResponseAsFromMetadata(conditions.map(_.map(_.delegate)).toList, default.delegate))
 
-  /** Uses the `onSuccess` response specification for successful responses (2xx), and the `onError` specification
-    * otherwise.
+  /** Uses the `onSuccess` response description for successful responses (2xx), and the `onError` description otherwise.
     */
   def asEither[A, B](onError: ResponseAs[A], onSuccess: ResponseAs[B]): ResponseAs[Either[A, B]] =
     fromMetadata(onError.map(Left(_)), ConditionalResponseAs(_.isSuccess, onSuccess.map(Right(_))))
       .showAs(s"either(${onError.show}, ${onSuccess.show})")
 
-  /** Use both `l` and `r` to read the response body. Neither response specifications may use streaming or web sockets.
+  /** Uses both `l` and `r` to handle the response body. Neither response descriptions may use streaming or web sockets.
     */
   def asBoth[A, B](l: ResponseAs[A], r: ResponseAs[B]): ResponseAs[(A, B)] =
     asBothOption(l, r)
@@ -119,8 +153,8 @@ trait SttpApi extends SttpExtensions with UriInterpolator {
       }
       .showAs(s"(${l.show}, ${r.show})")
 
-  /** Use `l` to read the response body. If the raw body value which is used by `l` is replayable (a file or byte
-    * array), also use `r` to read the response body. Otherwise ignore `r` (if the raw body is a stream).
+  /** Uses `l` to handle the response body. If the raw body value which is used by `l` is replayable (a file or byte
+    * array), also uses `r` to read the response body. Otherwise ignores `r` (if the raw body is a stream).
     */
   def asBothOption[A, B](l: ResponseAs[A], r: ResponseAs[B]): ResponseAs[(A, Option[B])] =
     ResponseAs(ResponseAsBoth(l.delegate, r.delegate))
@@ -208,44 +242,81 @@ trait SttpApi extends SttpExtensions with UriInterpolator {
 
   // stream response specifications
 
+  /** Handles the response body by either reading a string (for non-2xx responses), or otherwise providing a stream with
+    * the response's data to `f`. The stream is always closed after `f` completes.
+    *
+    * A non-blocking, asynchronous streaming implementation must be provided as the [[Streams]] parameter.
+    */
   def asStream[F[_], T, S](s: Streams[S])(
       f: s.BinaryStream => F[T]
   ): StreamResponseAs[Either[String, T], S with Effect[F]] =
     asEither(asStringAlways, asStreamAlways(s)(f))
 
+  /** Handles the response body by either reading a string (for non-2xx responses), or otherwise providing a stream with
+    * the response's data, along with the response metadata, to `f`. The stream is always closed after `f` completes.
+    *
+    * A non-blocking, asynchronous streaming implementation must be provided as the [[Streams]] parameter.
+    */
   def asStreamWithMetadata[F[_], T, S](s: Streams[S])(
       f: (s.BinaryStream, ResponseMetadata) => F[T]
   ): StreamResponseAs[Either[String, T], S with Effect[F]] =
     asEither(asStringAlways, asStreamAlwaysWithMetadata(s)(f))
 
+  /** Handles the response body by providing a stream with the response's data to `f`, regardless of the status code.
+    * The stream is always closed after `f` completes.
+    *
+    * A non-blocking, asynchronous streaming implementation must be provided as the [[Streams]] parameter.
+    */
   def asStreamAlways[F[_], T, S](s: Streams[S])(f: s.BinaryStream => F[T]): StreamResponseAs[T, S with Effect[F]] =
     asStreamAlwaysWithMetadata(s)((s, _) => f(s))
 
+  /** Handles the response body by providing a stream with the response's data, along with the response metadata, to
+    * `f`, regardless of the status code. The stream is always closed after `f` completes.
+    *
+    * A non-blocking, asynchronous streaming implementation must be provided as the [[Streams]] parameter.
+    */
   def asStreamAlwaysWithMetadata[F[_], T, S](s: Streams[S])(
       f: (s.BinaryStream, ResponseMetadata) => F[T]
   ): StreamResponseAs[T, S with Effect[F]] = StreamResponseAs(ResponseAsStream(s)(f))
 
+  /** Handles the response body by either reading a string (for non-2xx responses), or otherwise returning a stream with
+    * the response's data. It's the responsibility of the caller to consume & close the stream.
+    *
+    * A non-blocking, asynchronous streaming implementation must be provided as the [[Streams]] parameter.
+    */
   def asStreamUnsafe[S](s: Streams[S]): StreamResponseAs[Either[String, s.BinaryStream], S] =
     asEither(asStringAlways, asStreamAlwaysUnsafe(s))
 
+  /** Handles the response body by returning a stream with the response's data, regardless of the status code. It's the
+    * responsibility of the caller to consume & close the stream.
+    *
+    * A non-blocking, asynchronous streaming implementation must be provided as the [[Streams]] parameter.
+    */
   def asStreamAlwaysUnsafe[S](s: Streams[S]): StreamResponseAs[s.BinaryStream, S] =
     StreamResponseAs(ResponseAsStreamUnsafe(s))
 
+  /** Uses the [[StreamResponseAs]] description that matches the condition (using the response's metadata). The
+    * conditional response descriptions might include handling the response as a non-blocking, asynchronous stream.
+    *
+    * This allows using different response description basing on the status code, for example. If none of the conditions
+    * match, the default response handling description is used.
+    */
   def fromMetadata[T, S](
       default: ResponseAs[T],
       conditions: ConditionalResponseAs[StreamResponseAs[T, S]]*
   ): StreamResponseAs[T, S] =
     StreamResponseAs[T, S](ResponseAsFromMetadata(conditions.map(_.map(_.delegate)).toList, default.delegate))
 
-  /** Uses the `onSuccess` response specification for successful responses (2xx), and the `onError` specification
-    * otherwise.
+  /** Uses the `onSuccess` response description for successful responses (2xx), and the `onError` description otherwise.
+    *
+    * The sucessful response description might include handling the response as a non-blocking, asynchronous stream.
     */
   def asEither[A, B, S](onError: ResponseAs[A], onSuccess: StreamResponseAs[B, S]): StreamResponseAs[Either[A, B], S] =
     fromMetadata[Either[A, B], S](onError.map(Left(_)), ConditionalResponseAs(_.isSuccess, onSuccess.map(Right(_))))
       .showAs(s"either(${onError.show}, ${onSuccess.show})")
 
-  /** Use `l` to read the response body. If the raw body value which is used by `l` is replayable (a file or byte
-    * array), also use `r` to read the response body. Otherwise ignore `r` (if the raw body is a stream).
+  /** Uses `l` to handle the response body. If the raw body value which is used by `l` is replayable (a file or byte
+    * array), also uses `r` to read the response body. Otherwise ignores `r` (if the raw body is a stream).
     */
   def asBothOption[A, B, S](l: StreamResponseAs[A, S], r: ResponseAs[B]): StreamResponseAs[(A, Option[B]), S] =
     StreamResponseAs[(A, Option[B]), S](ResponseAsBoth(l.delegate, r.delegate))

--- a/core/src/main/scala/sttp/client4/SttpWebSocketAsyncApi.scala
+++ b/core/src/main/scala/sttp/client4/SttpWebSocketAsyncApi.scala
@@ -4,34 +4,90 @@ import sttp.model.ResponseMetadata
 import sttp.ws.WebSocket
 
 trait SttpWebSocketAsyncApi {
+
+  /** Handles the response body by either reading a string (for non-2xx responses), or otherwise providing an open
+    * [[WebSocket]] instance to the `f` function.
+    *
+    * The effect type used by `f` must be compatible with the effect type of the backend. The web socket is always
+    * closed after `f` completes.
+    */
   def asWebSocket[F[_], T](f: WebSocket[F] => F[T]): WebSocketResponseAs[F, Either[String, T]] =
     asWebSocketEither(asStringAlways, asWebSocketAlways(f))
 
+  /** Handles the response as a web socket, providing an open [[WebSocket]] instance to the `f` function, if the status
+    * code is 2xx. Otherwise, returns a failed effect (with [[HttpError]]).
+    *
+    * The effect type used by `f` must be compatible with the effect type of the backend. The web socket is always
+    * closed after `f` completes.
+    *
+    * @see
+    *   the [[ResponseAs.orFail]] method can be used to convert any response description which returns an `Either` into
+    *   an exception-throwing variant.
+    */
+  def asWebSocketOrFail[F[_], T](f: WebSocket[F] => F[T]): WebSocketResponseAs[F, T] = asWebSocket(f).orFail
+
+  /** Handles the response body by either reading a string (for non-2xx responses), or otherwise providing an open
+    * [[WebSocket]] instance, along with the response metadata, to the `f` function.
+    *
+    * The effect type used by `f` must be compatible with the effect type of the backend. The web socket is always
+    * closed after `f` completes.
+    */
   def asWebSocketWithMetadata[F[_], T](
       f: (WebSocket[F], ResponseMetadata) => F[T]
   ): WebSocketResponseAs[F, Either[String, T]] =
     asWebSocketEither(asStringAlways, asWebSocketAlwaysWithMetadata(f))
 
+  /** Handles the response body by providing an open [[WebSocket]] instance to the `f` function, regardless of the
+    * status code.
+    *
+    * The effect type used by `f` must be compatible with the effect type of the backend. The web socket is always
+    * closed after `f` completes.
+    */
   def asWebSocketAlways[F[_], T](f: WebSocket[F] => F[T]): WebSocketResponseAs[F, T] =
     asWebSocketAlwaysWithMetadata((w, _) => f(w))
 
+  /** Handles the response body by providing an open [[WebSocket]] instance to the `f` function, along with the response
+    * metadata, regardless of the status code.
+    *
+    * The effect type used by `f` must be compatible with the effect type of the backend. The web socket is always
+    * closed after `f` completes.
+    */
   def asWebSocketAlwaysWithMetadata[F[_], T](f: (WebSocket[F], ResponseMetadata) => F[T]): WebSocketResponseAs[F, T] =
     WebSocketResponseAs(ResponseAsWebSocket(f))
 
+  /** Handles the response body by either reading a string (for non-2xx responses), or otherwise returning an open
+    * [[WebSocket]] instance. It is the responsibility of the caller to consume & close the web socket.
+    *
+    * The effect type `F` must be compatible with the effect type of the backend.
+    */
   def asWebSocketUnsafe[F[_]]: WebSocketResponseAs[F, Either[String, WebSocket[F]]] =
     asWebSocketEither(asStringAlways, asWebSocketAlwaysUnsafe)
 
+  /** Handles the response body by returning an open [[WebSocket]] instance, regardless of the status code. It is the
+    * responsibility of the caller to consume & close the web socket.
+    *
+    * The effect type `F` must be compatible with the effect type of the backend.
+    */
   def asWebSocketAlwaysUnsafe[F[_]]: WebSocketResponseAs[F, WebSocket[F]] =
     WebSocketResponseAs(ResponseAsWebSocketUnsafe())
 
+  /** Uses the [[ResponseAs]] description that matches the condition (using the response's metadata).
+    *
+    * This allows using different response description basing on the status code, for example. If none of the conditions
+    * match, the default response handling description is used.
+    *
+    * The effect type `F` must be compatible with the effect type of the backend.
+    */
   def fromMetadata[F[_], T](
       default: ResponseAs[T],
       conditions: ConditionalResponseAs[WebSocketResponseAs[F, T]]*
   ): WebSocketResponseAs[F, T] =
     WebSocketResponseAs(ResponseAsFromMetadata(conditions.map(_.map(_.delegate)).toList, default.delegate))
 
-  /** Uses the `onSuccess` response specification for 101 responses (switching protocols) on JVM/Native, 200 responses
-    * on JS. Otherwise, use the `onError` specification.
+  /** Uses the `onSuccess` response description for 101 responses (switching protocols) on JVM/Native, 200 responses on
+    * JS. Otherwise, use the `onError` description.
+    *
+    * The effect type `F` must be compatible with the effect type of the backend.
     */
   def asWebSocketEither[F[_], A, B](
       onError: ResponseAs[A],

--- a/core/src/main/scala/sttp/client4/SttpWebSocketAsyncApi.scala
+++ b/core/src/main/scala/sttp/client4/SttpWebSocketAsyncApi.scala
@@ -21,10 +21,11 @@ trait SttpWebSocketAsyncApi {
     * closed after `f` completes.
     *
     * @see
-    *   the [[ResponseAs.orFail]] method can be used to convert any response description which returns an `Either` into
+    *   the [[ResponseAs#orFail]] method can be used to convert any response description which returns an `Either` into
     *   an exception-throwing variant.
     */
-  def asWebSocketOrFail[F[_], T](f: WebSocket[F] => F[T]): WebSocketResponseAs[F, T] = asWebSocket(f).orFail
+  def asWebSocketOrFail[F[_], T](f: WebSocket[F] => F[T]): WebSocketResponseAs[F, T] =
+    asWebSocket(f).orFail.showAs("as web socket or fail")
 
   /** Handles the response body by either reading a string (for non-2xx responses), or otherwise providing an open
     * [[WebSocket]] instance, along with the response metadata, to the `f` function.

--- a/core/src/main/scala/sttp/client4/SttpWebSocketStreamApi.scala
+++ b/core/src/main/scala/sttp/client4/SttpWebSocketStreamApi.scala
@@ -5,15 +5,53 @@ import sttp.model.StatusCode
 import sttp.ws.WebSocketFrame
 
 trait SttpWebSocketStreamApi {
+
+  /** Handles the response body by either reading a string (for non-2xx responses), or otherwise using the given `p`
+    * stream processing pipe to handle the incoming & produce the outgoing web socket frames.
+    *
+    * The web socket is always closed after `p` completes.
+    *
+    * A non-blocking, asynchronous streaming implementation must be provided as the [[Streams]] parameter.
+    */
   def asWebSocketStream[S](
       s: Streams[S]
   )(p: s.Pipe[WebSocketFrame.Data[_], WebSocketFrame]): WebSocketStreamResponseAs[Either[String, Unit], S] =
     asWebSocketEither(asStringAlways, asWebSocketStreamAlways(s)(p))
 
+  /** Handles the response as a web socket, using the given `p` stream processing pipe to handle the incoming & produce
+    * the outgoing web socket frames, if the status code is 2xx. Otherwise, returns a failed effect (with
+    * [[HttpError]]).
+    *
+    * The effect type used by `f` must be compatible with the effect type of the backend. The web socket is always
+    * closed after `p` completes.
+    *
+    * A non-blocking, asynchronous streaming implementation must be provided as the [[Streams]] parameter.
+    *
+    * @see
+    *   the [[ResponseAs.orFail]] method can be used to convert any response description which returns an `Either` into
+    *   an exception-throwing variant.
+    */
+  def asWebSocketStreamOrFail[S](
+      s: Streams[S]
+  )(p: s.Pipe[WebSocketFrame.Data[_], WebSocketFrame]): WebSocketStreamResponseAs[Unit, S] =
+    asWebSocketStream(s)(p).orFail
+
+  /** Handles the response body by using the given `p` stream processing pipe to handle the incoming & produce the
+    * outgoing web socket frames, regardless of the status code.
+    *
+    * The web socket is always closed after `p` completes.
+    *
+    * A non-blocking, asynchronous streaming implementation must be provided as the [[Streams]] parameter.
+    */
   def asWebSocketStreamAlways[S](s: Streams[S])(
       p: s.Pipe[WebSocketFrame.Data[_], WebSocketFrame]
   ): WebSocketStreamResponseAs[Unit, S] = WebSocketStreamResponseAs[Unit, S](ResponseAsWebSocketStream(s, p))
 
+  /** Uses the [[ResponseAs]] description that matches the condition (using the response's metadata).
+    *
+    * This allows using different response description basing on the status code, for example. If none of the conditions
+    * match, the default response handling description is used.
+    */
   def fromMetadata[T, S](
       default: ResponseAs[T],
       conditions: ConditionalResponseAs[WebSocketStreamResponseAs[T, S]]*
@@ -22,8 +60,8 @@ trait SttpWebSocketStreamApi {
       ResponseAsFromMetadata(conditions.map(_.map(_.delegate)).toList, default.delegate)
     )
 
-  /** Uses the `onSuccess` response specification for 101 responses (switching protocols), and the `onError`
-    * specification otherwise.
+  /** Uses the `onSuccess` response description for 101 responses (switching protocols) on JVM/Native, 200 responses on
+    * JS. Otherwise, use the `onError` description.
     */
   def asWebSocketEither[A, B, S](
       onError: ResponseAs[A],

--- a/core/src/main/scala/sttp/client4/SttpWebSocketStreamApi.scala
+++ b/core/src/main/scala/sttp/client4/SttpWebSocketStreamApi.scala
@@ -28,13 +28,13 @@ trait SttpWebSocketStreamApi {
     * A non-blocking, asynchronous streaming implementation must be provided as the [[Streams]] parameter.
     *
     * @see
-    *   the [[ResponseAs.orFail]] method can be used to convert any response description which returns an `Either` into
+    *   the [[ResponseAs#orFail]] method can be used to convert any response description which returns an `Either` into
     *   an exception-throwing variant.
     */
   def asWebSocketStreamOrFail[S](
       s: Streams[S]
   )(p: s.Pipe[WebSocketFrame.Data[_], WebSocketFrame]): WebSocketStreamResponseAs[Unit, S] =
-    asWebSocketStream(s)(p).orFail
+    asWebSocketStream(s)(p).orFail.showAs("as web socket stream or fail")
 
   /** Handles the response body by using the given `p` stream processing pipe to handle the incoming & produce the
     * outgoing web socket frames, regardless of the status code.

--- a/core/src/main/scala/sttp/client4/SttpWebSocketSyncApi.scala
+++ b/core/src/main/scala/sttp/client4/SttpWebSocketSyncApi.scala
@@ -6,36 +6,79 @@ import sttp.shared.Identity
 import sttp.ws.WebSocket
 
 trait SttpWebSocketSyncApi {
+
+  /** Handles the response body by either reading a string (for non-2xx responses), or otherwise providing an open
+    * [[WebSocket]] instance to the `f` function.
+    *
+    * The web socket is always closed after `f` completes.
+    */
   def asWebSocket[T](f: SyncWebSocket => T): WebSocketResponseAs[Identity, Either[String, T]] =
     asWebSocketEither(asStringAlways, asWebSocketAlways(f))
 
+  /** Handles the response as a web socket, providing an open [[WebSocket]] instance to the `f` function, if the status
+    * code is 2xx. Otherwise, throws an [[HttpError]].
+    *
+    * The web socket is always closed after `f` completes.
+    *
+    * @see
+    *   the [[ResponseAs.orFail]] method can be used to convert any response description which returns an `Either` into
+    *   an exception-throwing variant.
+    */
+  def asWebSocketOrFail[T](f: SyncWebSocket => T): WebSocketResponseAs[Identity, T] = asWebSocket(f).orFail
+
+  /** Handles the response body by either reading a string (for non-2xx responses), or otherwise providing an open
+    * [[WebSocket]] instance, along with the response metadata, to the `f` function.
+    *
+    * The web socket is always closed after `f` completes.
+    */
   def asWebSocketWithMetadata[T](
       f: (SyncWebSocket, ResponseMetadata) => T
   ): WebSocketResponseAs[Identity, Either[String, T]] =
     asWebSocketEither(asStringAlways, asWebSocketAlwaysWithMetadata(f))
 
+  /** Handles the response body by providing an open [[WebSocket]] instance to the `f` function, regardless of the
+    * status code.
+    *
+    * The web socket is always closed after `f` completes.
+    */
   def asWebSocketAlways[T](f: SyncWebSocket => T): WebSocketResponseAs[Identity, T] =
     asWebSocketAlwaysWithMetadata((w, _) => f(w))
 
+  /** Handles the response body by providing an open [[WebSocket]] instance to the `f` function, along with the response
+    * metadata, regardless of the status code.
+    *
+    * The web socket is always closed after `f` completes.
+    */
   def asWebSocketAlwaysWithMetadata[T](
       f: (SyncWebSocket, ResponseMetadata) => T
   ): WebSocketResponseAs[Identity, T] =
     WebSocketResponseAs[Identity, T](ResponseAsWebSocket[Identity, T]((ws, m) => f(new SyncWebSocket(ws), m)))
 
+  /** Handles the response body by either reading a string (for non-2xx responses), or otherwise returning an open
+    * [[WebSocket]] instance. It is the responsibility of the caller to consume & close the web socket.
+    */
   def asWebSocketUnsafe: WebSocketResponseAs[Identity, Either[String, SyncWebSocket]] =
     asWebSocketEither(asStringAlways, asWebSocketAlwaysUnsafe)
 
+  /** Handles the response body by returning an open [[WebSocket]] instance, regardless of the status code. It is the
+    * responsibility of the caller to consume & close the web socket.
+    */
   def asWebSocketAlwaysUnsafe: WebSocketResponseAs[Identity, SyncWebSocket] =
     WebSocketResponseAs[Identity, WebSocket[Identity]](ResponseAsWebSocketUnsafe()).map(new SyncWebSocket(_))
 
+  /** Uses the [[ResponseAs]] description that matches the condition (using the response's metadata).
+    *
+    * This allows using different response description basing on the status code, for example. If none of the conditions
+    * match, the default response handling description is used.
+    */
   def fromMetadata[T](
       default: ResponseAs[T],
       conditions: ConditionalResponseAs[WebSocketResponseAs[Identity, T]]*
   ): WebSocketResponseAs[Identity, T] =
     WebSocketResponseAs(ResponseAsFromMetadata(conditions.map(_.map(_.delegate)).toList, default.delegate))
 
-  /** Uses the `onSuccess` response specification for 101 responses (switching protocols) on JVM/Native, 200 responses
-    * on JS. Otherwise, use the `onError` specification.
+  /** Uses the `onSuccess` response description for 101 responses (switching protocols) on JVM/Native, 200 responses on
+    * JS. Otherwise, use the `onError` description.
     */
   def asWebSocketEither[A, B](
       onError: ResponseAs[A],

--- a/core/src/main/scala/sttp/client4/SttpWebSocketSyncApi.scala
+++ b/core/src/main/scala/sttp/client4/SttpWebSocketSyncApi.scala
@@ -21,10 +21,11 @@ trait SttpWebSocketSyncApi {
     * The web socket is always closed after `f` completes.
     *
     * @see
-    *   the [[ResponseAs.orFail]] method can be used to convert any response description which returns an `Either` into
+    *   the [[ResponseAs#orFail]] method can be used to convert any response description which returns an `Either` into
     *   an exception-throwing variant.
     */
-  def asWebSocketOrFail[T](f: SyncWebSocket => T): WebSocketResponseAs[Identity, T] = asWebSocket(f).orFail
+  def asWebSocketOrFail[T](f: SyncWebSocket => T): WebSocketResponseAs[Identity, T] =
+    asWebSocket(f).orFail.showAs("as web socket or fail")
 
   /** Handles the response body by either reading a string (for non-2xx responses), or otherwise providing an open
     * [[WebSocket]] instance, along with the response metadata, to the `f` function.

--- a/core/src/main/scala/sttp/client4/request.scala
+++ b/core/src/main/scala/sttp/client4/request.scala
@@ -28,6 +28,7 @@ import sttp.attributes.AttributeMap
 trait GenericRequest[+T, -R] extends RequestBuilder[GenericRequest[T, R]] with RequestMetadata {
   def body: GenericRequestBody[R]
   def response: ResponseAsDelegate[T, R]
+
   def mapResponse[T2](f: T => T2): GenericRequest[T2, R]
 
   def toCurl: String = ToCurlConverter(this)
@@ -166,19 +167,6 @@ case class Request[T](
     * unchanged.
     */
   def send(backend: SyncBackend): Response[T] = backend.send(this)
-}
-
-object Request {
-  implicit class RichRequestTEither[A, B](r: Request[Either[A, B]]) {
-    def mapResponseRight[B2](f: B => B2): Request[Either[A, B2]] = r.copy(response = r.response.mapRight(f))
-    def responseGetRight: Request[B] = r.copy(response = r.response.orFail)
-  }
-
-  implicit class RichRequestTEitherResponseException[HE, DE, B](
-      r: Request[Either[ResponseException[HE, DE], B]]
-  ) {
-    def responseGetEither: Request[Either[HE, B]] = r.copy(response = r.response.orFailDeserialization)
-  }
 }
 
 //

--- a/core/src/main/scala/sttp/client4/request.scala
+++ b/core/src/main/scala/sttp/client4/request.scala
@@ -171,13 +171,13 @@ case class Request[T](
 object Request {
   implicit class RichRequestTEither[A, B](r: Request[Either[A, B]]) {
     def mapResponseRight[B2](f: B => B2): Request[Either[A, B2]] = r.copy(response = r.response.mapRight(f))
-    def responseGetRight: Request[B] = r.copy(response = r.response.getRight)
+    def responseGetRight: Request[B] = r.copy(response = r.response.orFail)
   }
 
   implicit class RichRequestTEitherResponseException[HE, DE, B](
       r: Request[Either[ResponseException[HE, DE], B]]
   ) {
-    def responseGetEither: Request[Either[HE, B]] = r.copy(response = r.response.getEither)
+    def responseGetEither: Request[Either[HE, B]] = r.copy(response = r.response.orFailDeserialization)
   }
 }
 

--- a/core/src/test/scala/sttp/client4/testing/BackendStubTests.scala
+++ b/core/src/test/scala/sttp/client4/testing/BackendStubTests.scala
@@ -144,8 +144,7 @@ class BackendStubTests extends AnyFlatSpec with Matchers with ScalaFutures {
 
     val result = basicRequest
       .get(uri"http://example.org")
-      .mapResponseRight(_.toInt)
-      .mapResponseRight(_ * 2)
+      .response(asString.mapRight((_: String).toInt).mapRight((_: Int) * 2))
       .send(backend)
 
     result.body should be(Right(20))

--- a/core/src/test/scala/sttp/client4/testing/BackendStubTests.scala
+++ b/core/src/test/scala/sttp/client4/testing/BackendStubTests.scala
@@ -144,7 +144,8 @@ class BackendStubTests extends AnyFlatSpec with Matchers with ScalaFutures {
 
     val result = basicRequest
       .get(uri"http://example.org")
-      .response(asString.mapRight((_: String).toInt).mapRight((_: Int) * 2))
+      .mapResponseRight(_.toInt)
+      .mapResponseRight(_ * 2)
       .send(backend)
 
     result.body should be(Right(20))

--- a/core/src/test/scala/sttp/client4/testing/BackendStubTests.scala
+++ b/core/src/test/scala/sttp/client4/testing/BackendStubTests.scala
@@ -60,7 +60,7 @@ class BackendStubTests extends AnyFlatSpec with Matchers with ScalaFutures {
     val backend = testingStub
     val r = basicRequest
       .get(uri"http://example.org/d?p=v")
-      .response(asString.mapRight(_.toInt))
+      .response(asString.mapRight((_: String).toInt))
       .send(backend)
     r.body should be(Right(10))
   }
@@ -253,7 +253,7 @@ class BackendStubTests extends AnyFlatSpec with Matchers with ScalaFutures {
     val backend = BackendStub.synchronous.whenAnyRequest.thenRespond("1234")
     basicRequest
       .get(uri"http://example.org")
-      .response(asBoth(asString.mapRight(_.toInt), asStringAlways))
+      .response(asBoth(asString.mapRight((_: String).toInt), asStringAlways))
       .send(backend)
       .body shouldBe ((Right(1234), "1234"))
   }
@@ -452,8 +452,8 @@ class BackendStubTests extends AnyFlatSpec with Matchers with ScalaFutures {
     (s.getBytes(Utf8), asString(Utf8), Some(Right(s))),
     (new ByteArrayInputStream(s.getBytes(Utf8)), asString(Utf8), Some(Right(s))),
     (10, asString(Utf8), None),
-    ("10", asString(Utf8).mapRight(_.toInt), Some(Right(10))),
-    (11, asString(Utf8).mapRight(_.toInt), None),
+    ("10", asString(Utf8).mapRight((_: String).toInt), Some(Right(10))),
+    (11, asString(Utf8).mapRight((_: String).toInt), None),
     ((), asString(Utf8), Some(Right("")))
   )
 

--- a/core/src/test/scala/sttp/client4/testing/BackendStubTests.scala
+++ b/core/src/test/scala/sttp/client4/testing/BackendStubTests.scala
@@ -144,8 +144,8 @@ class BackendStubTests extends AnyFlatSpec with Matchers with ScalaFutures {
 
     val result = basicRequest
       .get(uri"http://example.org")
-      .mapResponseRight(_.toInt)
-      .mapResponseRight(_ * 2)
+      .mapResponseRight((_: String).toInt)
+      .mapResponseRight((_: Int) * 2)
       .send(backend)
 
     result.body should be(Right(20))

--- a/core/src/test/scala/sttp/client4/testing/HttpTest.scala
+++ b/core/src/test/scala/sttp/client4/testing/HttpTest.scala
@@ -92,7 +92,7 @@ trait HttpTest[F[_]]
     "as string with mapping using mapResponse" in {
       postEcho
         .body(testBody)
-        .mapResponseRight(_.length)
+        .response(asString.mapRight((_: String).length))
         .send(backend)
         .toFuture()
         .map(response => response.body should be(Right(expectedPostEchoResponse.length)))
@@ -572,7 +572,7 @@ trait HttpTest[F[_]]
     }
 
     "redirect when redirects should be followed, and the response is parsed" in {
-      r2.response(asString).mapResponseRight(_.toInt).send(backend).toFuture().map { resp =>
+      r2.response(asString.mapRight((_: String).toInt)).send(backend).toFuture().map { resp =>
         resp.code shouldBe StatusCode.Ok
         resp.body shouldBe Right(r4response.toInt)
       }

--- a/core/src/test/scala/sttp/client4/testing/HttpTest.scala
+++ b/core/src/test/scala/sttp/client4/testing/HttpTest.scala
@@ -92,7 +92,7 @@ trait HttpTest[F[_]]
     "as string with mapping using mapResponse" in {
       postEcho
         .body(testBody)
-        .mapResponseRight(_.length)
+        .mapResponseRight((_: String).length)
         .send(backend)
         .toFuture()
         .map(response => response.body should be(Right(expectedPostEchoResponse.length)))
@@ -572,7 +572,7 @@ trait HttpTest[F[_]]
     }
 
     "redirect when redirects should be followed, and the response is parsed" in {
-      r2.response(asString).mapResponseRight(_.toInt).send(backend).toFuture().map { resp =>
+      r2.response(asString).mapResponseRight((_: String).toInt).send(backend).toFuture().map { resp =>
         resp.code shouldBe StatusCode.Ok
         resp.body shouldBe Right(r4response.toInt)
       }

--- a/core/src/test/scala/sttp/client4/testing/HttpTest.scala
+++ b/core/src/test/scala/sttp/client4/testing/HttpTest.scala
@@ -83,7 +83,7 @@ trait HttpTest[F[_]]
     "as string with mapping using map" in {
       postEcho
         .body(testBody)
-        .response(asString.mapRight(_.length))
+        .response(asString.mapRight((_: String).length))
         .send(backend)
         .toFuture()
         .map(response => response.body should be(Right(expectedPostEchoResponse.length)))
@@ -172,7 +172,7 @@ trait HttpTest[F[_]]
     "as both string and mapped string" in {
       postEcho
         .body(testBody)
-        .response(asBoth(asStringAlways, asByteArray.mapRight(_.length)))
+        .response(asBoth(asStringAlways, asByteArray.mapRight((_: Array[Byte]).length)))
         .send(backend)
         .toFuture()
         .map { response =>

--- a/core/src/test/scala/sttp/client4/testing/HttpTest.scala
+++ b/core/src/test/scala/sttp/client4/testing/HttpTest.scala
@@ -92,7 +92,7 @@ trait HttpTest[F[_]]
     "as string with mapping using mapResponse" in {
       postEcho
         .body(testBody)
-        .response(asString.mapRight((_: String).length))
+        .mapResponseRight(_.length)
         .send(backend)
         .toFuture()
         .map(response => response.body should be(Right(expectedPostEchoResponse.length)))
@@ -572,7 +572,7 @@ trait HttpTest[F[_]]
     }
 
     "redirect when redirects should be followed, and the response is parsed" in {
-      r2.response(asString.mapRight((_: String).toInt)).send(backend).toFuture().map { resp =>
+      r2.response(asString).mapResponseRight(_.toInt).send(backend).toFuture().map { resp =>
         resp.code shouldBe StatusCode.Ok
         resp.body shouldBe Right(r4response.toInt)
       }

--- a/core/src/test/scalanative/sttp/client4/testing/SyncHttpTest.scala
+++ b/core/src/test/scalanative/sttp/client4/testing/SyncHttpTest.scala
@@ -61,7 +61,7 @@ trait SyncHttpTest
     "as string with mapping using mapResponse" in {
       val response = postEcho
         .body(testBody)
-        .mapResponseRight(_.length)
+        .mapResponseRight((_: String).length)
         .send(backend)
       response.body should be(Right(expectedPostEchoResponse.length))
     }

--- a/core/src/test/scalanative/sttp/client4/testing/SyncHttpTest.scala
+++ b/core/src/test/scalanative/sttp/client4/testing/SyncHttpTest.scala
@@ -53,7 +53,7 @@ trait SyncHttpTest
     "as string with mapping using map" in {
       val response = postEcho
         .body(testBody)
-        .response(asString.mapRight(_.length))
+        .response(asString.mapRight((_: String).length))
         .send(backend)
       response.body should be(Right(expectedPostEchoResponse.length))
     }
@@ -119,7 +119,7 @@ trait SyncHttpTest
     "as both string and mapped string" in {
       val response = postEcho
         .body(testBody)
-        .response(asBoth(asStringAlways, asByteArray.mapRight(_.length)))
+        .response(asBoth(asStringAlways, asByteArray.mapRight((_: Array[Byte]).length)))
         .send(backend)
 
       response.body shouldBe ((expectedPostEchoResponse, Right(expectedPostEchoResponse.getBytes.length)))
@@ -367,7 +367,7 @@ trait SyncHttpTest
     }
 
     "redirect when redirects should be followed, and the response is parsed" in {
-      val resp = r2.response(asString.mapRight(_.toInt)).send(backend)
+      val resp = r2.response(asString.mapRight((_: String).toInt)).send(backend)
       resp.code shouldBe StatusCode.Ok
       resp.body should be(Right(r4response.toInt))
     }

--- a/core/src/test/scalanative/sttp/client4/testing/SyncHttpTest.scala
+++ b/core/src/test/scalanative/sttp/client4/testing/SyncHttpTest.scala
@@ -61,7 +61,7 @@ trait SyncHttpTest
     "as string with mapping using mapResponse" in {
       val response = postEcho
         .body(testBody)
-        .response(asString.mapRight((_: String).length))
+        .mapResponseRight(_.length)
         .send(backend)
       response.body should be(Right(expectedPostEchoResponse.length))
     }

--- a/core/src/test/scalanative/sttp/client4/testing/SyncHttpTest.scala
+++ b/core/src/test/scalanative/sttp/client4/testing/SyncHttpTest.scala
@@ -61,7 +61,7 @@ trait SyncHttpTest
     "as string with mapping using mapResponse" in {
       val response = postEcho
         .body(testBody)
-        .mapResponseRight(_.length)
+        .response(asString.mapRight((_: String).length))
         .send(backend)
       response.body should be(Right(expectedPostEchoResponse.length))
     }

--- a/docs/json.md
+++ b/docs/json.md
@@ -22,7 +22,7 @@ def asJsonAlways[B]: ResponseAs[Either[DeserializationException[Exception], B]] 
 def asJsonEither[E, B]: ResponseAs[Either[ResponseException[E, Exception], B]] = ???
 ```
 
-The response specifications can be further refined using `.getRight` and `.getEither`, see [response body specifications](responses/body.md).
+The response specifications can be further refined using `.orFail` and `.orFailDeserialization`, see [response body specifications](responses/body.md).
 
 Following data class will be used through the next few examples:
 

--- a/docs/json.md
+++ b/docs/json.md
@@ -7,7 +7,7 @@ Each integration is available as an import, which brings `asJson` methods into s
 The following variants of `asJson` methods are available:
 
 * `asJson(b: B)` - serializes the body so that it can be used as a request's body, e.g. using `basicRequest.body(asJson(myValue))`
-* `asJson[B]` - specifies that the body should be deserialized to json, but only if the response is successful (2xx); shoud be used to specify how a response should be handled, e.g. `basicRequest.response(asJson[T])`
+* `asJson[B]` - specifies that the body should be deserialized to json, but only if the response is successful (2xx); should be used to specify how a response should be handled, e.g. `basicRequest.response(asJson[T])`
 * `asJsonAlways[B]` - specifies that the body should be deserialized to json, regardless of the status code
 * `asJsonEither[E, B]` - specifies that the body should be deserialized to json, using different deserializers for error and successful (2xx) responses
 

--- a/docs/json.md
+++ b/docs/json.md
@@ -6,20 +6,27 @@ Each integration is available as an import, which brings `asJson` methods into s
 
 The following variants of `asJson` methods are available:
 
-* `asJson(b: B)` - serializes the body so that it can be used as a request's body, e.g. using `basicRequest.body(asJson(myValue))`
-* `asJson[B]` - specifies that the body should be deserialized to json, but only if the response is successful (2xx); should be used to specify how a response should be handled, e.g. `basicRequest.response(asJson[T])`
+* `asJson(b: B)` - to be used when specifying the body of a request: serializes the body so that it can be used as a request's body, e.g. using `basicRequest.body(asJson(myValue))`
+* `asJson[B]` - to be used when specifying how the response body should be handled: specifies that the body should be deserialized to json, but only if the response is successful (2xx); otherwise, a `Left` is returned, with body as a string
+* `asJsonOrFail[B]` - specifies that the body should be deserialized to json, if the response is successful (2xx); throws an exception/returns a failed effect if the response code is other than 2xx, or if deserialization fails
 * `asJsonAlways[B]` - specifies that the body should be deserialized to json, regardless of the status code
 * `asJsonEither[E, B]` - specifies that the body should be deserialized to json, using different deserializers for error and successful (2xx) responses
+* `asJsonEitherOrFail[E, B]` - specifies that the body should be deserialized to json, using different deserializers for error and successful (2xx) responses; throws an exception/returns a failed effect, if deserialization fails
 
 The type signatures vary depending on the underlying library (required implicits and error representation differs), but they obey the following pattern:
 
 ```scala mdoc:compile-only
 import sttp.client4._
 
+// request bodies
 def asJson[B](b: B): StringBody = ???
+
+// response handling description
 def asJson[B]: ResponseAs[Either[ResponseException[String, Exception], B]] = ???
+def asJsonOrFail[B]: ResponseAs[B] = ???
 def asJsonAlways[B]: ResponseAs[Either[DeserializationException[Exception], B]] = ???
 def asJsonEither[E, B]: ResponseAs[Either[ResponseException[E, Exception], B]] = ???
+def asJsonEitherOrFail[E, B]: ResponseAs[Either[E, B]] = ???
 ```
 
 The response specifications can be further refined using `.orFail` and `.orFailDeserialization`, see [response body specifications](responses/body.md).

--- a/docs/responses/basics.md
+++ b/docs/responses/basics.md
@@ -1,6 +1,6 @@
 # Responses
 
-Responses are represented as instances of the case class `Response[T]`, where `T` is the type of the response body. When sending a request, an effect containing the response will be returned. For example, for asynchronous backends, we can get a `Future[Response[T]]`, while for the default synchronous backend, the wrapper will be a no-op, `Identity`, which is the same as no wrapper at all.
+Responses are represented as instances of the case class `Response[T]`, where `T` is the type of the response body. When sending a request, the response might be return directly, or wrapped with an effect containing the response. For example, for asynchronous backends, we can get a `Future[Response[T]]`, while for the default synchronous backend, there's no wrapper at all.
 
 If sending the request fails, either due to client or connection errors, an exception will be thrown (synchronous backends), or a failed effect will be returned (e.g. a failed future).
 
@@ -50,5 +50,4 @@ If the cookies from a response should be set without changes on the request, thi
 
 ## Obtaining the response body
 
-The response body can be obtained through the `.body: T` property. `T` is the body deserialized as specified in the request description - see
-the next section on [response body specifications](body.md).
+The response body can be obtained through the `.body: T` property. `T` is the type of the body to which it's deserialized, as specified in the request description - see the next section on [response body specifications](body.md).

--- a/docs/responses/body.md
+++ b/docs/responses/body.md
@@ -79,12 +79,12 @@ basicRequest.response(asFile(someFile))
 
 ## Failing when the response code is not 2xx
 
-Sometimes it's convenient to get a failed effect (or an exception thrown) when the response status code is not successful. In such cases, the response specification can be modified using the `.getRight` combinator:
+Sometimes it's convenient to get a failed effect (or an exception thrown) when the response status code is not successful. In such cases, the response specification can be modified using the `.orFail` combinator:
 
 ```scala mdoc:compile-only
 import sttp.client4._
 
-basicRequest.response(asString.getRight): PartialRequest[String]
+basicRequest.response(asString.orFail): PartialRequest[String]
 ```
 
 The combinator works in all cases where the response body is specified to be deserialized as an `Either`. If the left is already an exception, it will be thrown unchanged. Otherwise, the left-value will be wrapped in an `HttpError`.
@@ -92,7 +92,7 @@ The combinator works in all cases where the response body is specified to be des
 ```eval_rst
 .. note::
 
- While both ``asStringAlways`` and ``asString.getRight`` have the type ``ResponseAs[String, Any]``, they are different. The first will return the response body as a string always, regardless of the responses' status code. The second will return a failed effect / throw a ``HttpError`` exception for non-2xx status codes, and the string as body only for 2xx status codes.
+ While both ``asStringAlways`` and ``asString.orFail`` have the type ``ResponseAs[String, Any]``, they are different. The first will return the response body as a string always, regardless of the responses' status code. The second will return a failed effect / throw a ``HttpError`` exception for non-2xx status codes, and the string as body only for 2xx status codes.
 ```
 
 There's also a variant of the combinator, `.getEither`, which can be used to extract typed errors and fail the effect if there's a deserialization error.

--- a/docs/responses/body.md
+++ b/docs/responses/body.md
@@ -110,7 +110,7 @@ As an example, to read the response body as an int, the following response descr
 ```scala mdoc:compile-only
 import sttp.client4._
 
-val asInt: ResponseAs[Either[String, Int]] = asString.mapRight(_.toInt)
+val asInt: ResponseAs[Either[String, Int]] = asString.mapRight((_: String).toInt)
 
 basicRequest
   .get(uri"http://example.com")

--- a/docs/responses/exceptions.md
+++ b/docs/responses/exceptions.md
@@ -28,7 +28,7 @@ import sttp.client4._
 def asJson[T]: ResponseAs[Either[ResponseException[String, Exception], T]] = ???
 ``` 
 
-There are also the `.getRight` and `.getEither` methods on eligible response specifications, which convert http errors or deserialization exceptions as failed effects.
+There are also the `.orFail` and `.orFailDeserialization` methods on eligible response specifications, which convert http errors or deserialization exceptions as failed effects.
 
 ## Possible outcomes
 

--- a/examples-ce2/src/main/scala/sttp/client4/examples/GetAndParseJsonOrFailMonixCirce.scala
+++ b/examples-ce2/src/main/scala/sttp/client4/examples/GetAndParseJsonOrFailMonixCirce.scala
@@ -5,14 +5,14 @@ import sttp.client4._
 import sttp.client4.httpclient.monix.HttpClientMonixBackend
 import sttp.client4.circe._
 
-object GetAndParseJsonGetRightMonixCirce extends App {
+object GetAndParseJsonOrFailMonixCirce extends App {
   import monix.execution.Scheduler.Implicits.global
 
   case class HttpBinResponse(origin: String, headers: Map[String, String])
 
   val request: Request[HttpBinResponse] = basicRequest
     .get(uri"https://httpbin.org/get")
-    .response(asJson[HttpBinResponse].getRight)
+    .response(asJson[HttpBinResponse].orFail)
 
   HttpClientMonixBackend
     .resource()

--- a/examples/src/main/scala/sttp/client4/examples/LogRequestsSlf4j.scala
+++ b/examples/src/main/scala/sttp/client4/examples/LogRequestsSlf4j.scala
@@ -12,7 +12,7 @@ object LogRequestsSlf4j extends App {
 
   val request = basicRequest
     .get(uri"https://httpbin.org/get")
-    .response(asJson[HttpBinResponse].getRight)
+    .response(asJson[HttpBinResponse].orFail)
 
   val backend: SyncBackend =
     Slf4jLoggingBackend(

--- a/generated-docs/out/examples.md
+++ b/generated-docs/out/examples.md
@@ -85,7 +85,7 @@ libraryDependencies ++= List(
 Example code:
 
 ```eval_rst
-.. literalinclude:: ../../examples-ce2/src/main/scala/sttp/client4/examples/GetAndParseJsonGetRightMonixCirce.scala
+.. literalinclude:: ../../examples-ce2/src/main/scala/sttp/client4/examples/GetAndParseJsonOrFailMonixCirce.scala
     :language: scala
 ```
 

--- a/json/circe/src/main/scala/sttp/client4/circe/SttpCirceApi.scala
+++ b/json/circe/src/main/scala/sttp/client4/circe/SttpCirceApi.scala
@@ -6,6 +6,7 @@ import io.circe.{Decoder, Encoder, Printer}
 import sttp.client4.internal.Utf8
 import sttp.model.MediaType
 import sttp.client4.json._
+import sttp.client4.ResponseAs.deserializeEitherWithErrorOrThrow
 
 trait SttpCirceApi {
 
@@ -23,6 +24,12 @@ trait SttpCirceApi {
     */
   def asJson[B: Decoder: IsOption]: ResponseAs[Either[ResponseException[String, io.circe.Error], B]] =
     asString.mapWithMetadata(ResponseAs.deserializeRightWithError(deserializeJson)).showAsJson
+
+  /** If the response is successful (2xx), tries to deserialize the body from a string into JSON. Otherwise, if the
+    * response code is other than 2xx, or a deserialization error occurs, throws an [[ResponseException]] / returns a
+    * failed effect.
+    */
+  def asJsonOrFail[B: Decoder: IsOption]: ResponseAs[B] = asJson[B].orFail.showAsJsonOrFail
 
   /** Tries to deserialize the body from a string into JSON, regardless of the response code. Returns:
     *   - `Right(b)` if the parsing was successful
@@ -45,6 +52,14 @@ trait SttpCirceApi {
         case de @ DeserializationException(_, _) => de
       }
     }.showAsJsonEither
+
+  /** Deserializes the body from a string into JSON, using different deserializers depending on the status code. If a
+    * deserialization error occurs, throws a [[DeserializationException]] / returns a failed effect.
+    */
+  def asJsonEitherOrFail[E: Decoder: IsOption, B: Decoder: IsOption]: ResponseAs[Either[E, B]] =
+    asStringAlways
+      .mapWithMetadata(deserializeEitherWithErrorOrThrow(deserializeJson[E], deserializeJson[B]))
+      .showAsJsonEitherOrFail
 
   def deserializeJson[B: Decoder: IsOption]: String => Either[io.circe.Error, B] =
     JsonInput.sanitize[B].andThen(decode[B])

--- a/json/circe/src/main/scala/sttp/client4/circe/SttpCirceApi.scala
+++ b/json/circe/src/main/scala/sttp/client4/circe/SttpCirceApi.scala
@@ -39,9 +39,11 @@ trait SttpCirceApi {
     */
   def asJsonEither[E: Decoder: IsOption, B: Decoder: IsOption]
       : ResponseAs[Either[ResponseException[E, io.circe.Error], B]] =
-    asJson[B].mapLeft {
-      case HttpError(e, code) => deserializeJson[E].apply(e).fold(DeserializationException(e, _), HttpError(_, code))
-      case de @ DeserializationException(_, _) => de
+    asJson[B].mapLeft { (l: ResponseException[String, io.circe.Error]) =>
+      l match {
+        case HttpError(e, code) => deserializeJson[E].apply(e).fold(DeserializationException(e, _), HttpError(_, code))
+        case de @ DeserializationException(_, _) => de
+      }
     }.showAsJsonEither
 
   def deserializeJson[B: Decoder: IsOption]: String => Either[io.circe.Error, B] =

--- a/json/circe/src/test/scala/sttp/client4/circe/CirceTests.scala
+++ b/json/circe/src/test/scala/sttp/client4/circe/CirceTests.scala
@@ -7,6 +7,7 @@ import sttp.client4._
 import sttp.model._
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
+import sttp.client4.json.RunResponseAs
 
 class CirceTests extends AnyFlatSpec with Matchers with EitherValues {
 
@@ -34,33 +35,33 @@ class CirceTests extends AnyFlatSpec with Matchers with EitherValues {
 
     val responseAs = asJson[Outer]
 
-    runJsonResponseAs(responseAs)(body).right.value shouldBe expected
+    RunResponseAs(responseAs)(body).right.value shouldBe expected
   }
 
   it should "decode None from empty body" in {
     val responseAs = asJson[Option[Inner]]
 
-    runJsonResponseAs(responseAs)("").right.value shouldBe None
+    RunResponseAs(responseAs)("").right.value shouldBe None
   }
 
   it should "decode Left(None) from empty body" in {
     import EitherDecoders._
     val responseAs = asJson[Either[Option[Inner], Outer]]
 
-    runJsonResponseAs(responseAs)("").right.value shouldBe Left(None)
+    RunResponseAs(responseAs)("").right.value shouldBe Left(None)
   }
 
   it should "decode Right(None) from empty body" in {
     import EitherDecoders._
     val responseAs = asJson[Either[Outer, Option[Inner]]]
 
-    runJsonResponseAs(responseAs)("").right.value shouldBe Right(None)
+    RunResponseAs(responseAs)("").right.value shouldBe Right(None)
   }
 
   it should "fail to decode from empty input" in {
     val responseAs = asJson[Inner]
 
-    runJsonResponseAs(responseAs)("").left.value should matchPattern {
+    RunResponseAs(responseAs)("").left.value should matchPattern {
       case DeserializationException("", _: io.circe.ParsingFailure) =>
     }
   }
@@ -70,7 +71,7 @@ class CirceTests extends AnyFlatSpec with Matchers with EitherValues {
 
     val responseAs = asJson[Outer]
 
-    val Left(DeserializationException(original, _)) = runJsonResponseAs(responseAs)(body)
+    val Left(DeserializationException(original, _)) = RunResponseAs(responseAs)(body)
     original shouldBe body
   }
 
@@ -78,7 +79,7 @@ class CirceTests extends AnyFlatSpec with Matchers with EitherValues {
     val outer = Outer(Inner(42, true, "horses"), "cats")
 
     val encoded = extractBody(basicRequest.body(asJson(outer)))
-    val decoded = runJsonResponseAs(asJson[Outer])(encoded)
+    val decoded = RunResponseAs(asJson[Outer])(encoded)
 
     decoded.right.value shouldBe outer
   }
@@ -119,6 +120,37 @@ class CirceTests extends AnyFlatSpec with Matchers with EitherValues {
     actualContentType should be(expectedContentType)
   }
 
+  it should "decode when using asJsonOrFail" in {
+    val body = """{"foo":{"a":42,"b":true,"c":"horses"},"bar":"cats"}"""
+    val expected = Outer(Inner(42, true, "horses"), "cats")
+
+    RunResponseAs(asJsonOrFail[Outer])(body) shouldBe expected
+  }
+
+  it should "fail when using asJsonOrFail for incorrect JSON" in {
+    val body = """invalid json"""
+
+    assertThrows[DeserializationException[io.circe.Error]] {
+      RunResponseAs(asJsonOrFail[Outer])(body)
+    }
+  }
+
+  it should "decode success when using asJsonEitherOrFail" in {
+    val body = """{"foo":{"a":42,"b":true,"c":"horses"},"bar":"cats"}"""
+    val expected = Outer(Inner(42, true, "horses"), "cats")
+
+    RunResponseAs(asJsonEitherOrFail[Inner, Outer])(body) shouldBe Right(expected)
+  }
+
+  it should "decode failure when using asJsonEitherOrFail" in {
+    val body = """{"a":21,"b":false,"c":"hippos"}"""
+    val expected = Inner(21, false, "hippos")
+
+    RunResponseAs(asJsonEitherOrFail[Inner, Outer], ResponseMetadata(StatusCode.BadRequest, "", Nil))(
+      body
+    ) shouldBe Left(expected)
+  }
+
   case class Inner(a: Int, b: Boolean, c: String)
 
   object Inner {
@@ -148,17 +180,5 @@ class CirceTests extends AnyFlatSpec with Matchers with EitherValues {
         body
       case wrongBody =>
         fail(s"Request body does not serialize to correct StringBody: $wrongBody")
-    }
-
-  def runJsonResponseAs[A](responseAs: ResponseAs[A]): String => A =
-    responseAs.delegate match {
-      case responseAs: MappedResponseAs[_, A, Nothing] =>
-        responseAs.raw match {
-          case ResponseAsByteArray =>
-            s => responseAs.g(s.getBytes(Utf8), ResponseMetadata(StatusCode.Ok, "", Nil))
-          case _ =>
-            fail("MappedResponseAs does not wrap a ResponseAsByteArray")
-        }
-      case _ => fail("ResponseAs is not a MappedResponseAs")
     }
 }

--- a/json/common/src/main/scala/sttp/client4/json/package.scala
+++ b/json/common/src/main/scala/sttp/client4/json/package.scala
@@ -4,6 +4,8 @@ package object json {
   implicit class RichResponseAs[T](ra: ResponseAs[T]) {
     def showAsJson: ResponseAs[T] = ra.showAs("either(as string, as json)")
     def showAsJsonAlways: ResponseAs[T] = ra.showAs("as json")
+    def showAsJsonOrFail: ResponseAs[T] = ra.showAs("as json or fail")
     def showAsJsonEither: ResponseAs[T] = ra.showAs("either(as json, as json)")
+    def showAsJsonEitherOrFail: ResponseAs[T] = ra.showAs("either(as json, as json) or fail")
   }
 }

--- a/json/common/src/test/scala/sttp/client4/json/RunResponseAs.scala
+++ b/json/common/src/test/scala/sttp/client4/json/RunResponseAs.scala
@@ -1,0 +1,26 @@
+package sttp.client4.json
+
+import sttp.client4.ResponseAs
+import sttp.client4.MappedResponseAs
+import sttp.client4.ResponseAsByteArray
+import sttp.client4.internal.Utf8
+import sttp.model.ResponseMetadata
+import sttp.model.StatusCode
+import org.scalatest.Assertions.fail
+
+object RunResponseAs {
+  def apply[A](
+      responseAs: ResponseAs[A],
+      responseMetadata: ResponseMetadata = ResponseMetadata(StatusCode.Ok, "", Nil)
+  ): String => A =
+    responseAs.delegate match {
+      case responseAs: MappedResponseAs[_, A, Nothing] @unchecked =>
+        responseAs.raw match {
+          case ResponseAsByteArray =>
+            s => responseAs.g(s.getBytes(Utf8), responseMetadata)
+          case _ =>
+            fail("MappedResponseAs does not wrap a ResponseAsByteArray")
+        }
+      case _ => fail("ResponseAs is not a MappedResponseAs")
+    }
+}

--- a/json/json4s/src/main/scala/sttp/client4/json4s/SttpJson4sApi.scala
+++ b/json/json4s/src/main/scala/sttp/client4/json4s/SttpJson4sApi.scala
@@ -46,10 +46,12 @@ trait SttpJson4sApi {
       formats: Formats,
       serialization: Serialization
   ): ResponseAs[Either[ResponseException[E, Exception], B]] =
-    asJson[B].mapLeft {
-      case HttpError(e, code) =>
-        ResponseAs.deserializeCatchingExceptions(deserializeJson[E])(e).fold(identity, HttpError(_, code))
-      case de @ DeserializationException(_, _) => de
+    asJson[B].mapLeft { (l: ResponseException[String, Exception]) =>
+      l match {
+        case HttpError(e, code) =>
+          ResponseAs.deserializeCatchingExceptions(deserializeJson[E])(e).fold(identity, HttpError(_, code))
+        case de @ DeserializationException(_, _) => de
+      }
     }.showAsJsonEither
 
   def deserializeJson[B: Manifest](implicit

--- a/json/json4s/src/test/scala/sttp/client4/Json4sTests.scala
+++ b/json/json4s/src/test/scala/sttp/client4/Json4sTests.scala
@@ -11,6 +11,7 @@ import sttp.model._
 import scala.language.higherKinds
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
+import sttp.client4.json.RunResponseAs
 
 class Json4sTests extends AnyFlatSpec with Matchers with EitherValues {
   implicit val serialization: Serialization.type = native.Serialization
@@ -34,32 +35,31 @@ class Json4sTests extends AnyFlatSpec with Matchers with EitherValues {
 
     val responseAs = asJson[Outer]
 
-    runJsonResponseAs(responseAs)(body) shouldBe Right(expected)
+    RunResponseAs(responseAs)(body) shouldBe Right(expected)
   }
 
   it should "decode None from empty body" in {
     val responseAs = asJson[Option[Inner]]
 
-    runJsonResponseAs(responseAs)("") shouldBe Right(None)
+    RunResponseAs(responseAs)("") shouldBe Right(None)
   }
 
   it should "decode Left(None) from empty body" in {
     val responseAs = asJson[Either[Option[Inner], Outer]]
 
-    runJsonResponseAs(responseAs)("") shouldBe Right(Left(None))
+    RunResponseAs(responseAs)("") shouldBe Right(Left(None))
   }
 
   it should "decode Right(None) from empty body" in {
     val responseAs = asJson[Either[Outer, Option[Inner]]]
 
-    runJsonResponseAs(responseAs)("") shouldBe Right(Right(None))
+    RunResponseAs(responseAs)("") shouldBe Right(Right(None))
   }
 
   it should "fail to decode from empty input" in {
     val responseAs = asJson[Inner]
 
-    runJsonResponseAs(responseAs)("") should matchPattern {
-      case Left(DeserializationException(_, _: MappingException)) =>
+    RunResponseAs(responseAs)("") should matchPattern { case Left(DeserializationException(_, _: MappingException)) =>
     }
   }
 
@@ -68,8 +68,7 @@ class Json4sTests extends AnyFlatSpec with Matchers with EitherValues {
 
     val responseAs = asJson[Outer]
 
-    runJsonResponseAs(responseAs)(body) should matchPattern {
-      case Left(DeserializationException(_, _: ParseException)) =>
+    RunResponseAs(responseAs)(body) should matchPattern { case Left(DeserializationException(_, _: ParseException)) =>
     }
   }
 
@@ -96,24 +95,43 @@ class Json4sTests extends AnyFlatSpec with Matchers with EitherValues {
     actualContentType should be(expectedContentType)
   }
 
+  it should "decode when using asJsonOrFail" in {
+    val body = """{"foo":{"a":42,"b":true,"c":"horses"},"bar":"cats"}"""
+    val expected = Outer(Inner(42, true, "horses"), "cats")
+
+    RunResponseAs(asJsonOrFail[Outer])(body) shouldBe expected
+  }
+
+  it should "fail when using asJsonOrFail for incorrect JSON" in {
+    val body = """invalid json"""
+
+    assertThrows[Exception] {
+      RunResponseAs(asJsonOrFail[Outer])(body)
+    }
+  }
+
+  it should "decode success when using asJsonEitherOrFail" in {
+    val body = """{"foo":{"a":42,"b":true,"c":"horses"},"bar":"cats"}"""
+    val expected = Outer(Inner(42, true, "horses"), "cats")
+
+    RunResponseAs(asJsonEitherOrFail[Inner, Outer])(body) shouldBe Right(expected)
+  }
+
+  it should "decode failure when using asJsonEitherOrFail" in {
+    val body = """{"a":21,"b":false,"c":"hippos"}"""
+    val expected = Inner(21, false, "hippos")
+
+    RunResponseAs(asJsonEitherOrFail[Inner, Outer], ResponseMetadata(StatusCode.BadRequest, "", Nil))(
+      body
+    ) shouldBe Left(expected)
+  }
+
   def extractBody[T](request: PartialRequest[T]): String =
     request.body match {
       case StringBody(body, "utf-8", MediaType.ApplicationJson) =>
         body
       case wrongBody =>
         fail(s"Request body does not serialize to correct StringBody: $wrongBody")
-    }
-
-  def runJsonResponseAs[A](responseAs: ResponseAs[A]): String => A =
-    responseAs.delegate match {
-      case responseAs: MappedResponseAs[_, A, Nothing] =>
-        responseAs.raw match {
-          case ResponseAsByteArray =>
-            s => responseAs.g(s.getBytes(Utf8), ResponseMetadata(StatusCode.Ok, "", Nil))
-          case _ =>
-            fail("MappedResponseAs does not wrap a ResponseAsByteArray")
-        }
-      case _ => fail("ResponseAs is not a MappedResponseAs")
     }
 }
 

--- a/json/jsoniter/src/main/scala/sttp/client4/jsoniter/SttpJsoniterJsonApi.scala
+++ b/json/jsoniter/src/main/scala/sttp/client4/jsoniter/SttpJsoniterJsonApi.scala
@@ -47,9 +47,11 @@ trait SttpJsoniterJsonApi {
       E: JsonValueCodec: IsOption,
       B: JsonValueCodec: IsOption
   ]: ResponseAs[Either[ResponseException[E, Exception], B]] =
-    asJson[B].mapLeft {
-      case de @ DeserializationException(_, _) => de
-      case HttpError(e, code) => deserializeJson[E].apply(e).fold(DeserializationException(e, _), HttpError(_, code))
+    asJson[B].mapLeft { (l: ResponseException[String, Exception]) =>
+      l match {
+        case de @ DeserializationException(_, _) => de
+        case HttpError(e, code) => deserializeJson[E].apply(e).fold(DeserializationException(e, _), HttpError(_, code))
+      }
     }.showAsJsonEither
 
   def deserializeJson[B: JsonValueCodec: IsOption]: String => Either[Exception, B] = { (s: String) =>

--- a/json/jsoniter/src/main/scala/sttp/client4/jsoniter/SttpJsoniterJsonApi.scala
+++ b/json/jsoniter/src/main/scala/sttp/client4/jsoniter/SttpJsoniterJsonApi.scala
@@ -30,6 +30,12 @@ trait SttpJsoniterJsonApi {
   def asJson[B: JsonValueCodec: IsOption]: ResponseAs[Either[ResponseException[String, Exception], B]] =
     asString.mapWithMetadata(ResponseAs.deserializeRightWithError(deserializeJson[B])).showAsJson
 
+  /** If the response is successful (2xx), tries to deserialize the body from a string into JSON. Otherwise, if the
+    * response code is other than 2xx, or a deserialization error occurs, throws an [[ResponseException]] / returns a
+    * failed effect.
+    */
+  def asJsonOrFail[B: JsonValueCodec: IsOption]: ResponseAs[B] = asJson[B].orFail.showAsJsonOrFail
+
   /** Tries to deserialize the body from a string into JSON, regardless of the response code. Returns:
     *   - `Right(b)` if the parsing was successful
     *   - `Left(DeserializationException)` if there's an error during deserialization
@@ -53,6 +59,14 @@ trait SttpJsoniterJsonApi {
         case HttpError(e, code) => deserializeJson[E].apply(e).fold(DeserializationException(e, _), HttpError(_, code))
       }
     }.showAsJsonEither
+
+  /** Deserializes the body from a string into JSON, using different deserializers depending on the status code. If a
+    * deserialization error occurs, throws a [[DeserializationException]] / returns a failed effect.
+    */
+  def asJsonEitherOrFail[E: JsonValueCodec: IsOption, B: JsonValueCodec: IsOption]: ResponseAs[Either[E, B]] =
+    asStringAlways
+      .mapWithMetadata(ResponseAs.deserializeEitherWithErrorOrThrow(deserializeJson[E], deserializeJson[B]))
+      .showAsJsonEitherOrFail
 
   def deserializeJson[B: JsonValueCodec: IsOption]: String => Either[Exception, B] = { (s: String) =>
     try Right(readFromString[B](JsonInput.sanitize[B].apply(s)))

--- a/json/play-json/src/main/scala/sttp/client4/playJson/SttpPlayJsonApi.scala
+++ b/json/play-json/src/main/scala/sttp/client4/playJson/SttpPlayJsonApi.scala
@@ -7,6 +7,7 @@ import sttp.client4._
 import sttp.model.MediaType
 
 import scala.util.{Failure, Success, Try}
+import sttp.client4.ResponseAs.deserializeEitherWithErrorOrThrow
 
 trait SttpPlayJsonApi {
   implicit val errorMessageForPlayError: ShowError[JsError] = new ShowError[JsError] {
@@ -24,6 +25,12 @@ trait SttpPlayJsonApi {
     */
   def asJson[B: Reads: IsOption]: ResponseAs[Either[ResponseException[String, JsError], B]] =
     asString.mapWithMetadata(ResponseAs.deserializeRightWithError(deserializeJson[B])).showAsJson
+
+  /** If the response is successful (2xx), tries to deserialize the body from a string into JSON. Otherwise, if the
+    * response code is other than 2xx, or a deserialization error occurs, throws an [[ResponseException]] / returns a
+    * failed effect.
+    */
+  def asJsonOrFail[B: Reads: IsOption]: ResponseAs[B] = asJson[B].orFail.showAsJsonOrFail
 
   /** Tries to deserialize the body from a string into JSON, regardless of the response code. Returns:
     *   - `Right(b)` if the parsing was successful
@@ -46,6 +53,14 @@ trait SttpPlayJsonApi {
         case de @ DeserializationException(_, _) => de
       }
     }.showAsJsonEither
+
+  /** Deserializes the body from a string into JSON, using different deserializers depending on the status code. If a
+    * deserialization error occurs, throws a [[DeserializationException]] / returns a failed effect.
+    */
+  def asJsonEitherOrFail[E: Reads: IsOption, B: Reads: IsOption]: ResponseAs[Either[E, B]] =
+    asStringAlways
+      .mapWithMetadata(deserializeEitherWithErrorOrThrow(deserializeJson[E], deserializeJson[B]))
+      .showAsJsonEitherOrFail
 
   // Note: None of the play-json utilities attempt to catch invalid
   // json, so Json.parse needs to be wrapped in Try

--- a/json/play-json/src/main/scala/sttp/client4/playJson/SttpPlayJsonApi.scala
+++ b/json/play-json/src/main/scala/sttp/client4/playJson/SttpPlayJsonApi.scala
@@ -39,10 +39,12 @@ trait SttpPlayJsonApi {
     *   - `Left(DeserializationException)` if there's an error during deserialization
     */
   def asJsonEither[E: Reads: IsOption, B: Reads: IsOption]: ResponseAs[Either[ResponseException[E, JsError], B]] =
-    asJson[B].mapLeft {
-      case HttpError(e, code) =>
-        deserializeJson[E].apply(e).fold(DeserializationException(e, _), HttpError(_, code))
-      case de @ DeserializationException(_, _) => de
+    asJson[B].mapLeft { (l: ResponseException[String, JsError]) =>
+      l match {
+        case HttpError(e, code) =>
+          deserializeJson[E].apply(e).fold(DeserializationException(e, _), HttpError(_, code))
+        case de @ DeserializationException(_, _) => de
+      }
     }.showAsJsonEither
 
   // Note: None of the play-json utilities attempt to catch invalid

--- a/json/spray-json/src/main/scala/sttp/client4/sprayJson/SttpSprayJsonApi.scala
+++ b/json/spray-json/src/main/scala/sttp/client4/sprayJson/SttpSprayJsonApi.scala
@@ -35,10 +35,12 @@ trait SttpSprayJsonApi {
     */
   def asJsonEither[E: JsonReader: IsOption, B: JsonReader: IsOption]
       : ResponseAs[Either[ResponseException[E, Exception], B]] =
-    asJson[B].mapLeft {
-      case HttpError(e, code) =>
-        ResponseAs.deserializeCatchingExceptions(deserializeJson[E])(e).fold(identity, HttpError(_, code))
-      case de @ DeserializationException(_, _) => de
+    asJson[B].mapLeft { (l: ResponseException[String, Exception]) =>
+      l match {
+        case HttpError(e, code) =>
+          ResponseAs.deserializeCatchingExceptions(deserializeJson[E])(e).fold(identity, HttpError(_, code))
+        case de @ DeserializationException(_, _) => de
+      }
     }.showAsJsonEither
 
   def deserializeJson[B: JsonReader: IsOption]: String => B =

--- a/json/upickle/src/main/scala/sttp/client4/upicklejson/SttpUpickleApi.scala
+++ b/json/upickle/src/main/scala/sttp/client4/upicklejson/SttpUpickleApi.scala
@@ -35,9 +35,11 @@ trait SttpUpickleApi {
     */
   def asJsonEither[E: upickleApi.Reader: IsOption, B: upickleApi.Reader: IsOption]
       : ResponseAs[Either[ResponseException[E, Exception], B]] =
-    asJson[B].mapLeft {
-      case HttpError(e, code) => deserializeJson[E].apply(e).fold(DeserializationException(e, _), HttpError(_, code))
-      case de @ DeserializationException(_, _) => de
+    asJson[B].mapLeft { (l: ResponseException[String, Exception]) =>
+      l match {
+        case HttpError(e, code) => deserializeJson[E].apply(e).fold(DeserializationException(e, _), HttpError(_, code))
+        case de @ DeserializationException(_, _) => de
+      }
     }.showAsJsonEither
 
   def deserializeJson[B: upickleApi.Reader: IsOption]: String => Either[Exception, B] = { (s: String) =>

--- a/json/upickle/src/test/scala/sttp/client4/upicklejson/UpickleTests.scala
+++ b/json/upickle/src/test/scala/sttp/client4/upicklejson/UpickleTests.scala
@@ -7,6 +7,7 @@ import sttp.model._
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import ujson.Obj
+import sttp.client4.json.RunResponseAs
 
 class UpickleTests extends AnyFlatSpec with Matchers with EitherValues {
   "The upickle module" should "encode arbitrary bodies given an encoder" in {
@@ -30,7 +31,7 @@ class UpickleTests extends AnyFlatSpec with Matchers with EitherValues {
 
     val responseAs = asJson[Outer]
 
-    runJsonResponseAs(responseAs)(body).right.value shouldBe expected
+    RunResponseAs(responseAs)(body).right.value shouldBe expected
   }
 
   it should "decode None from empty array body" in {
@@ -39,7 +40,7 @@ class UpickleTests extends AnyFlatSpec with Matchers with EitherValues {
 
     val responseAs = asJson[Option[Inner]]
 
-    runJsonResponseAs(responseAs)("[]").right.value shouldBe None
+    RunResponseAs(responseAs)("[]").right.value shouldBe None
   }
 
   it should "decode Left(None) from upickle notation" in {
@@ -48,7 +49,7 @@ class UpickleTests extends AnyFlatSpec with Matchers with EitherValues {
 
     val responseAs = asJson[Either[Option[Inner], Outer]]
 
-    runJsonResponseAs(responseAs)("[0,[]]").right.value shouldBe Left(None)
+    RunResponseAs(responseAs)("[0,[]]").right.value shouldBe Left(None)
   }
 
   it should "decode Right(None) from upickle notation" in {
@@ -57,7 +58,7 @@ class UpickleTests extends AnyFlatSpec with Matchers with EitherValues {
 
     val responseAs = asJson[Either[Outer, Option[Inner]]]
 
-    runJsonResponseAs(responseAs)("[1,[]]").right.value shouldBe Right(None)
+    RunResponseAs(responseAs)("[1,[]]").right.value shouldBe Right(None)
   }
 
   it should "fail to decode from empty input" in {
@@ -66,7 +67,7 @@ class UpickleTests extends AnyFlatSpec with Matchers with EitherValues {
 
     val responseAs = asJson[Inner]
 
-    runJsonResponseAs(responseAs)("").left.value should matchPattern { case DeserializationException(_, _) => }
+    RunResponseAs(responseAs)("").left.value should matchPattern { case DeserializationException(_, _) => }
   }
 
   it should "fail to decode invalid json" in {
@@ -77,7 +78,7 @@ class UpickleTests extends AnyFlatSpec with Matchers with EitherValues {
 
     val responseAs = asJson[Outer]
 
-    val Left(DeserializationException(original, _)) = runJsonResponseAs(responseAs)(body)
+    val Left(DeserializationException(original, _)) = RunResponseAs(responseAs)(body)
     original shouldBe body
   }
 
@@ -88,7 +89,7 @@ class UpickleTests extends AnyFlatSpec with Matchers with EitherValues {
     val outer = Outer(Inner(42, true, "horses"), "cats")
 
     val encoded = extractBody(basicRequest.body(asJson(outer)))
-    val decoded = runJsonResponseAs(asJson[Outer])(encoded)
+    val decoded = RunResponseAs(asJson[Outer])(encoded)
 
     decoded.right.value shouldBe outer
   }
@@ -152,6 +153,49 @@ class UpickleTests extends AnyFlatSpec with Matchers with EitherValues {
     extractBody(req) shouldBe expected
   }
 
+  it should "decode when using asJsonOrFail" in {
+    import UsingDefaultReaderWriters._
+    import sttp.client4.upicklejson.default._
+
+    val body = """{"foo":{"a":42,"b":true,"c":"horses"},"bar":"cats"}"""
+    val expected = Outer(Inner(42, true, "horses"), "cats")
+
+    RunResponseAs(asJsonOrFail[Outer])(body) shouldBe expected
+  }
+
+  it should "fail when using asJsonOrFail for incorrect JSON" in {
+    import UsingDefaultReaderWriters._
+    import sttp.client4.upicklejson.default._
+
+    val body = """invalid json"""
+
+    assertThrows[DeserializationException[Exception]] {
+      RunResponseAs(asJsonOrFail[Outer])(body)
+    }
+  }
+
+  it should "decode success when using asJsonEitherOrFail" in {
+    import UsingDefaultReaderWriters._
+    import sttp.client4.upicklejson.default._
+
+    val body = """{"foo":{"a":42,"b":true,"c":"horses"},"bar":"cats"}"""
+    val expected = Outer(Inner(42, true, "horses"), "cats")
+
+    RunResponseAs(asJsonEitherOrFail[Inner, Outer])(body) shouldBe Right(expected)
+  }
+
+  it should "decode failure when using asJsonEitherOrFail" in {
+    import UsingDefaultReaderWriters._
+    import sttp.client4.upicklejson.default._
+
+    val body = """{"a":21,"b":false,"c":"hippos"}"""
+    val expected = Inner(21, false, "hippos")
+
+    RunResponseAs(asJsonEitherOrFail[Inner, Outer], ResponseMetadata(StatusCode.BadRequest, "", Nil))(
+      body
+    ) shouldBe Left(expected)
+  }
+
   case class Inner(a: Int, b: Boolean, c: String)
   case class Outer(foo: Inner, bar: String)
 
@@ -173,17 +217,5 @@ class UpickleTests extends AnyFlatSpec with Matchers with EitherValues {
         body
       case wrongBody =>
         fail(s"Request body does not serialize to correct StringBody: $wrongBody")
-    }
-
-  def runJsonResponseAs[A](responseAs: ResponseAs[A]): String => A =
-    responseAs.delegate match {
-      case responseAs: MappedResponseAs[_, A, Nothing] @unchecked =>
-        responseAs.raw match {
-          case ResponseAsByteArray =>
-            s => responseAs.g(s.getBytes(Utf8), ResponseMetadata(StatusCode.Ok, "", Nil))
-          case _ =>
-            fail("MappedResponseAs does not wrap a ResponseAsByteArray")
-        }
-      case _ => fail("ResponseAs is not a MappedResponseAs")
     }
 }

--- a/json/zio-json/src/main/scala/sttp/client4/ziojson/SttpZioJsonApi.scala
+++ b/json/zio-json/src/main/scala/sttp/client4/ziojson/SttpZioJsonApi.scala
@@ -29,6 +29,12 @@ trait SttpZioJsonApi extends SttpZioJsonApiExtensions {
   def asJson[B: JsonDecoder: IsOption]: ResponseAs[Either[ResponseException[String, String], B]] =
     asString.mapWithMetadata(ResponseAs.deserializeRightWithError(deserializeJson)).showAsJson
 
+  /** If the response is successful (2xx), tries to deserialize the body from a string into JSON. Otherwise, if the
+    * response code is other than 2xx, or a deserialization error occurs, throws an [[ResponseException]] / returns a
+    * failed effect.
+    */
+  def asJsonOrFail[B: JsonDecoder: IsOption]: ResponseAs[B] = asJson[B].orFail.showAsJsonOrFail
+
   /** Tries to deserialize the body from a string into JSON, regardless of the response code. Returns:
     *   - `Right(b)` if the parsing was successful
     *   - `Left(DeserializationException)` if there's an error during deserialization
@@ -50,6 +56,14 @@ trait SttpZioJsonApi extends SttpZioJsonApiExtensions {
         case de @ DeserializationException(_, _) => de
       }
     }.showAsJsonEither
+
+  /** Deserializes the body from a string into JSON, using different deserializers depending on the status code. If a
+    * deserialization error occurs, throws a [[DeserializationException]] / returns a failed effect.
+    */
+  def asJsonEitherOrFail[E: JsonDecoder: IsOption, B: JsonDecoder: IsOption]: ResponseAs[Either[E, B]] =
+    asStringAlways
+      .mapWithMetadata(ResponseAs.deserializeEitherWithErrorOrThrow(deserializeJson[E], deserializeJson[B]))
+      .showAsJsonEitherOrFail
 
   def deserializeJson[B: JsonDecoder: IsOption]: String => Either[String, B] =
     JsonInput.sanitize[B].andThen(_.fromJson[B])

--- a/json/zio-json/src/main/scala/sttp/client4/ziojson/SttpZioJsonApi.scala
+++ b/json/zio-json/src/main/scala/sttp/client4/ziojson/SttpZioJsonApi.scala
@@ -44,9 +44,11 @@ trait SttpZioJsonApi extends SttpZioJsonApiExtensions {
     */
   def asJsonEither[E: JsonDecoder: IsOption, B: JsonDecoder: IsOption]
       : ResponseAs[Either[ResponseException[E, String], B]] =
-    asJson[B].mapLeft {
-      case HttpError(e, code) => deserializeJson[E].apply(e).fold(DeserializationException(e, _), HttpError(_, code))
-      case de @ DeserializationException(_, _) => de
+    asJson[B].mapLeft { (l: ResponseException[String, String]) =>
+      l match {
+        case HttpError(e, code) => deserializeJson[E].apply(e).fold(DeserializationException(e, _), HttpError(_, code))
+        case de @ DeserializationException(_, _) => de
+      }
     }.showAsJsonEither
 
   def deserializeJson[B: JsonDecoder: IsOption]: String => Either[String, B] =

--- a/json/zio-json/src/test/scala/sttp/client4/ziojson/ZioJsonTests.scala
+++ b/json/zio-json/src/test/scala/sttp/client4/ziojson/ZioJsonTests.scala
@@ -9,6 +9,7 @@ import sttp.client4.internal.Utf8
 import sttp.model._
 import zio.Chunk
 import zio.json.ast.Json
+import sttp.client4.json.RunResponseAs
 
 class ZioJsonTests extends AnyFlatSpec with Matchers with EitherValues {
 
@@ -25,27 +26,27 @@ class ZioJsonTests extends AnyFlatSpec with Matchers with EitherValues {
 
     val responseAs = asJson[Outer]
 
-    runJsonResponseAs(responseAs)(body).right.value shouldBe expected
+    RunResponseAs(responseAs)(body).right.value shouldBe expected
   }
 
   it should "decode None from empty body" in {
     val responseAs = asJson[Option[Inner]]
 
-    runJsonResponseAs(responseAs)("").right.value shouldBe None
+    RunResponseAs(responseAs)("").right.value shouldBe None
   }
 
   it should "decode Left(None) from empty body" in {
     import EitherDecoders._
     val responseAs = asJson[Either[Option[Inner], Outer]]
 
-    runJsonResponseAs(responseAs)("").right.value shouldBe Left(None)
+    RunResponseAs(responseAs)("").right.value shouldBe Left(None)
   }
 
   it should "decode Right(None) from empty body" in {
     import EitherDecoders._
     val responseAs = asJson[Either[Outer, Option[Inner]]]
 
-    runJsonResponseAs(responseAs)("").right.value shouldBe Right(None)
+    RunResponseAs(responseAs)("").right.value shouldBe Right(None)
   }
 
   it should "fail to decode invalid json" in {
@@ -53,14 +54,14 @@ class ZioJsonTests extends AnyFlatSpec with Matchers with EitherValues {
 
     val responseAs = asJson[Outer]
 
-    val Left(DeserializationException(original, _)) = runJsonResponseAs(responseAs)(body)
+    val Left(DeserializationException(original, _)) = RunResponseAs(responseAs)(body)
     original shouldBe body
   }
 
   it should "fail to decode from empty input" in {
     val responseAs = asJson[Inner]
 
-    runJsonResponseAs(responseAs)("").left.value should matchPattern { case DeserializationException("", _: String) =>
+    RunResponseAs(responseAs)("").left.value should matchPattern { case DeserializationException("", _: String) =>
     }
   }
 
@@ -68,7 +69,7 @@ class ZioJsonTests extends AnyFlatSpec with Matchers with EitherValues {
     val outer = Outer(Inner(42, true, "horses"), "cats")
 
     val encoded = extractBody(basicRequest.body(asJson(outer)))
-    val decoded = runJsonResponseAs(asJson[Outer])(encoded)
+    val decoded = RunResponseAs(asJson[Outer])(encoded)
 
     decoded.right.value shouldBe outer
   }
@@ -106,24 +107,43 @@ class ZioJsonTests extends AnyFlatSpec with Matchers with EitherValues {
     actualContentType should be(expectedContentType)
   }
 
+  it should "decode when using asJsonOrFail" in {
+    val body = """{"foo":{"a":42,"b":true,"c":"horses"},"bar":"cats"}"""
+    val expected = Outer(Inner(42, true, "horses"), "cats")
+
+    RunResponseAs(asJsonOrFail[Outer])(body) shouldBe expected
+  }
+
+  it should "fail when using asJsonOrFail for incorrect JSON" in {
+    val body = """invalid json"""
+
+    assertThrows[DeserializationException[Exception]] {
+      RunResponseAs(asJsonOrFail[Outer])(body)
+    }
+  }
+
+  it should "decode success when using asJsonEitherOrFail" in {
+    val body = """{"foo":{"a":42,"b":true,"c":"horses"},"bar":"cats"}"""
+    val expected = Outer(Inner(42, true, "horses"), "cats")
+
+    RunResponseAs(asJsonEitherOrFail[Inner, Outer])(body) shouldBe Right(expected)
+  }
+
+  it should "decode failure when using asJsonEitherOrFail" in {
+    val body = """{"a":21,"b":false,"c":"hippos"}"""
+    val expected = Inner(21, false, "hippos")
+
+    RunResponseAs(asJsonEitherOrFail[Inner, Outer], ResponseMetadata(StatusCode.BadRequest, "", Nil))(
+      body
+    ) shouldBe Left(expected)
+  }
+
   def extractBody[T](request: PartialRequest[T]): String =
     request.body match {
       case StringBody(body, "utf-8", MediaType.ApplicationJson) =>
         body
       case wrongBody =>
         fail(s"Request body does not serialize to correct StringBody: $wrongBody")
-    }
-
-  def runJsonResponseAs[A](responseAs: ResponseAs[A]): String => A =
-    responseAs.delegate match {
-      case responseAs: MappedResponseAs[_, A, Nothing] @unchecked =>
-        responseAs.raw match {
-          case ResponseAsByteArray =>
-            s => responseAs.g(s.getBytes(Utf8), ResponseMetadata(StatusCode.Ok, "", Nil))
-          case _ =>
-            fail("MappedResponseAs does not wrap a ResponseAsByteArray")
-        }
-      case _ => fail("ResponseAs is not a MappedResponseAs")
     }
 
   object EitherDecoders {

--- a/json/zio1-json/src/main/scala/sttp/client4/ziojson/SttpZioJsonApi.scala
+++ b/json/zio1-json/src/main/scala/sttp/client4/ziojson/SttpZioJsonApi.scala
@@ -29,6 +29,12 @@ trait SttpZioJsonApi extends SttpZioJsonApiExtensions {
   def asJson[B: JsonDecoder: IsOption]: ResponseAs[Either[ResponseException[String, String], B]] =
     asString.mapWithMetadata(ResponseAs.deserializeRightWithError(deserializeJson)).showAsJson
 
+  /** If the response is successful (2xx), tries to deserialize the body from a string into JSON. Otherwise, if the
+    * response code is other than 2xx, or a deserialization error occurs, throws an [[ResponseException]] / returns a
+    * failed effect.
+    */
+  def asJsonOrFail[B: JsonDecoder: IsOption]: ResponseAs[B] = asJson[B].orFail.showAsJsonOrFail
+
   /** Tries to deserialize the body from a string into JSON, regardless of the response code. Returns:
     *   - `Right(b)` if the parsing was successful
     *   - `Left(DeserializationException)` if there's an error during deserialization
@@ -50,6 +56,14 @@ trait SttpZioJsonApi extends SttpZioJsonApiExtensions {
         case de @ DeserializationException(_, _) => de
       }
     }.showAsJsonEither
+
+  /** Deserializes the body from a string into JSON, using different deserializers depending on the status code. If a
+    * deserialization error occurs, throws a [[DeserializationException]] / returns a failed effect.
+    */
+  def asJsonEitherOrFail[E: JsonDecoder: IsOption, B: JsonDecoder: IsOption]: ResponseAs[Either[E, B]] =
+    asStringAlways
+      .mapWithMetadata(ResponseAs.deserializeEitherWithErrorOrThrow(deserializeJson[E], deserializeJson[B]))
+      .showAsJsonEitherOrFail
 
   def deserializeJson[B: JsonDecoder: IsOption]: String => Either[String, B] =
     JsonInput.sanitize[B].andThen(_.fromJson[B])

--- a/json/zio1-json/src/main/scala/sttp/client4/ziojson/SttpZioJsonApi.scala
+++ b/json/zio1-json/src/main/scala/sttp/client4/ziojson/SttpZioJsonApi.scala
@@ -44,9 +44,11 @@ trait SttpZioJsonApi extends SttpZioJsonApiExtensions {
     */
   def asJsonEither[E: JsonDecoder: IsOption, B: JsonDecoder: IsOption]
       : ResponseAs[Either[ResponseException[E, String], B]] =
-    asJson[B].mapLeft {
-      case HttpError(e, code) => deserializeJson[E].apply(e).fold(DeserializationException(e, _), HttpError(_, code))
-      case de @ DeserializationException(_, _) => de
+    asJson[B].mapLeft { (l: ResponseException[String, String]) =>
+      l match {
+        case HttpError(e, code) => deserializeJson[E].apply(e).fold(DeserializationException(e, _), HttpError(_, code))
+        case de @ DeserializationException(_, _) => de
+      }
     }.showAsJsonEither
 
   def deserializeJson[B: JsonDecoder: IsOption]: String => Either[String, B] =

--- a/json/zio1-json/src/test/scala/sttp/client4/ziojson/ZioJsonTests.scala
+++ b/json/zio1-json/src/test/scala/sttp/client4/ziojson/ZioJsonTests.scala
@@ -9,6 +9,7 @@ import sttp.client4.internal.Utf8
 import sttp.model._
 import zio.Chunk
 import zio.json.ast.Json
+import sttp.client4.json.RunResponseAs
 
 class ZioJsonTests extends AnyFlatSpec with Matchers with EitherValues {
 
@@ -25,27 +26,27 @@ class ZioJsonTests extends AnyFlatSpec with Matchers with EitherValues {
 
     val responseAs = asJson[Outer]
 
-    runJsonResponseAs(responseAs)(body).right.value shouldBe expected
+    RunResponseAs(responseAs)(body).right.value shouldBe expected
   }
 
   it should "decode None from empty body" in {
     val responseAs = asJson[Option[Inner]]
 
-    runJsonResponseAs(responseAs)("").right.value shouldBe None
+    RunResponseAs(responseAs)("").right.value shouldBe None
   }
 
   it should "decode Left(None) from empty body" in {
     import EitherDecoders._
     val responseAs = asJson[Either[Option[Inner], Outer]]
 
-    runJsonResponseAs(responseAs)("").right.value shouldBe Left(None)
+    RunResponseAs(responseAs)("").right.value shouldBe Left(None)
   }
 
   it should "decode Right(None) from empty body" in {
     import EitherDecoders._
     val responseAs = asJson[Either[Outer, Option[Inner]]]
 
-    runJsonResponseAs(responseAs)("").right.value shouldBe Right(None)
+    RunResponseAs(responseAs)("").right.value shouldBe Right(None)
   }
 
   it should "fail to decode invalid json" in {
@@ -53,14 +54,14 @@ class ZioJsonTests extends AnyFlatSpec with Matchers with EitherValues {
 
     val responseAs = asJson[Outer]
 
-    val Left(DeserializationException(original, _)) = runJsonResponseAs(responseAs)(body)
+    val Left(DeserializationException(original, _)) = RunResponseAs(responseAs)(body)
     original shouldBe body
   }
 
   it should "fail to decode from empty input" in {
     val responseAs = asJson[Inner]
 
-    runJsonResponseAs(responseAs)("").left.value should matchPattern { case DeserializationException("", _: String) =>
+    RunResponseAs(responseAs)("").left.value should matchPattern { case DeserializationException("", _: String) =>
     }
   }
 
@@ -68,7 +69,7 @@ class ZioJsonTests extends AnyFlatSpec with Matchers with EitherValues {
     val outer = Outer(Inner(42, true, "horses"), "cats")
 
     val encoded = extractBody(basicRequest.body(asJson(outer)))
-    val decoded = runJsonResponseAs(asJson[Outer])(encoded)
+    val decoded = RunResponseAs(asJson[Outer])(encoded)
 
     decoded.right.value shouldBe outer
   }
@@ -106,24 +107,43 @@ class ZioJsonTests extends AnyFlatSpec with Matchers with EitherValues {
     actualContentType should be(expectedContentType)
   }
 
+  it should "decode when using asJsonOrFail" in {
+    val body = """{"foo":{"a":42,"b":true,"c":"horses"},"bar":"cats"}"""
+    val expected = Outer(Inner(42, true, "horses"), "cats")
+
+    RunResponseAs(asJsonOrFail[Outer])(body) shouldBe expected
+  }
+
+  it should "fail when using asJsonOrFail for incorrect JSON" in {
+    val body = """invalid json"""
+
+    assertThrows[DeserializationException[Exception]] {
+      RunResponseAs(asJsonOrFail[Outer])(body)
+    }
+  }
+
+  it should "decode success when using asJsonEitherOrFail" in {
+    val body = """{"foo":{"a":42,"b":true,"c":"horses"},"bar":"cats"}"""
+    val expected = Outer(Inner(42, true, "horses"), "cats")
+
+    RunResponseAs(asJsonEitherOrFail[Inner, Outer])(body) shouldBe Right(expected)
+  }
+
+  it should "decode failure when using asJsonEitherOrFail" in {
+    val body = """{"a":21,"b":false,"c":"hippos"}"""
+    val expected = Inner(21, false, "hippos")
+
+    RunResponseAs(asJsonEitherOrFail[Inner, Outer], ResponseMetadata(StatusCode.BadRequest, "", Nil))(
+      body
+    ) shouldBe Left(expected)
+  }
+
   def extractBody[T](request: PartialRequest[T]): String =
     request.body match {
       case StringBody(body, "utf-8", MediaType.ApplicationJson) =>
         body
       case wrongBody =>
         fail(s"Request body does not serialize to correct StringBody: $wrongBody")
-    }
-
-  def runJsonResponseAs[A](responseAs: ResponseAs[A]): String => A =
-    responseAs.delegate match {
-      case responseAs: MappedResponseAs[_, A, Nothing] =>
-        responseAs.raw match {
-          case ResponseAsByteArray =>
-            s => responseAs.g(s.getBytes(Utf8), ResponseMetadata(StatusCode.Ok, "", Nil))
-          case _ =>
-            fail("MappedResponseAs does not wrap a ResponseAsByteArray")
-        }
-      case _ => fail("ResponseAs is not a MappedResponseAs")
     }
 
   object EitherDecoders {

--- a/observability/opentelemetry-metrics-backend/src/test/scala/sttp/client4/opentelemetry/OpenTelemetryMetricsBackendTest.scala
+++ b/observability/opentelemetry-metrics-backend/src/test/scala/sttp/client4/opentelemetry/OpenTelemetryMetricsBackendTest.scala
@@ -192,7 +192,7 @@ class OpenTelemetryMetricsBackendTest extends AnyFlatSpec with Matchers with Opt
     assertThrows[SttpClientException] {
       basicRequest
         .get(uri"http://127.0.0.1/foo")
-        .response(asString.getRight)
+        .response(asString.orFail)
         .send(backend)
     }
 
@@ -231,7 +231,7 @@ class OpenTelemetryMetricsBackendTest extends AnyFlatSpec with Matchers with Opt
     // when
     basicRequest
       .get(uri"http://127.0.0.1/foo")
-      .response(asString.getRight)
+      .response(asString.orFail)
       .send(backend)
 
     // then

--- a/observability/prometheus-backend/src/test/scala/sttp/client4/prometheus/PrometheusBackendTest.scala
+++ b/observability/prometheus-backend/src/test/scala/sttp/client4/prometheus/PrometheusBackendTest.scala
@@ -350,7 +350,7 @@ class PrometheusBackendTest
     assertThrows[SttpClientException] {
       basicRequest
         .get(uri"http://127.0.0.1/foo")
-        .response(asString.getRight)
+        .response(asString.orFail)
         .send(backend)
     }
 
@@ -401,7 +401,7 @@ class PrometheusBackendTest
     // when
     basicRequest
       .get(uri"http://127.0.0.1/foo")
-      .response(asString.getRight)
+      .response(asString.orFail)
       .send(backend)
 
     // then


### PR DESCRIPTION
Closes #1771

Changes:
* introduce `asXyzOrFail` methods which throw exceptions for non-2xx responses
* add `asJsonOrFail`, `asJsonOrFailEither` variants to all integrations
* `quickRequest` now uses `asStringOrFail` as the default response type
* scaladocs & docs updates
* move `.mapRight`, `.orFail` to `ResponseAs` for better discoverability (instead of extension methods), however this causes that type parameters have to be provided explicitly sometimes

cc @bishabosha @lbialy