### PR TITLE
Simplify ResponseException

### DIFF
--- a/core/src/main/scala/sttp/client4/Response.scala
+++ b/core/src/main/scala/sttp/client4/Response.scala
@@ -31,7 +31,8 @@ case class Response[+T](
     s"Response($body,$code,$statusText,${Headers.toStringSafe(headers)},$history,$request)"
 }
 
-private[sttp] object Response {
+/** For testing, responses can be more conveniently created using [[ResponseStub]]. */
+object Response {
 
   def apply[T](body: T, code: StatusCode, requestMetadata: RequestMetadata): Response[T] =
     Response(body, code, resolveStatusText(code), Nil, Nil, requestMetadata)

--- a/core/src/main/scala/sttp/client4/ResponseException.scala
+++ b/core/src/main/scala/sttp/client4/ResponseException.scala
@@ -4,16 +4,16 @@ import scala.annotation.tailrec
 import sttp.model.ResponseMetadata
 
 /** Used to represent errors, that might occur when handling the response body. Typically, this type is used as the
-  * left-side of a top-level either (where the right-side represents a successful request and deserialization).
+  * left-side of a top-level either (where the right-side represents a successful request and deserialization),
   *
-  * A response exception can itself either be one of two cases:
+  * A response exception can itself be one of two cases:
   *   - a [[HttpError]], when the response code is other than 2xx (or whatever is considered "success" by the response
   *     handling description); the body is deserialized to `HE`
   *   - a [[DeserializationException]], when there's an error during deserialization (this might include both
   *     deserialization exceptions of the success and error branches)
   *
-  * When thrown/returned when sending a request, will be additionally wrapped with a
-  * [[SttpClientException.ResponseHandlingException]].
+  * When thrown/returned when sending a request (e.g. in `...OrFailed` response handling descriptions), will be
+  * additionally wrapped with a [[SttpClientException.ResponseHandlingException]].
   *
   * @tparam HE
   *   The type of the body to which the response is deserialized, when the response code is different than success

--- a/core/src/main/scala/sttp/client4/ResponseException.scala
+++ b/core/src/main/scala/sttp/client4/ResponseException.scala
@@ -5,13 +5,16 @@ import sttp.model.StatusCode
 import scala.annotation.tailrec
 
 /** Used to represent errors, that might occur when handling the response body. Typically, this type is used as the
-  * left-side of a top-level either (where the right-side represents a successfull request and deserialization).
+  * left-side of a top-level either (where the right-side represents a successful request and deserialization).
   *
   * A response exception can itself either be one of two cases:
   *   - a [[HttpError]], when the response code is other than 2xx (or whatever is considered "success" by the response
   *     handling description); the body is deserialized to `HE`
   *   - a [[DeserializationException]], when there's an error during deserialization (this might include both
   *     deserialization exceptions of the success and error branches)
+  *
+  * When thrown/returned when sending a request, will be additionally wrapped with a
+  * [[SttpClientException.ResponseHandlingException]].
   *
   * @tparam HE
   *   The type of the body to which the response is deserialized, when the response code is different than success
@@ -31,7 +34,7 @@ sealed abstract class ResponseException[+HE, +DE](error: String, cause: Option[T
 case class HttpError[+HE](body: HE, statusCode: StatusCode)
     extends ResponseException[HE, Nothing](s"statusCode: $statusCode, response: $body", None)
 
-/** Represents an error that occured during deserialization of `body`.
+/** Represents an error that occurred during deserialization of `body`.
   *
   * @tparam DE
   *   A deserialization-library-specific error type, describing the deserialization error in more detail.

--- a/core/src/main/scala/sttp/client4/ResponseException.scala
+++ b/core/src/main/scala/sttp/client4/ResponseException.scala
@@ -42,11 +42,11 @@ case class DeserializationException(body: String, cause: Exception, override val
       response
     )
 
-object HttpError {
-  @tailrec def find(exception: Throwable): Option[HttpError[_]] =
+object ResponseException {
+  @tailrec def find(exception: Throwable): Option[ResponseException[_]] =
     Option(exception) match {
-      case Some(error: HttpError[_]) => Some(error)
-      case Some(_)                   => find(exception.getCause)
-      case None                      => Option.empty
+      case Some(e: ResponseException[_]) => Some(e)
+      case Some(_)                       => find(exception.getCause)
+      case None                          => None
     }
 }

--- a/core/src/main/scala/sttp/client4/ResponseException.scala
+++ b/core/src/main/scala/sttp/client4/ResponseException.scala
@@ -3,17 +3,18 @@ package sttp.client4
 import scala.annotation.tailrec
 import sttp.model.ResponseMetadata
 
-/** Used to represent errors, that might occur when handling the response body. Typically, this type is used as the
-  * left-side of a top-level either (where the right-side represents a successful request and deserialization),
+/** Used to represent errors, that might occur when handling the response body, that was otherwise received
+  * successfully.
   *
   * A response exception can itself be one of two cases:
   *   - a [[HttpError]], when the response code is other than 2xx (or whatever is considered "success" by the response
   *     handling description); the body is deserialized to `HE`
-  *   - a [[DeserializationException]], when there's an error during deserialization (this might include both
-  *     deserialization exceptions of the success and error branches)
+  *   - a [[DeserializationException]], when there's an error during deserialization (this includes deserialization
+  *     exceptions of both the success and error branches)
   *
-  * When thrown/returned when sending a request (e.g. in `...OrFailed` response handling descriptions), will be
-  * additionally wrapped with a [[SttpClientException.ResponseHandlingException]].
+  * This type is often used as the left-side of a top-level either (where the right-side represents a successful request
+  * and deserialization). When thrown/returned when sending a request (e.g. in `...OrFailed` response handling
+  * descriptions), will be additionally wrapped with a [[SttpClientException.ResponseHandlingException]].
   *
   * @tparam HE
   *   The type of the body to which the response is deserialized, when the response code is different than success

--- a/core/src/main/scala/sttp/client4/ResponseException.scala
+++ b/core/src/main/scala/sttp/client4/ResponseException.scala
@@ -32,7 +32,7 @@ sealed abstract class ResponseException[+HE](
   *   The type of the body to which the error response is deserialized.
   */
 case class HttpError[+HE](body: HE, override val response: ResponseMetadata)
-    extends ResponseException[HE](s"statusCode: $${response.statusCode}, response: $body", None, response)
+    extends ResponseException[HE](s"statusCode: ${response.code}, response: $body", None, response)
 
 /** Represents an error that occurred during deserialization of `body`. */
 case class DeserializationException(body: String, cause: Exception, override val response: ResponseMetadata)

--- a/core/src/main/scala/sttp/client4/SttpApi.scala
+++ b/core/src/main/scala/sttp/client4/SttpApi.scala
@@ -54,8 +54,8 @@ trait SttpApi extends SttpExtensions with UriInterpolator {
   val basicRequest: PartialRequest[Either[String, String]] =
     emptyRequest.acceptEncoding("gzip, deflate")
 
-  /** A starting request which always reads the response body as a string, if the response code is successfull (2xx),
-    * and fails (throws an exception, or returns a failed effect) otherwise.
+  /** A starting request which always reads the response body as a string, if the response code is successful (2xx), and
+    * fails (throws an exception, or returns a failed effect) otherwise.
     */
   val quickRequest: PartialRequest[String] = basicRequest.response(asStringOrFail)
 
@@ -96,8 +96,8 @@ trait SttpApi extends SttpExtensions with UriInterpolator {
       }
       .showAs("as string")
 
-  /** Reads the response as a `String`, if the status code is 2xx. Otherwise, throws an [[HttpError]] / returns a failed
-    * effect. Use the `utf-8` charset by default, unless specified otherwise in the response headers.
+  /** Reads the response as a `String`, if the status code is 2xx. Otherwise, throws an [[UnexpectedStatusCode]] /
+    * returns a failed effect. Use the `utf-8` charset by default, unless specified otherwise in the response headers.
     *
     * @see
     *   the [[ResponseAs#orFail]] method can be used to convert any response description which returns an `Either` into
@@ -116,7 +116,7 @@ trait SttpApi extends SttpExtensions with UriInterpolator {
   def asByteArrayAlways: ResponseAs[Array[Byte]] = ResponseAs(ResponseAsByteArray)
 
   /** Reads the response as an array of bytes, without any processing, if the status code is 2xx. Otherwise, throws an
-    * [[HttpError]] / returns a failed effect.
+    * [[UnexpectedStatusCode]] / returns a failed effect.
     *
     * @see
     *   the [[ResponseAs#orFail]] method can be used to convert any response description which returns an `Either` into
@@ -148,8 +148,9 @@ trait SttpApi extends SttpExtensions with UriInterpolator {
     asStringAlways(charset2).map(GenericResponseAs.parseParams(_, charset2)).showAs("as params")
   }
 
-  /** Deserializes the response as form parameters, if the status code is 2xx. Otherwise, throws an [[HttpError]] /
-    * returns a failed effect. Uses the `utf-8` charset by default, unless specified otherwise in the response headers.
+  /** Deserializes the response as form parameters, if the status code is 2xx. Otherwise, throws an
+    * [[UnexpectedStatusCode]] / returns a failed effect. Uses the `utf-8` charset by default, unless specified
+    * otherwise in the response headers.
     *
     * @see
     *   the [[ResponseAs#orFail]] method can be used to convert any response description which returns an `Either` into
@@ -284,8 +285,8 @@ trait SttpApi extends SttpExtensions with UriInterpolator {
     asEither(asStringAlways, asStreamAlways(s)(f))
 
   /** Handles the response body by providing a stream with the response's data to `f`, if the status code is 2xx.
-    * Otherwise, returns a failed effect (with [[HttpError]]). The effect type used by `f` must be compatible with the
-    * effect type of the backend. The stream is always closed after `f` completes.
+    * Otherwise, returns a failed effect (with [[UnexpectedStatusCode]]). The effect type used by `f` must be compatible
+    * with the effect type of the backend. The stream is always closed after `f` completes.
     *
     * A non-blocking, asynchronous streaming implementation must be provided as the [[Streams]] parameter.
     *

--- a/core/src/main/scala/sttp/client4/SttpClientException.scala
+++ b/core/src/main/scala/sttp/client4/SttpClientException.scala
@@ -39,10 +39,8 @@ object SttpClientException extends SttpClientExceptionExtensions {
   /** Wraps a [[ResponseException]] which occurred during response handling. Enriches the response exception with the
     * context of the request, for which it happened.
     */
-  class ResponseHandlingException[+HE, +DE](
-      request: GenericRequest[_, _],
-      val responseException: ResponseException[HE, DE]
-  ) extends ReadException(request, responseException)
+  class ResponseHandlingException[+HE](request: GenericRequest[_, _], val responseException: ResponseException[HE])
+      extends ReadException(request, responseException)
 
   def adjustExceptions[F[_], T](
       monadError: MonadError[F]

--- a/core/src/main/scala/sttp/client4/SttpClientException.scala
+++ b/core/src/main/scala/sttp/client4/SttpClientException.scala
@@ -23,13 +23,15 @@ import sttp.monad.MonadError
   * @param cause
   *   The original exception.
   */
-abstract class SttpClientException(val request: GenericRequest[_, _], val cause: Exception)
+sealed abstract class SttpClientException(val request: GenericRequest[_, _], val cause: Exception)
     extends Exception(s"Exception when sending request: ${request.method} ${request.uri}", cause)
 
 object SttpClientException extends SttpClientExceptionExtensions {
   class ConnectException(request: GenericRequest[_, _], cause: Exception) extends SttpClientException(request, cause)
 
   class ReadException(request: GenericRequest[_, _], cause: Exception) extends SttpClientException(request, cause)
+
+  //
 
   class TimeoutException(request: GenericRequest[_, _], cause: Exception) extends ReadException(request, cause)
 
@@ -41,6 +43,8 @@ object SttpClientException extends SttpClientExceptionExtensions {
     */
   class ResponseHandlingException[+HE](request: GenericRequest[_, _], val responseException: ResponseException[HE])
       extends ReadException(request, responseException)
+
+  //
 
   def adjustExceptions[F[_], T](
       monadError: MonadError[F]

--- a/core/src/main/scala/sttp/client4/SttpClientException.scala
+++ b/core/src/main/scala/sttp/client4/SttpClientException.scala
@@ -1,12 +1,16 @@
 package sttp.client4
 
 import sttp.monad.MonadError
-import sttp.model.Uri
 
 /** Known exceptions that might occur when using a backend. Currently this covers:
-  *   - connect exceptions: when a connection (tcp socket) can't be established to the target host
-  *   - read exceptions: when a connection has been established, but there's any kind of problem receiving or handling
-  *     the response (e.g. a broken socket or a deserialization error)
+  *   - [[SttpClientException.ConnectException]]: when a connection (tcp socket) can't be established to the target host
+  *   - [[SttpClientException.ReadException]]: when a connection has been established, but there's any kind of problem
+  *     receiving or handling the response (e.g. a broken socket or a deserialization error)
+  *
+  * The read exceptions are further classified into:
+  *   - [[SttpClientException.TimeoutException]]
+  *   - [[SttpClientException.TooManyRedirectsException]]
+  *   - [[SttpClientException.ResponseHandlingException]], wrapping a [[ResponseException]]
   *
   * In general, it's safe to assume that the request hasn't been sent in case of connect exceptions. With read
   * exceptions, the target host might or might have not received and processed the request.
@@ -31,6 +35,14 @@ object SttpClientException extends SttpClientExceptionExtensions {
 
   class TooManyRedirectsException(request: GenericRequest[_, _], val redirects: Int)
       extends ReadException(request, null)
+
+  /** Wraps a [[ResponseException]] which occurred during response handling. Enriches the response exception with the
+    * context of the request, for which it happened.
+    */
+  class ResponseHandlingException[+HE, +DE](
+      request: GenericRequest[_, _],
+      val responseException: ResponseException[HE, DE]
+  ) extends ReadException(request, responseException)
 
   def adjustExceptions[F[_], T](
       monadError: MonadError[F]

--- a/core/src/main/scala/sttp/client4/SttpWebSocketAsyncApi.scala
+++ b/core/src/main/scala/sttp/client4/SttpWebSocketAsyncApi.scala
@@ -15,7 +15,7 @@ trait SttpWebSocketAsyncApi {
     asWebSocketEither(asStringAlways, asWebSocketAlways(f))
 
   /** Handles the response as a web socket, providing an open [[WebSocket]] instance to the `f` function, if the status
-    * code is 2xx. Otherwise, returns a failed effect (with [[HttpError]]).
+    * code is 2xx. Otherwise, returns a failed effect (with [[]]).
     *
     * The effect type used by `f` must be compatible with the effect type of the backend. The web socket is always
     * closed after `f` completes.

--- a/core/src/main/scala/sttp/client4/SttpWebSocketStreamApi.scala
+++ b/core/src/main/scala/sttp/client4/SttpWebSocketStreamApi.scala
@@ -20,7 +20,7 @@ trait SttpWebSocketStreamApi {
 
   /** Handles the response as a web socket, using the given `p` stream processing pipe to handle the incoming & produce
     * the outgoing web socket frames, if the status code is 2xx. Otherwise, returns a failed effect (with
-    * [[HttpError]]).
+    * [[UnexpectedStatusCode]]).
     *
     * The effect type used by `f` must be compatible with the effect type of the backend. The web socket is always
     * closed after `p` completes.

--- a/core/src/main/scala/sttp/client4/SttpWebSocketSyncApi.scala
+++ b/core/src/main/scala/sttp/client4/SttpWebSocketSyncApi.scala
@@ -16,7 +16,7 @@ trait SttpWebSocketSyncApi {
     asWebSocketEither(asStringAlways, asWebSocketAlways(f))
 
   /** Handles the response as a web socket, providing an open [[WebSocket]] instance to the `f` function, if the status
-    * code is 2xx. Otherwise, throws an [[HttpError]].
+    * code is 2xx. Otherwise, throws an [[UnexpectedStatusCode]].
     *
     * The web socket is always closed after `f` completes.
     *

--- a/core/src/main/scala/sttp/client4/logging/Log.scala
+++ b/core/src/main/scala/sttp/client4/logging/Log.scala
@@ -1,12 +1,12 @@
 package sttp.client4.logging
 
 import sttp.client4.GenericRequest
-import sttp.client4.HttpError
 import sttp.client4.Response
 import sttp.model.ResponseMetadata
 import sttp.model.StatusCode
 
 import scala.concurrent.duration.Duration
+import sttp.client4.ResponseException
 
 /** Performs logging before requests are sent and after requests complete successfully or with an exception. */
 trait Log[F[_]] {
@@ -72,6 +72,7 @@ class DefaultLog[F[_]](
           if (beforeCurlInsteadOfShow && _logRequestBody && _logRequestHeaders) request.toCurl(sensitiveHeaders)
           else request.show(includeBody = _logRequestBody, _logRequestHeaders, sensitiveHeaders)
         }",
+      throwable = None,
       context = logContext.forRequest(request)
     )
 
@@ -80,22 +81,14 @@ class DefaultLog[F[_]](
       response: Response[_],
       responseBody: Option[String],
       elapsed: Option[Duration]
-  ): F[Unit] = handleResponse(
-    request,
-    response,
-    responseBody,
-    request.loggingOptions.logResponseBody.getOrElse(responseBody.isDefined),
-    request.loggingOptions.logResponseHeaders.getOrElse(logResponseHeaders),
-    elapsed
-  )
+  ): F[Unit] = handleResponse(request, response, responseBody, elapsed, None)
 
   private def handleResponse(
       request: GenericRequest[_, _],
       response: ResponseMetadata,
       responseBody: Option[String],
-      logResponseBody: Boolean,
-      _logResponseHeaders: Boolean,
-      elapsed: Option[Duration]
+      elapsed: Option[Duration],
+      e: Option[Throwable]
   ): F[Unit] = {
     val responseWithBody = Response(
       responseBody.getOrElse(""),
@@ -109,32 +102,30 @@ class DefaultLog[F[_]](
     logger(
       level = responseLogLevel(response.code),
       message = {
-        val responseAsString = responseWithBody.show(logResponseBody, _logResponseHeaders, sensitiveHeaders)
+        val responseAsString = responseWithBody.show(
+          request.loggingOptions.logResponseBody.getOrElse(responseBody.isDefined),
+          request.loggingOptions.logResponseHeaders.getOrElse(logResponseHeaders),
+          sensitiveHeaders
+        )
         s"Request: ${request.showBasic}${took(elapsed)}, response: $responseAsString"
       },
+      throwable = e,
       context = logContext.forResponse(request, response, elapsed)
     )
   }
 
-  override def requestException(request: GenericRequest[_, _], elapsed: Option[Duration], e: Exception): F[Unit] = {
-    val logLevel = HttpError.find(e) match {
-      case Some(HttpError(_, meta)) =>
-        responseLogLevel(meta.code)
-      case _ =>
-        responseExceptionLogLevel
+  override def requestException(request: GenericRequest[_, _], elapsed: Option[Duration], e: Exception): F[Unit] =
+    ResponseException.find(e) match {
+      case Some(re) =>
+        handleResponse(request, re.response, None, elapsed, Some(e))
+      case None =>
+        logger(
+          level = responseExceptionLogLevel,
+          message = s"Exception when sending request: ${request.showBasic}${took(elapsed)}",
+          throwable = Some(e),
+          context = logContext.forRequest(request)
+        )
     }
-    logger(
-      level = logLevel,
-      message = s"Exception when sending request: ${request.showBasic}${took(elapsed)}",
-      throwable = e,
-      context = logContext.forRequest(request)
-    )
-  }
 
   private def took(elapsed: Option[Duration]): String = elapsed.fold("")(e => f", took: ${e.toMillis / 1000.0}%.3fs")
-}
-
-object DefaultLog {
-  def defaultResponseLogLevel(c: StatusCode): LogLevel =
-    if (c.isClientError || c.isServerError) LogLevel.Warn else LogLevel.Debug
 }

--- a/core/src/main/scala/sttp/client4/logging/LogConfig.scala
+++ b/core/src/main/scala/sttp/client4/logging/LogConfig.scala
@@ -32,7 +32,9 @@ case class LogConfig(
     /** The log level that is used for the log message, that is being logged after receiving a response, depending on
       * the status code.
       */
-    responseLogLevel: StatusCode => LogLevel = DefaultLog.defaultResponseLogLevel,
+    responseLogLevel: StatusCode => LogLevel = { (c: StatusCode) =>
+      if (c.isClientError) LogLevel.Error else { if (c.isServerError) LogLevel.Warn else LogLevel.Debug }
+    },
     /** The log level that is used for the log message, that is being logged when an exception occurs during sending of
       * a request.
       */

--- a/core/src/main/scala/sttp/client4/logging/LogContext.scala
+++ b/core/src/main/scala/sttp/client4/logging/LogContext.scala
@@ -1,15 +1,14 @@
 package sttp.client4.logging
 
-import sttp.client4.Response
 import sttp.model.{HeaderNames, RequestMetadata}
 
 import scala.collection.mutable
 import scala.concurrent.duration.Duration
+import sttp.model.ResponseMetadata
 
 trait LogContext {
   def forRequest(request: RequestMetadata): Map[String, Any]
-
-  def forResponse(response: Response[_], duration: Option[Duration]): Map[String, Any]
+  def forResponse(request: RequestMetadata, response: ResponseMetadata, duration: Option[Duration]): Map[String, Any]
 }
 
 object LogContext {
@@ -18,7 +17,11 @@ object LogContext {
     */
   def empty: LogContext = new LogContext {
     def forRequest(request: RequestMetadata): Map[String, Any] = Map.empty
-    def forResponse(response: Response[_], duration: Option[Duration]): Map[String, Any] = Map.empty
+    def forResponse(
+        request: RequestMetadata,
+        response: ResponseMetadata,
+        duration: Option[Duration]
+    ): Map[String, Any] = Map.empty
   }
 
   /** Default log context, which logs the main request and response metadata.
@@ -45,10 +48,14 @@ object LogContext {
       context.toMap
     }
 
-    def forResponse(response: Response[_], duration: Option[Duration]): Map[String, Any] = {
+    def forResponse(
+        request: RequestMetadata,
+        response: ResponseMetadata,
+        duration: Option[Duration]
+    ): Map[String, Any] = {
       val context = mutable.Map.empty[String, Any]
 
-      context ++= forRequest(response.request)
+      context ++= forRequest(request)
       context += "http.response.status_code" -> response.code.code
 
       if (logResponseHeaders)

--- a/core/src/main/scala/sttp/client4/logging/Logger.scala
+++ b/core/src/main/scala/sttp/client4/logging/Logger.scala
@@ -2,8 +2,7 @@ package sttp.client4.logging
 
 /** Interfaces with a logger system. */
 trait Logger[F[_]] {
-  def apply(level: LogLevel, message: => String, context: Map[String, Any]): F[Unit]
-  def apply(level: LogLevel, message: => String, throwable: Throwable, context: Map[String, Any]): F[Unit]
+  def apply(level: LogLevel, message: => String, throwable: Option[Throwable], context: Map[String, Any]): F[Unit]
 }
 
 sealed trait LogLevel

--- a/core/src/main/scala/sttp/client4/request.scala
+++ b/core/src/main/scala/sttp/client4/request.scala
@@ -59,6 +59,8 @@ sealed trait GenericRequest[+T, -R] extends RequestBuilder[GenericRequest[T, R]]
     case _: WebSocketStreamRequest[_, _] => true
     case _                               => false
   }
+
+  override def showBasic: String = s"$method $uri"
 }
 
 //
@@ -85,8 +87,6 @@ case class Request[T](
     attributes: AttributeMap
 ) extends GenericRequest[T, Any]
     with RequestBuilder[Request[T]] {
-
-  override def showBasic: String = s"$method $uri"
 
   override def method(method: Method, uri: Uri): Request[T] = copy(uri = uri, method = method)
   override def withHeaders(headers: Seq[Header]): Request[T] = copy(headers = headers)
@@ -212,8 +212,6 @@ final case class StreamRequest[T, R](
 ) extends GenericRequest[T, R]
     with RequestBuilder[StreamRequest[T, R]] {
 
-  override def showBasic: String = s"$method $uri"
-
   override def method(method: Method, uri: Uri): StreamRequest[T, R] = copy(method = method, uri = uri)
   override def withHeaders(headers: Seq[Header]): StreamRequest[T, R] = copy(headers = headers)
   override def withOptions(options: RequestOptions): StreamRequest[T, R] = copy(options = options)
@@ -294,8 +292,6 @@ final case class WebSocketRequest[F[_], T](
 ) extends GenericRequest[T, WebSockets with Effect[F]]
     with RequestBuilder[WebSocketRequest[F, T]] {
 
-  override def showBasic: String = s"$method (WebSocket) $uri"
-
   override def method(method: Method, uri: Uri): WebSocketRequest[F, T] = copy(method = method, uri = uri)
   override def withHeaders(headers: Seq[Header]): WebSocketRequest[F, T] = copy(headers = headers)
   override def withOptions(options: RequestOptions): WebSocketRequest[F, T] = copy(options = options)
@@ -373,8 +369,6 @@ final case class WebSocketStreamRequest[T, S](
     attributes: AttributeMap
 ) extends GenericRequest[T, S with WebSockets]
     with RequestBuilder[WebSocketStreamRequest[T, S]] {
-
-  override def showBasic: String = s"$method (WebSocket) $uri"
 
   override def method(method: Method, uri: Uri): WebSocketStreamRequest[T, S] = copy(method = method, uri = uri)
   override def withHeaders(headers: Seq[Header]): WebSocketStreamRequest[T, S] = copy(headers = headers)

--- a/core/src/main/scalajs/sttp/client4/SttpClientExceptionExtensions.scala
+++ b/core/src/main/scalajs/sttp/client4/SttpClientExceptionExtensions.scala
@@ -5,6 +5,8 @@ import sttp.client4.ws.{GotAWebSocketException, NotAWebSocketException}
 
 import scala.annotation.tailrec
 
+import sttp.client4.SttpClientException.ResponseHandlingException
+
 trait SttpClientExceptionExtensions {
   @tailrec
   final def defaultExceptionToSttpClientException(request: GenericRequest[_, _], e: Exception): Option[Exception] =
@@ -15,7 +17,7 @@ trait SttpClientExceptionExtensions {
       case e: java.io.IOException                   => Some(new ReadException(request, e))
       case e: NotAWebSocketException                => Some(new ReadException(request, e))
       case e: GotAWebSocketException                => Some(new ReadException(request, e))
-      case e: ResponseException[_, _]               => Some(new ReadException(request, e))
+      case e: ResponseException[_, _]               => Some(new ResponseHandlingException(request, e))
       case e if e.getCause != null && e.getCause.isInstanceOf[Exception] =>
         defaultExceptionToSttpClientException(request, e.getCause.asInstanceOf[Exception])
       case _ => None

--- a/core/src/main/scalajs/sttp/client4/SttpClientExceptionExtensions.scala
+++ b/core/src/main/scalajs/sttp/client4/SttpClientExceptionExtensions.scala
@@ -17,7 +17,7 @@ trait SttpClientExceptionExtensions {
       case e: java.io.IOException                   => Some(new ReadException(request, e))
       case e: NotAWebSocketException                => Some(new ReadException(request, e))
       case e: GotAWebSocketException                => Some(new ReadException(request, e))
-      case e: ResponseException[_, _]               => Some(new ResponseHandlingException(request, e))
+      case e: ResponseException[_]                  => Some(new ResponseHandlingException(request, e))
       case e if e.getCause != null && e.getCause.isInstanceOf[Exception] =>
         defaultExceptionToSttpClientException(request, e.getCause.asInstanceOf[Exception])
       case _ => None

--- a/core/src/main/scalajvm/sttp/client4/SttpClientExceptionExtensions.scala
+++ b/core/src/main/scalajvm/sttp/client4/SttpClientExceptionExtensions.scala
@@ -1,7 +1,11 @@
 package sttp.client4
 
-import sttp.client4.SttpClientException.{ConnectException, ReadException, TimeoutException}
-import sttp.client4.ws.{GotAWebSocketException, NotAWebSocketException}
+import sttp.client4.SttpClientException.ConnectException
+import sttp.client4.SttpClientException.ReadException
+import sttp.client4.SttpClientException.ResponseHandlingException
+import sttp.client4.SttpClientException.TimeoutException
+import sttp.client4.ws.GotAWebSocketException
+import sttp.client4.ws.NotAWebSocketException
 
 import scala.annotation.tailrec
 
@@ -24,7 +28,7 @@ trait SttpClientExceptionExtensions {
       case e: java.io.IOException                   => Some(new ReadException(request, e))
       case e: NotAWebSocketException                => Some(new ReadException(request, e))
       case e: GotAWebSocketException                => Some(new ReadException(request, e))
-      case e: ResponseException[_, _]               => Some(new ReadException(request, e))
+      case e: ResponseException[_, _]               => Some(new ResponseHandlingException(request, e))
       case e if e.getCause != null && e.getCause.isInstanceOf[Exception] =>
         defaultExceptionToSttpClientException(request, e.getCause.asInstanceOf[Exception])
       case _ => None

--- a/core/src/main/scalajvm/sttp/client4/SttpClientExceptionExtensions.scala
+++ b/core/src/main/scalajvm/sttp/client4/SttpClientExceptionExtensions.scala
@@ -1,13 +1,10 @@
 package sttp.client4
 
-import sttp.client4.SttpClientException.ConnectException
-import sttp.client4.SttpClientException.ReadException
-import sttp.client4.SttpClientException.ResponseHandlingException
-import sttp.client4.SttpClientException.TimeoutException
-import sttp.client4.ws.GotAWebSocketException
-import sttp.client4.ws.NotAWebSocketException
+import sttp.client4.SttpClientException.{ConnectException, ReadException, TimeoutException}
+import sttp.client4.ws.{GotAWebSocketException, NotAWebSocketException}
 
 import scala.annotation.tailrec
+import sttp.client4.SttpClientException.ResponseHandlingException
 
 trait SttpClientExceptionExtensions {
   @tailrec
@@ -28,7 +25,7 @@ trait SttpClientExceptionExtensions {
       case e: java.io.IOException                   => Some(new ReadException(request, e))
       case e: NotAWebSocketException                => Some(new ReadException(request, e))
       case e: GotAWebSocketException                => Some(new ReadException(request, e))
-      case e: ResponseException[_, _]               => Some(new ResponseHandlingException(request, e))
+      case e: ResponseException[_]                  => Some(new ResponseHandlingException(request, e))
       case e if e.getCause != null && e.getCause.isInstanceOf[Exception] =>
         defaultExceptionToSttpClientException(request, e.getCause.asInstanceOf[Exception])
       case _ => None

--- a/core/src/main/scalanative/sttp/client4/SttpClientExceptionExtensions.scala
+++ b/core/src/main/scalanative/sttp/client4/SttpClientExceptionExtensions.scala
@@ -1,6 +1,6 @@
 package sttp.client4
 
-import sttp.client4.SttpClientException.{ConnectException, ReadException, TimeoutException}
+import sttp.client4.SttpClientException.{ConnectException, ReadException, ResponseHandlingException, TimeoutException}
 import sttp.client4.ws.{GotAWebSocketException, NotAWebSocketException}
 
 import scala.annotation.tailrec
@@ -23,7 +23,7 @@ trait SttpClientExceptionExtensions {
       case e: java.io.IOException                   => Some(new ReadException(request, e))
       case e: NotAWebSocketException                => Some(new ReadException(request, e))
       case e: GotAWebSocketException                => Some(new ReadException(request, e))
-      case e: ResponseException[_, _]               => Some(new ReadException(request, e))
+      case e: ResponseException[_, _]               => Some(new ResponseHandlingException(request, e))
       case e if e.getCause != null && e.getCause.isInstanceOf[Exception] =>
         defaultExceptionToSttpClientException(request, e.getCause.asInstanceOf[Exception])
       case _ => None

--- a/core/src/main/scalanative/sttp/client4/SttpClientExceptionExtensions.scala
+++ b/core/src/main/scalanative/sttp/client4/SttpClientExceptionExtensions.scala
@@ -23,7 +23,7 @@ trait SttpClientExceptionExtensions {
       case e: java.io.IOException                   => Some(new ReadException(request, e))
       case e: NotAWebSocketException                => Some(new ReadException(request, e))
       case e: GotAWebSocketException                => Some(new ReadException(request, e))
-      case e: ResponseException[_, _]               => Some(new ResponseHandlingException(request, e))
+      case e: ResponseException[_]                  => Some(new ResponseHandlingException(request, e))
       case e if e.getCause != null && e.getCause.isInstanceOf[Exception] =>
         defaultExceptionToSttpClientException(request, e.getCause.asInstanceOf[Exception])
       case _ => None

--- a/core/src/test/scala/sttp/client4/LogContextTests.scala
+++ b/core/src/test/scala/sttp/client4/LogContextTests.scala
@@ -42,7 +42,7 @@ class LogContextTests extends AnyFlatSpec with Matchers {
       request = basicRequest.get(uri"http://example.org").auth.bearer("token")
     )
 
-    defaultLogContext.forResponse(response, Some(1234.millis)) should be(
+    defaultLogContext.forResponse(response.request, response, Some(1234.millis)) should be(
       Map(
         "http.request.uri" -> "http://example.org",
         "http.request.method" -> "GET",
@@ -65,7 +65,7 @@ class LogContextTests extends AnyFlatSpec with Matchers {
       request = basicRequest.get(uri"http://example.org").auth.bearer("token")
     )
 
-    defaultLogContext.forResponse(response, Some(1234.millis)) should be(
+    defaultLogContext.forResponse(response.request, response, Some(1234.millis)) should be(
       Map(
         "http.request.uri" -> "http://example.org",
         "http.request.method" -> "GET",

--- a/core/src/test/scala/sttp/client4/LogTests.scala
+++ b/core/src/test/scala/sttp/client4/LogTests.scala
@@ -10,6 +10,7 @@ import sttp.shared.Identity
 import scala.collection.immutable.Seq
 import scala.collection.mutable
 import sttp.client4.testing.ResponseStub
+import sttp.client4.ResponseException.DeserializationException
 
 class LogTests extends AnyFlatSpec with Matchers with BeforeAndAfter {
   private class SpyLogger extends Logger[Identity] {

--- a/core/src/test/scala/sttp/client4/testing/BackendStubTests.scala
+++ b/core/src/test/scala/sttp/client4/testing/BackendStubTests.scala
@@ -109,11 +109,13 @@ class BackendStubTests extends AnyFlatSpec with Matchers with ScalaFutures {
     val request = () =>
       basicRequest
         .get(uri"./test")
-        .response(asString.map(_ => throw DeserializationException("", new RuntimeException("test"))))
+        .response(
+          asString.mapWithMetadata((_, meta) => throw DeserializationException("", new RuntimeException("test"), meta))
+        )
         .send(testingBackend)
 
     val readException = the[sttp.client4.SttpClientException.ReadException] thrownBy request()
-    readException.cause shouldBe a[sttp.client4.DeserializationException[_]]
+    readException.cause shouldBe a[sttp.client4.DeserializationException]
   }
 
   it should "use rules in partial function" in {

--- a/core/src/test/scala/sttp/client4/testing/BackendStubTests.scala
+++ b/core/src/test/scala/sttp/client4/testing/BackendStubTests.scala
@@ -3,12 +3,16 @@ package sttp.client4.testing
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
-import sttp.client4.SttpClientException.ReadException
 import sttp.client4._
+import sttp.client4.ResponseException.DeserializationException
+import sttp.client4.SttpClientException.ReadException
 import sttp.client4.internal._
 import sttp.client4.ws.async._
 import sttp.model._
-import sttp.monad.{FutureMonad, IdentityMonad, MonadError, TryMonad}
+import sttp.monad.FutureMonad
+import sttp.monad.IdentityMonad
+import sttp.monad.MonadError
+import sttp.monad.TryMonad
 import sttp.shared.Identity
 import sttp.ws.WebSocketFrame
 import sttp.ws.testing.WebSocketStub
@@ -18,7 +22,9 @@ import java.util.concurrent.TimeoutException
 import java.util.concurrent.atomic.AtomicInteger
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
-import scala.util.{Failure, Success, Try}
+import scala.util.Failure
+import scala.util.Success
+import scala.util.Try
 
 class BackendStubTests extends AnyFlatSpec with Matchers with ScalaFutures {
   private val testingStub = SyncBackendStub
@@ -114,8 +120,8 @@ class BackendStubTests extends AnyFlatSpec with Matchers with ScalaFutures {
         )
         .send(testingBackend)
 
-    val readException = the[sttp.client4.SttpClientException.ReadException] thrownBy request()
-    readException.cause shouldBe a[sttp.client4.DeserializationException]
+    val readException = the[SttpClientException.ReadException] thrownBy request()
+    readException.cause shouldBe a[DeserializationException]
   }
 
   it should "use rules in partial function" in {

--- a/core/src/test/scala/sttp/client4/testing/HttpTest.scala
+++ b/core/src/test/scala/sttp/client4/testing/HttpTest.scala
@@ -160,7 +160,7 @@ trait HttpTest[F[_]]
         }
     }
 
-    "as failure, when the request is successfull" in {
+    "as failure, when the request is successful" in {
       basicRequest
         .post(uri"$endpoint/echo/custom_status/200")
         .body(testBody)
@@ -170,7 +170,7 @@ trait HttpTest[F[_]]
         .map(_.body shouldBe s"POST /echo/custom_status/200 $testBody")
     }
 
-    "as failure, when the request is not successfull" in {
+    "as failure, when the request is not successful" in {
       implicit val monadError: MonadError[F] = backend.monad
       basicRequest
         .post(uri"$endpoint/echo/custom_status/400")

--- a/core/src/test/scala/sttp/client4/testing/HttpTest.scala
+++ b/core/src/test/scala/sttp/client4/testing/HttpTest.scala
@@ -183,7 +183,7 @@ trait HttpTest[F[_]]
         }
         .toFuture()
         .map(
-          _ shouldBe "sttp.client4.ResponseException.UnexpectedStatusCode: statusCode: 400, response: POST /echo/custom_status/400 this is the body"
+          _ shouldBe "sttp.client4.ResponseException$UnexpectedStatusCode: statusCode: 400, response: POST /echo/custom_status/400 this is the body"
         )
     }
 

--- a/core/src/test/scala/sttp/client4/testing/HttpTest.scala
+++ b/core/src/test/scala/sttp/client4/testing/HttpTest.scala
@@ -183,7 +183,7 @@ trait HttpTest[F[_]]
         }
         .toFuture()
         .map(
-          _ shouldBe "sttp.client4.HttpError: statusCode: 400, response: POST /echo/custom_status/400 this is the body"
+          _ shouldBe "sttp.client4.ResponseException.UnexpectedStatusCode: statusCode: 400, response: POST /echo/custom_status/400 this is the body"
         )
     }
 

--- a/core/src/test/scala/sttp/client4/testing/streaming/StreamingTest.scala
+++ b/core/src/test/scala/sttp/client4/testing/streaming/StreamingTest.scala
@@ -286,7 +286,7 @@ abstract class StreamingTest[F[_], S]
       }
       .toFuture()
       .map(
-        _ shouldBe "sttp.client4.ResponseException.UnexpectedStatusCode: statusCode: 400, response: POST /echo/custom_status/400 streaming test"
+        _ shouldBe "sttp.client4.ResponseException$UnexpectedStatusCode: statusCode: 400, response: POST /echo/custom_status/400 streaming test"
       )
   }
 

--- a/core/src/test/scala/sttp/client4/testing/streaming/StreamingTest.scala
+++ b/core/src/test/scala/sttp/client4/testing/streaming/StreamingTest.scala
@@ -286,7 +286,7 @@ abstract class StreamingTest[F[_], S]
       }
       .toFuture()
       .map(
-        _ shouldBe "sttp.client4.HttpError: statusCode: 400, response: POST /echo/custom_status/400 streaming test"
+        _ shouldBe "sttp.client4.ResponseException.UnexpectedStatusCode: statusCode: 400, response: POST /echo/custom_status/400 streaming test"
       )
   }
 

--- a/core/src/test/scala/sttp/client4/testing/websocket/WebSocketTest.scala
+++ b/core/src/test/scala/sttp/client4/testing/websocket/WebSocketTest.scala
@@ -163,7 +163,9 @@ abstract class WebSocketTest[F[_]]
     val errCounter = new AtomicInteger()
 
     override def apply(level: LogLevel, message: => String, t: Option[Throwable], context: Map[String, Any]): F[Unit] =
-      monad.unit(println(message + t.fold("")(_.toString))).map(_ => errCounter.incrementAndGet())
+      monad.unit(println(message + t.fold("")(_.toString))).map { _ =>
+        val _ = if (level == LogLevel.Error) errCounter.incrementAndGet() else msgCounter.incrementAndGet()
+      }
   }
 
   it should "work with LoggingBackend" in {

--- a/core/src/test/scala/sttp/client4/testing/websocket/WebSocketTest.scala
+++ b/core/src/test/scala/sttp/client4/testing/websocket/WebSocketTest.scala
@@ -162,10 +162,8 @@ abstract class WebSocketTest[F[_]]
     val msgCounter = new AtomicInteger()
     val errCounter = new AtomicInteger()
 
-    override def apply(level: LogLevel, message: => String, context: Map[String, Any]): F[Unit] =
-      monad.unit(println(message)).map(_ => msgCounter.incrementAndGet())
-    override def apply(level: LogLevel, message: => String, t: Throwable, context: Map[String, Any]): F[Unit] =
-      monad.unit(println(message + t.toString)).map(_ => errCounter.incrementAndGet())
+    override def apply(level: LogLevel, message: => String, t: Option[Throwable], context: Map[String, Any]): F[Unit] =
+      monad.unit(println(message + t.fold("")(_.toString))).map(_ => errCounter.incrementAndGet())
   }
 
   it should "work with LoggingBackend" in {

--- a/docs/migrate_v3_v4.md
+++ b/docs/migrate_v3_v4.md
@@ -42,4 +42,5 @@ Any `Either`-based response description can be converted to a failing one using 
 * `async-http-client` backends are removed (as there's no reactive streams support in v3, making integration difficult)
 * request attributes replace request tags (same mechanism as in Tapir)
 * the parametrization of `ResponseException` is simplified, `DeserializationException` does not have a type parameter, always requiring an `Exception` as the cause instead
-* when a `DeserializationException` is thrown in the response handling specification, this will be logged as a successful response (as the response was received correctly), and counted as a success in the metrics as well
+* when a `ResponseException` is thrown in the response handling specification, this will be logged as a successful response (as the response was received correctly), and counted as a success in the metrics as well
+* `HttpError` is renamed to `UnexpectedStatusCode`, and along with `DeserializationException`, both types are nested within `ResponseException`

--- a/docs/migrate_v3_v4.md
+++ b/docs/migrate_v3_v4.md
@@ -42,3 +42,4 @@ Any `Either`-based response description can be converted to a failing one using 
 * `async-http-client` backends are removed (as there's no reactive streams support in v3, making integration difficult)
 * request attributes replace request tags (same mechanism as in Tapir)
 * the parametrization of `ResponseException` is simplified, `DeserializationException` does not have a type parameter, always requiring an `Exception` as the cause instead
+* when a `DeserializationException` is thrown in the response handling specification, this will be logged as a successful response (as the response was received correctly), and counted as a success in the metrics as well

--- a/docs/migrate_v3_v4.md
+++ b/docs/migrate_v3_v4.md
@@ -41,3 +41,4 @@ Any `Either`-based response description can be converted to a failing one using 
 * the `autoDecompressionDisabled` option is superseded by `autoDecompressionEnabled`
 * `async-http-client` backends are removed (as there's no reactive streams support in v3, making integration difficult)
 * request attributes replace request tags (same mechanism as in Tapir)
+* the parametrization of `ResponseException` is simplified, `DeserializationException` does not have a type parameter, always requiring an `Exception` as the cause instead

--- a/docs/other/json.md
+++ b/docs/other/json.md
@@ -22,10 +22,10 @@ import sttp.client4.*
 def asJson[B](b: B): StringBody = ???
 
 // response handling description
-def asJson[B]: ResponseAs[Either[ResponseException[String, Exception], B]] = ???
+def asJson[B]: ResponseAs[Either[ResponseException[String], B]] = ???
 def asJsonOrFail[B]: ResponseAs[B] = ???
-def asJsonAlways[B]: ResponseAs[Either[DeserializationException[Exception], B]] = ???
-def asJsonEither[E, B]: ResponseAs[Either[ResponseException[E, Exception], B]] = ???
+def asJsonAlways[B]: ResponseAs[Either[DeserializationException, B]] = ???
+def asJsonEither[E, B]: ResponseAs[Either[ResponseException[E], B]] = ???
 def asJsonEitherOrFail[E, B]: ResponseAs[Either[E, B]] = ???
 ```
 
@@ -60,7 +60,7 @@ val backend: SyncBackend = DefaultSyncBackend()
 import io.circe.generic.auto._
 val requestPayload = RequestPayload("some data")
 
-val response: Response[Either[ResponseException[String, io.circe.Error], ResponsePayload]] =
+val response: Response[Either[ResponseException[String], ResponsePayload]] =
   basicRequest
     .post(uri"...")
     .body(asJson(requestPayload))
@@ -98,7 +98,7 @@ val requestPayload = RequestPayload("some data")
 given Serialization = org.json4s.native.Serialization
 given Formats = org.json4s.DefaultFormats
 
-val response: Response[Either[ResponseException[String, Exception], ResponsePayload]] =
+val response: Response[Either[ResponseException[String], ResponsePayload]] =
   basicRequest
     .post(uri"...")
     .body(asJson(requestPayload))
@@ -130,7 +130,7 @@ implicit val myResponseJsonFormat: RootJsonFormat[ResponsePayload] = ???
 
 val requestPayload = RequestPayload("some data")
 
-val response: Response[Either[ResponseException[String, Exception], ResponsePayload]] =
+val response: Response[Either[ResponseException[String], ResponsePayload]] =
   basicRequest
     .post(uri"...")
     .body(asJson(requestPayload))
@@ -187,7 +187,7 @@ implicit val myResponseJsonDecoder: JsonDecoder[ResponsePayload] = DeriveJsonDec
 
 val requestPayload = RequestPayload("some data")
 
-val response: Response[Either[ResponseException[String, String], ResponsePayload]] =
+val response: Response[Either[ResponseException[String], ResponsePayload]] =
 basicRequest
   .post(uri"...")
   .body(asJson(requestPayload))
@@ -227,7 +227,7 @@ implicit val payloadJsonCodec: JsonValueCodec[RequestPayload] = JsonCodecMaker.m
 implicit val jsonEitherDecoder: JsonValueCodec[ResponsePayload] = JsonCodecMaker.make
 val requestPayload = RequestPayload("some data")
 
-val response: Response[Either[ResponseException[String, Exception], ResponsePayload]] =
+val response: Response[Either[ResponseException[String], ResponsePayload]] =
 basicRequest
   .post(uri"...")
   .body(asJson(requestPayload))
@@ -264,7 +264,7 @@ implicit val responsePayloadRW: ReadWriter[ResponsePayload] = macroRW[ResponsePa
 
 val requestPayload = RequestPayload("some data")
 
-val response: Response[Either[ResponseException[String, Exception], ResponsePayload]] =
+val response: Response[Either[ResponseException[String], ResponsePayload]] =
 basicRequest
   .post(uri"...")
   .body(asJson(requestPayload))

--- a/docs/other/json.md
+++ b/docs/other/json.md
@@ -17,6 +17,7 @@ The type signatures vary depending on the underlying library (required implicits
 
 ```scala mdoc:compile-only
 import sttp.client4.*
+import sttp.client4.ResponseException.DeserializationException
 
 // request bodies
 def asJson[B](b: B): StringBody = ???

--- a/docs/other/xml.md
+++ b/docs/other/xml.md
@@ -33,7 +33,7 @@ trait SttpScalaxbApi:
         case e: Exception => Left(e)
 
   // response body handling description
-  def asXml[B: XMLFormat]: ResponseAs[Either[ResponseException[String, Exception], B], Any] =
+  def asXml[B: XMLFormat]: ResponseAs[Either[ResponseException[String], B], Any] =
     asString.mapWithMetadata(ResponseAs.deserializeRightWithError(deserializeXml[B]))
       .showAs("either(as string, as xml)")
 ```
@@ -64,7 +64,7 @@ given XmlElementLabel = XmlElementLabel("outer")
 // this import may differ depending on location of generated code
 import generated.Generated_OuterFormat 
 
-val response: Response[Either[ResponseException[String, Exception], Outer]] =
+val response: Response[Either[ResponseException[String], Outer]] =
   basicRequest
     .post(uri"...")
     .body(asXml(requestPayload))

--- a/docs/responses/body.md
+++ b/docs/responses/body.md
@@ -91,10 +91,10 @@ import sttp.client4.*
 basicRequest.response(asStringOrFail): PartialRequest[String]
 ```
 
-The `.orFail` combinator works in all cases where the response body is specified to be deserialized as an `Either`. If the left is already an exception, it will be thrown unchanged. Otherwise, the left-value will be wrapped in an `HttpError`.
+The `.orFail` combinator works in all cases where the response body is specified to be deserialized as an `Either`. If the left is already an exception, it will be thrown unchanged. Otherwise, the left-value will be wrapped in an `UnexpectedStatusCode`.
 
 ```{note}
-While both ``asStringAlways`` and ``asStringOrFail`` have the type ``ResponseAs[String]``, they are different. The first will return the response body as a string always, regardless of the responses' status code. The second will return a failed effect / throw a ``HttpError`` exception for non-2xx status codes, and the string as body only for 2xx status codes.
+While both `asStringAlways` and `asStringOrFail` have the type `ResponseAs[String]`, they are different. The first will return the response body as a string always, regardless of the responses' status code. The second will return a failed effect / throw a `UnexpectedStatusCode` exception for non-2xx status codes, and the string as body only for 2xx status codes.
 ```
 
 There's also a variant of the combinator, `.orFailDeserialization`, which can be used to extract typed errors and fail the effect if there's a deserialization error.

--- a/docs/responses/body.md
+++ b/docs/responses/body.md
@@ -153,7 +153,7 @@ sealed trait MyModel
 case class SuccessModel(name: String, age: Int) extends MyModel
 case class ErrorModel(message: String) extends MyModel
 
-val myRequest: Request[Either[ResponseException[String, io.circe.Error], MyModel]] =
+val myRequest: Request[Either[ResponseException[String], MyModel]] =
   basicRequest
     .get(uri"https://example.com")
     .response(fromMetadata(

--- a/docs/responses/exceptions.md
+++ b/docs/responses/exceptions.md
@@ -24,7 +24,7 @@ Unknown exceptions aren't categorized and are re-thrown unchanged.
 
 ## Response-handling, deserialization errors
 
-Exceptions might be thrown when deserializing the response body - depending on the specification of how to handle response bodies. The built-in deserializers (see e.g. [json](../other/json.md)) return errors represented as `ResponseException[HE]`, which can either be a `HttpError` (protocol-level failures, containing a potentially deserialized body value) or a `DeserializationException` (containing a deserialization-library-specific exception).
+Exceptions might be thrown when deserializing the response body - depending on the specification of how to handle response bodies. The built-in deserializers (see e.g. [json](../other/json.md)) return errors represented as `ResponseException[HE]`, which can either be a `UnexpectedStatusCode` (protocol-level failures, containing a potentially deserialized body value) or a `DeserializationException` (containing a deserialization-library-specific exception).
 
 This means that a typical `asJson` response specification will result in the body being read as:
 

--- a/docs/responses/exceptions.md
+++ b/docs/responses/exceptions.md
@@ -7,25 +7,30 @@ HTTP requests might fail in a variety of ways! There are two basic types of fail
 
 The first type of failures is represented by exceptions, which are thrown when sending the request (using `request.send(backend)`). The second type of failure is represented as a `Response[T]`, with the appropriate response code. The response body might depend on the status code; by default the response is read as a `Either[String, String]`, where the left side represents protocol-level failure, and the right side: success.
 
-Exceptions might be thrown directly (synchronous, direct-style backends), or returned as failed effects (other backends, e.g. failed `scala.concurrent.Future`). Backends will try to categorise these exceptions into a `SttpClientException`, which has three subclasses:
+Exceptions might be thrown directly (synchronous, direct-style backends), or returned as failed effects (other backends, e.g. failed `scala.concurrent.Future`). Backends will try to categorize these exceptions into a `SttpClientException`, which has two main subclass branches:
 
 * `ConnectException`: when a connection (tcp socket) can't be established to the target host
 * `ReadException`: when a connection has been established, but there's any kind of problem receiving the response (e.g. a broken socket)
-* `TimeoutException`: a discriminated subtype of `ReadException` for timeout fails
+
+Read exceptions might be further categorized into:
+
+* `TimeoutException`: any kind of timeout when reading
+* `TooManyRedirectsException`: throw by the [follow-redirects](../conf/redirects.md) backend
+* `ResponseHandlingException`: wrapping a [[ResponseException]] (exception that occurs when handling the response body, using e.g. `asJson`)
 
 In general, it's safe to assume that the request hasn't been sent in case of connect exceptions. With read exceptions, the target host might or might not have received and processed the request.
 
-Unknown exceptions aren't categorised and are re-thrown unchanged.
+Unknown exceptions aren't categorized and are re-thrown unchanged.
 
-## Deserialization errors
+## Response-handling, deserialization errors
 
-Exceptions might also be thrown when deserializing the response body - depending on the specification of how to handle response bodies. The built-in deserializers (see e.g. [json](../other/json.md)) return errors represented as `ResponseException[HE, DE]`, which can either be a `HttpError` (protocol-level failures, containing a potentially deserialized body value) or a `DeserializationException` (containing a deserialization-library-specific exception).
+Exceptions might be thrown when deserializing the response body - depending on the specification of how to handle response bodies. The built-in deserializers (see e.g. [json](../other/json.md)) return errors represented as `ResponseException[HE]`, which can either be a `HttpError` (protocol-level failures, containing a potentially deserialized body value) or a `DeserializationException` (containing a deserialization-library-specific exception).
 
 This means that a typical `asJson` response specification will result in the body being read as:
 
 ```scala mdoc:silent
 import sttp.client4.*
-def asJson[T]: ResponseAs[Either[ResponseException[String, Exception], T]] = ???
+def asJson[T]: ResponseAs[Either[ResponseException[String], T]] = ???
 ``` 
 
 There are also the `.orFail` and `.orFailDeserialization` methods on eligible response specifications, which convert http errors or deserialization exceptions as failed effects.
@@ -37,5 +42,5 @@ Summing up, when the response is deserialized (e.g. to json), sending a request 
 * network-level success (HTTP request sent and response received)
   * http error (4xx, 5xx), successfully parsed (**a value wrapped in `Left`, or a failed effect**)
   * http success (2xx), successfully parsed (**a value possibly wrapped in `Right`**)
-  * deseralization error (**a value wrapped in `Left`, or a failed effect**)
+  * deserialization error (**a value wrapped in `Left`, or a failed effect**)
 * network-level failure (invalid host, broken socket): failed effect

--- a/effects/ox/src/test/scala/sttp/client4/impl/ox/ws/OxWebSocketsTest.scala
+++ b/effects/ox/src/test/scala/sttp/client4/impl/ox/ws/OxWebSocketsTest.scala
@@ -145,7 +145,7 @@ class OxWebSocketTest extends AnyFlatSpec with BeforeAndAfterAll with Matchers w
     val errCounter = new AtomicInteger()
 
     override def apply(level: LogLevel, message: => String, t: Option[Throwable], context: Map[String, Any]): Unit =
-      errCounter.incrementAndGet().discard
+      if level == LogLevel.Error then errCounter.incrementAndGet().discard else msgCounter.incrementAndGet().discard
 
   it should "work with LoggingBackend" in supervised {
     val logger = new TestLogger()

--- a/effects/ox/src/test/scala/sttp/client4/impl/ox/ws/OxWebSocketsTest.scala
+++ b/effects/ox/src/test/scala/sttp/client4/impl/ox/ws/OxWebSocketsTest.scala
@@ -144,9 +144,7 @@ class OxWebSocketTest extends AnyFlatSpec with BeforeAndAfterAll with Matchers w
     val msgCounter = new AtomicInteger()
     val errCounter = new AtomicInteger()
 
-    override def apply(level: LogLevel, message: => String, context: Map[String, Any]): Unit =
-      msgCounter.incrementAndGet().discard
-    override def apply(level: LogLevel, message: => String, t: Throwable, context: Map[String, Any]): Unit =
+    override def apply(level: LogLevel, message: => String, t: Option[Throwable], context: Map[String, Any]): Unit =
       errCounter.incrementAndGet().discard
 
   it should "work with LoggingBackend" in supervised {

--- a/examples/src/main/scala/sttp/client4/examples/GetRawResponseBodySynchronous.scala
+++ b/examples/src/main/scala/sttp/client4/examples/GetRawResponseBodySynchronous.scala
@@ -10,21 +10,21 @@ import io.circe.generic.auto.*
 import sttp.client4.*
 import sttp.client4.circe.*
 
-@main def getRawResponseBodySynchronous(): Unit =
-  case class HttpBinResponse(origin: String, headers: Map[String, String])
+// @main def getRawResponseBodySynchronous(): Unit =
+//   case class HttpBinResponse(origin: String, headers: Map[String, String])
 
-  val request = basicRequest
-    .get(uri"https://httpbin.org/get")
-    .response(asBoth(asJson[HttpBinResponse], asStringAlways))
+//   val request = basicRequest
+//     .get(uri"https://httpbin.org/get")
+//     .response(asBoth(asJson[HttpBinResponse], asStringAlways))
 
-  val backend: SyncBackend = DefaultSyncBackend()
+//   val backend: SyncBackend = DefaultSyncBackend()
 
-  try
-    val response: Response[(Either[ResponseException[String, circe.Error], HttpBinResponse], String)] =
-      request.send(backend)
+//   try
+//     val response: Response[(Either[ResponseException[String], HttpBinResponse], String)] =
+//       request.send(backend)
 
-    val (parsed, raw) = response.body
+//     val (parsed, raw) = response.body
 
-    println("Got response - parsed: " + parsed)
-    println("Got response - raw: " + raw)
-  finally backend.close()
+//     println("Got response - parsed: " + parsed)
+//     println("Got response - raw: " + raw)
+//   finally backend.close()

--- a/examples/src/main/scala/sttp/client4/examples/json/getAndParseJsonPekkoHttpJson4s.scala
+++ b/examples/src/main/scala/sttp/client4/examples/json/getAndParseJsonPekkoHttpJson4s.scala
@@ -16,21 +16,21 @@ import sttp.client4.pekkohttp.*
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 
-@main def getAndParseJsonPekkoHttpJson4s(): Unit =
-  case class HttpBinResponse(origin: String, headers: Map[String, String])
+// @main def getAndParseJsonPekkoHttpJson4s(): Unit =
+//   case class HttpBinResponse(origin: String, headers: Map[String, String])
 
-  given Serialization = org.json4s.native.Serialization
-  given Formats = org.json4s.DefaultFormats
+//   given Serialization = org.json4s.native.Serialization
+//   given Formats = org.json4s.DefaultFormats
 
-  val request = basicRequest
-    .get(uri"https://httpbin.org/get")
-    .response(asJson[HttpBinResponse])
+//   val request = basicRequest
+//     .get(uri"https://httpbin.org/get")
+//     .response(asJson[HttpBinResponse])
 
-  val backend: Backend[Future] = PekkoHttpBackend()
-  val response: Future[Response[Either[ResponseException[String, Exception], HttpBinResponse]]] =
-    request.send(backend)
+//   val backend: Backend[Future] = PekkoHttpBackend()
+//   val response: Future[Response[Either[ResponseException[String], HttpBinResponse]]] =
+//     request.send(backend)
 
-  for r <- response do
-    println(s"Got response code: ${r.code}")
-    println(r.body)
-    backend.close()
+//   for r <- response do
+//     println(s"Got response code: ${r.code}")
+//     println(r.body)
+//     backend.close()

--- a/json/circe/src/main/scala/sttp/client4/circe/SttpCirceApi.scala
+++ b/json/circe/src/main/scala/sttp/client4/circe/SttpCirceApi.scala
@@ -1,12 +1,16 @@
 package sttp.client4.circe
 
-import sttp.client4._
+import io.circe.Decoder
+import io.circe.Encoder
+import io.circe.Printer
 import io.circe.parser.decode
-import io.circe.{Decoder, Encoder, Printer}
-import sttp.client4.internal.Utf8
-import sttp.model.MediaType
-import sttp.client4.json._
+import sttp.client4._
 import sttp.client4.ResponseAs.deserializeEitherWithErrorOrThrow
+import sttp.client4.ResponseException.DeserializationException
+import sttp.client4.ResponseException.UnexpectedStatusCode
+import sttp.client4.internal.Utf8
+import sttp.client4.json._
+import sttp.model.MediaType
 
 trait SttpCirceApi {
 
@@ -19,7 +23,8 @@ trait SttpCirceApi {
 
   /** If the response is successful (2xx), tries to deserialize the body from a string into JSON. Returns:
     *   - `Right(b)` if the parsing was successful
-    *   - `Left(HttpError(String))` if the response code was other than 2xx (deserialization is not attempted)
+    *   - `Left(UnexpectedStatusCode(String))` if the response code was other than 2xx (deserialization is not
+    *     attempted)
     *   - `Left(DeserializationException)` if there's an error during deserialization
     */
   def asJson[B: Decoder: IsOption]: ResponseAs[Either[ResponseException[String], B]] =
@@ -41,14 +46,14 @@ trait SttpCirceApi {
   /** Tries to deserialize the body from a string into JSON, using different deserializers depending on the status code.
     * Returns:
     *   - `Right(B)` if the response was 2xx and parsing was successful
-    *   - `Left(HttpError(E))` if the response was other than 2xx and parsing was successful
+    *   - `Left(UnexpectedStatusCode(E))` if the response was other than 2xx and parsing was successful
     *   - `Left(DeserializationException)` if there's an error during deserialization
     */
   def asJsonEither[E: Decoder: IsOption, B: Decoder: IsOption]: ResponseAs[Either[ResponseException[E], B]] =
     asJson[B].mapLeft { (l: ResponseException[String]) =>
       l match {
-        case HttpError(e, meta) =>
-          deserializeJson[E].apply(e).fold(DeserializationException(e, _, meta), HttpError(_, meta))
+        case UnexpectedStatusCode(e, meta) =>
+          deserializeJson[E].apply(e).fold(DeserializationException(e, _, meta), UnexpectedStatusCode(_, meta))
         case de @ DeserializationException(_, _, _) => de
       }
     }.showAsJsonEither

--- a/json/circe/src/test/scala/sttp/client4/circe/CirceTests.scala
+++ b/json/circe/src/test/scala/sttp/client4/circe/CirceTests.scala
@@ -62,7 +62,7 @@ class CirceTests extends AnyFlatSpec with Matchers with EitherValues {
     val responseAs = asJson[Inner]
 
     RunResponseAs(responseAs)("").left.value should matchPattern {
-      case DeserializationException("", _: io.circe.ParsingFailure) =>
+      case DeserializationException("", _: io.circe.ParsingFailure, _) =>
     }
   }
 
@@ -71,7 +71,7 @@ class CirceTests extends AnyFlatSpec with Matchers with EitherValues {
 
     val responseAs = asJson[Outer]
 
-    val Left(DeserializationException(original, _)) = RunResponseAs(responseAs)(body)
+    val Left(DeserializationException(original, _, _)) = RunResponseAs(responseAs)(body)
     original shouldBe body
   }
 
@@ -130,7 +130,7 @@ class CirceTests extends AnyFlatSpec with Matchers with EitherValues {
   it should "fail when using asJsonOrFail for incorrect JSON" in {
     val body = """invalid json"""
 
-    assertThrows[DeserializationException[io.circe.Error]] {
+    assertThrows[DeserializationException] {
       RunResponseAs(asJsonOrFail[Outer])(body)
     }
   }

--- a/json/circe/src/test/scala/sttp/client4/circe/CirceTests.scala
+++ b/json/circe/src/test/scala/sttp/client4/circe/CirceTests.scala
@@ -8,6 +8,7 @@ import sttp.model._
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import sttp.client4.json.RunResponseAs
+import sttp.client4.ResponseException.DeserializationException
 
 class CirceTests extends AnyFlatSpec with Matchers with EitherValues {
 

--- a/json/json4s/src/main/scala/sttp/client4/json4s/SttpJson4sApi.scala
+++ b/json/json4s/src/main/scala/sttp/client4/json4s/SttpJson4sApi.scala
@@ -6,6 +6,8 @@ import sttp.client4.internal.Utf8
 import sttp.client4.json._
 import sttp.model._
 import sttp.client4.ResponseAs.deserializeEitherOrThrow
+import sttp.client4.ResponseException.DeserializationException
+import sttp.client4.ResponseException.UnexpectedStatusCode
 
 trait SttpJson4sApi {
 
@@ -18,7 +20,8 @@ trait SttpJson4sApi {
 
   /** If the response is successful (2xx), tries to deserialize the body from a string into JSON. Returns:
     *   - `Right(b)` if the parsing was successful
-    *   - `Left(HttpError(String))` if the response code was other than 2xx (deserialization is not attempted)
+    *   - `Left(UnexpectedStatusCode(String))` if the response code was other than 2xx (deserialization is not
+    *     attempted)
     *   - `Left(DeserializationException)` if there's an error during deserialization
     */
   def asJson[B: Manifest](implicit
@@ -49,7 +52,7 @@ trait SttpJson4sApi {
   /** Tries to deserialize the body from a string into JSON, using different deserializers depending on the status code.
     * Returns:
     *   - `Right(B)` if the response was 2xx and parsing was successful
-    *   - `Left(HttpError(E))` if the response was other than 2xx and parsing was successful
+    *   - `Left(UnexpectedStatusCode(E))` if the response was other than 2xx and parsing was successful
     *   - `Left(DeserializationException)` if there's an error during deserialization
     */
   def asJsonEither[E: Manifest, B: Manifest](implicit
@@ -58,8 +61,10 @@ trait SttpJson4sApi {
   ): ResponseAs[Either[ResponseException[E], B]] =
     asJson[B].mapLeft { (l: ResponseException[String]) =>
       l match {
-        case HttpError(e, meta) =>
-          ResponseAs.deserializeCatchingExceptions(deserializeJson[E])(e, meta).fold(identity, HttpError(_, meta))
+        case UnexpectedStatusCode(e, meta) =>
+          ResponseAs
+            .deserializeCatchingExceptions(deserializeJson[E])(e, meta)
+            .fold(identity, UnexpectedStatusCode(_, meta))
         case de @ DeserializationException(_, _, _) => de
       }
     }.showAsJsonEither

--- a/json/json4s/src/test/scala/sttp/client4/Json4sTests.scala
+++ b/json/json4s/src/test/scala/sttp/client4/Json4sTests.scala
@@ -59,7 +59,8 @@ class Json4sTests extends AnyFlatSpec with Matchers with EitherValues {
   it should "fail to decode from empty input" in {
     val responseAs = asJson[Inner]
 
-    RunResponseAs(responseAs)("") should matchPattern { case Left(DeserializationException(_, _: MappingException)) =>
+    RunResponseAs(responseAs)("") should matchPattern {
+      case Left(DeserializationException(_, _: MappingException, _)) =>
     }
   }
 
@@ -68,7 +69,8 @@ class Json4sTests extends AnyFlatSpec with Matchers with EitherValues {
 
     val responseAs = asJson[Outer]
 
-    RunResponseAs(responseAs)(body) should matchPattern { case Left(DeserializationException(_, _: ParseException)) =>
+    RunResponseAs(responseAs)(body) should matchPattern {
+      case Left(DeserializationException(_, _: ParseException, _)) =>
     }
   }
 

--- a/json/json4s/src/test/scala/sttp/client4/Json4sTests.scala
+++ b/json/json4s/src/test/scala/sttp/client4/Json4sTests.scala
@@ -12,6 +12,7 @@ import scala.language.higherKinds
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import sttp.client4.json.RunResponseAs
+import sttp.client4.ResponseException.DeserializationException
 
 class Json4sTests extends AnyFlatSpec with Matchers with EitherValues {
   implicit val serialization: Serialization.type = native.Serialization

--- a/json/jsoniter/src/main/scala/sttp/client4/jsoniter/SttpJsoniterJsonApi.scala
+++ b/json/jsoniter/src/main/scala/sttp/client4/jsoniter/SttpJsoniterJsonApi.scala
@@ -6,7 +6,6 @@ import sttp.client4.IsOption
 import sttp.client4.JsonInput
 import sttp.client4.ResponseAs
 import sttp.client4.ResponseException
-import sttp.client4.ShowError
 import sttp.client4.StringBody
 import sttp.client4.asString
 import sttp.client4.asStringAlways
@@ -16,7 +15,6 @@ import sttp.model.MediaType
 
 trait SttpJsoniterJsonApi {
   import com.github.plokhotnyuk.jsoniter_scala.core._
-  import ShowError.showErrorMessageFromException
 
   /** Serialize the given value as JSON, to be used as a request's body using [[sttp.client4.Request.body]]. */
   def asJson[B](b: B)(implicit encoder: JsonValueCodec[B]): StringBody =
@@ -27,7 +25,7 @@ trait SttpJsoniterJsonApi {
     *   - `Left(HttpError(String))` if the response code was other than 2xx (deserialization is not attempted)
     *   - `Left(DeserializationException)` if there's an error during deserialization
     */
-  def asJson[B: JsonValueCodec: IsOption]: ResponseAs[Either[ResponseException[String, Exception], B]] =
+  def asJson[B: JsonValueCodec: IsOption]: ResponseAs[Either[ResponseException[String], B]] =
     asString.mapWithMetadata(ResponseAs.deserializeRightWithError(deserializeJson[B])).showAsJson
 
   /** If the response is successful (2xx), tries to deserialize the body from a string into JSON. Otherwise, if the
@@ -40,8 +38,8 @@ trait SttpJsoniterJsonApi {
     *   - `Right(b)` if the parsing was successful
     *   - `Left(DeserializationException)` if there's an error during deserialization
     */
-  def asJsonAlways[B: JsonValueCodec: IsOption]: ResponseAs[Either[DeserializationException[Exception], B]] =
-    asStringAlways.map(ResponseAs.deserializeWithError(deserializeJson[B])).showAsJsonAlways
+  def asJsonAlways[B: JsonValueCodec: IsOption]: ResponseAs[Either[DeserializationException, B]] =
+    asStringAlways.mapWithMetadata(ResponseAs.deserializeWithError(deserializeJson[B])).showAsJsonAlways
 
   /** Tries to deserialize the body from a string into JSON, using different deserializers depending on the status code.
     * Returns:
@@ -52,11 +50,12 @@ trait SttpJsoniterJsonApi {
   def asJsonEither[
       E: JsonValueCodec: IsOption,
       B: JsonValueCodec: IsOption
-  ]: ResponseAs[Either[ResponseException[E, Exception], B]] =
-    asJson[B].mapLeft { (l: ResponseException[String, Exception]) =>
+  ]: ResponseAs[Either[ResponseException[E], B]] =
+    asJson[B].mapLeft { (l: ResponseException[String]) =>
       l match {
-        case de @ DeserializationException(_, _) => de
-        case HttpError(e, code) => deserializeJson[E].apply(e).fold(DeserializationException(e, _), HttpError(_, code))
+        case de @ DeserializationException(_, _, _) => de
+        case HttpError(e, meta) =>
+          deserializeJson[E].apply(e).fold(DeserializationException(e, _, meta), HttpError(_, meta))
       }
     }.showAsJsonEither
 
@@ -65,13 +64,20 @@ trait SttpJsoniterJsonApi {
     */
   def asJsonEitherOrFail[E: JsonValueCodec: IsOption, B: JsonValueCodec: IsOption]: ResponseAs[Either[E, B]] =
     asStringAlways
-      .mapWithMetadata(ResponseAs.deserializeEitherWithErrorOrThrow(deserializeJson[E], deserializeJson[B]))
+      .mapWithMetadata((s, meta) =>
+        ResponseAs
+          .deserializeEitherWithErrorOrThrow(
+            s => deserializeJson[E].apply(s),
+            s => deserializeJson[B].apply(s)
+          )
+          .apply(s, meta)
+      )
       .showAsJsonEitherOrFail
 
-  def deserializeJson[B: JsonValueCodec: IsOption]: String => Either[Exception, B] = { (s: String) =>
+  def deserializeJson[B: JsonValueCodec: IsOption]: String => Either[JsonReaderException, B] = { (s: String) =>
     try Right(readFromString[B](JsonInput.sanitize[B].apply(s)))
     catch {
-      case de: JsonReaderException => Left(DeserializationException[JsonReaderException](s, de))
+      case de: JsonReaderException => Left(de)
     }
   }
 

--- a/json/jsoniter/src/test/scala/sttp/client4/jsoniter/JsoniterJsonTests.scala
+++ b/json/jsoniter/src/test/scala/sttp/client4/jsoniter/JsoniterJsonTests.scala
@@ -10,6 +10,7 @@ import sttp.model._
 import com.github.plokhotnyuk.jsoniter_scala.core._
 import com.github.plokhotnyuk.jsoniter_scala.macros._
 import sttp.client4.json.RunResponseAs
+import sttp.client4.ResponseException.DeserializationException
 
 class JsoniterJsonTests extends AnyFlatSpec with Matchers with EitherValues {
 

--- a/json/jsoniter/src/test/scala/sttp/client4/jsoniter/JsoniterJsonTests.scala
+++ b/json/jsoniter/src/test/scala/sttp/client4/jsoniter/JsoniterJsonTests.scala
@@ -44,13 +44,13 @@ class JsoniterJsonTests extends AnyFlatSpec with Matchers with EitherValues {
 
     val responseAs = asJson[Outer]
 
-    val Left(DeserializationException(original, _)) = RunResponseAs(responseAs)(body)
+    val Left(DeserializationException(original, _, _)) = RunResponseAs(responseAs)(body)
     original shouldBe body
   }
 
   it should "fail to decode from empty input" in {
     val responseAs = asJson[Inner]
-    RunResponseAs(responseAs)("").left.value should matchPattern { case DeserializationException("", _: Exception) =>
+    RunResponseAs(responseAs)("").left.value should matchPattern { case DeserializationException("", _: Exception, _) =>
     }
   }
 
@@ -105,7 +105,7 @@ class JsoniterJsonTests extends AnyFlatSpec with Matchers with EitherValues {
   it should "fail when using asJsonOrFail for incorrect JSON" in {
     val body = """invalid json"""
 
-    assertThrows[DeserializationException[Exception]] {
+    assertThrows[DeserializationException] {
       RunResponseAs(asJsonOrFail[Outer])(body)
     }
   }

--- a/json/play-json/src/main/scala/sttp/client4/playJson/SttpPlayJsonApi.scala
+++ b/json/play-json/src/main/scala/sttp/client4/playJson/SttpPlayJsonApi.scala
@@ -8,6 +8,8 @@ import sttp.model.MediaType
 
 import scala.util.{Failure, Success, Try}
 import sttp.client4.ResponseAs.deserializeEitherWithErrorOrThrow
+import sttp.client4.ResponseException.UnexpectedStatusCode
+import sttp.client4.ResponseException.DeserializationException
 
 trait SttpPlayJsonApi {
 
@@ -17,7 +19,8 @@ trait SttpPlayJsonApi {
 
   /** If the response is successful (2xx), tries to deserialize the body from a string into JSON. Returns:
     *   - `Right(b)` if the parsing was successful
-    *   - `Left(HttpError(String))` if the response code was other than 2xx (deserialization is not attempted)
+    *   - `Left(UnexpectedStatusCode(String))` if the response code was other than 2xx (deserialization is not
+    *     attempted)
     *   - `Left(DeserializationException)` if there's an error during deserialization
     */
   def asJson[B: Reads: IsOption]: ResponseAs[Either[ResponseException[String], B]] =
@@ -39,14 +42,14 @@ trait SttpPlayJsonApi {
   /** Tries to deserialize the body from a string into JSON, using different deserializers depending on the status code.
     * Returns:
     *   - `Right(B)` if the response was 2xx and parsing was successful
-    *   - `Left(HttpError(E))` if the response was other than 2xx and parsing was successful
+    *   - `Left(UnexpectedStatusCode(E))` if the response was other than 2xx and parsing was successful
     *   - `Left(DeserializationException)` if there's an error during deserialization
     */
   def asJsonEither[E: Reads: IsOption, B: Reads: IsOption]: ResponseAs[Either[ResponseException[E], B]] =
     asJson[B].mapLeft { (l: ResponseException[String]) =>
       l match {
-        case HttpError(e, meta) =>
-          deserializeJson[E].apply(e).fold(DeserializationException(e, _, meta), HttpError(_, meta))
+        case UnexpectedStatusCode(e, meta) =>
+          deserializeJson[E].apply(e).fold(DeserializationException(e, _, meta), UnexpectedStatusCode(_, meta))
         case de: DeserializationException => de
       }
     }.showAsJsonEither

--- a/json/play-json/src/test/scala/sttp/client4/PlayJsonTests.scala
+++ b/json/play-json/src/test/scala/sttp/client4/PlayJsonTests.scala
@@ -9,6 +9,7 @@ import sttp.model.StatusCode
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import sttp.client4.json.RunResponseAs
+import sttp.client4.ResponseException.DeserializationException
 
 class PlayJsonTests extends AnyFlatSpec with Matchers with EitherValues {
 

--- a/json/play-json/src/test/scala/sttp/client4/PlayJsonTests.scala
+++ b/json/play-json/src/test/scala/sttp/client4/PlayJsonTests.scala
@@ -61,7 +61,7 @@ class PlayJsonTests extends AnyFlatSpec with Matchers with EitherValues {
   it should "fail to decode from empty input" in {
     val responseAs = asJson[Inner]
 
-    RunResponseAs(responseAs)("") should matchPattern { case Left(DeserializationException("", _)) =>
+    RunResponseAs(responseAs)("") should matchPattern { case Left(DeserializationException("", _, _)) =>
     }
   }
 
@@ -70,7 +70,7 @@ class PlayJsonTests extends AnyFlatSpec with Matchers with EitherValues {
 
     val responseAs = asJson[Outer]
 
-    RunResponseAs(responseAs)(body) should matchPattern { case Left(DeserializationException(`body`, _)) =>
+    RunResponseAs(responseAs)(body) should matchPattern { case Left(DeserializationException(`body`, _, _)) =>
     }
   }
 
@@ -127,7 +127,7 @@ class PlayJsonTests extends AnyFlatSpec with Matchers with EitherValues {
   it should "fail when using asJsonOrFail for incorrect JSON" in {
     val body = """invalid json"""
 
-    assertThrows[DeserializationException[JsError]] {
+    assertThrows[DeserializationException] {
       RunResponseAs(asJsonOrFail[Outer])(body)
     }
   }

--- a/json/spray-json/src/main/scala/sttp/client4/sprayJson/SttpSprayJsonApi.scala
+++ b/json/spray-json/src/main/scala/sttp/client4/sprayJson/SttpSprayJsonApi.scala
@@ -6,6 +6,8 @@ import sttp.client4._
 import sttp.client4.json._
 import sttp.model._
 import sttp.client4.ResponseAs.deserializeEitherOrThrow
+import sttp.client4.ResponseException.DeserializationException
+import sttp.client4.ResponseException.UnexpectedStatusCode
 
 trait SttpSprayJsonApi {
 
@@ -15,7 +17,8 @@ trait SttpSprayJsonApi {
 
   /** If the response is successful (2xx), tries to deserialize the body from a string into JSON. Returns:
     *   - `Right(b)` if the parsing was successful
-    *   - `Left(HttpError(String))` if the response code was other than 2xx (deserialization is not attempted)
+    *   - `Left(UnexpectedStatusCode(String))` if the response code was other than 2xx (deserialization is not
+    *     attempted)
     *   - `Left(DeserializationException)` if there's an error during deserialization
     */
   def asJson[B: JsonReader: IsOption]: ResponseAs[Either[ResponseException[String], B]] =
@@ -37,14 +40,16 @@ trait SttpSprayJsonApi {
   /** Tries to deserialize the body from a string into JSON, using different deserializers depending on the status code.
     * Returns:
     *   - `Right(B)` if the response was 2xx and parsing was successful
-    *   - `Left(HttpError(E))` if the response was other than 2xx and parsing was successful
+    *   - `Left(UnexpectedStatusCode(E))` if the response was other than 2xx and parsing was successful
     *   - `Left(DeserializationException)` if there's an error during deserialization
     */
   def asJsonEither[E: JsonReader: IsOption, B: JsonReader: IsOption]: ResponseAs[Either[ResponseException[E], B]] =
     asJson[B].mapLeft { (l: ResponseException[String]) =>
       l match {
-        case HttpError(e, meta) =>
-          ResponseAs.deserializeCatchingExceptions(deserializeJson[E])(e, meta).fold(identity, HttpError(_, meta))
+        case UnexpectedStatusCode(e, meta) =>
+          ResponseAs
+            .deserializeCatchingExceptions(deserializeJson[E])(e, meta)
+            .fold(identity, UnexpectedStatusCode(_, meta))
         case de: DeserializationException => de
       }
     }.showAsJsonEither

--- a/json/spray-json/src/test/scala/sttp/client4/sprayJson/SprayJsonTests.scala
+++ b/json/spray-json/src/test/scala/sttp/client4/sprayJson/SprayJsonTests.scala
@@ -61,7 +61,8 @@ class SprayJsonTests extends AnyFlatSpec with Matchers with EitherValues {
   it should "fail to decode from empty input" in {
     val responseAs = asJson[Inner]
 
-    RunResponseAs(responseAs)("") should matchPattern { case Left(DeserializationException(_, _: ParsingException)) =>
+    RunResponseAs(responseAs)("") should matchPattern {
+      case Left(DeserializationException(_, _: ParsingException, _)) =>
     }
   }
 
@@ -70,7 +71,8 @@ class SprayJsonTests extends AnyFlatSpec with Matchers with EitherValues {
 
     val responseAs = asJson[Outer]
 
-    RunResponseAs(responseAs)(body) should matchPattern { case Left(DeserializationException(_, _: ParsingException)) =>
+    RunResponseAs(responseAs)(body) should matchPattern {
+      case Left(DeserializationException(_, _: ParsingException, _)) =>
     }
   }
 
@@ -110,7 +112,7 @@ class SprayJsonTests extends AnyFlatSpec with Matchers with EitherValues {
   it should "fail when using asJsonOrFail for incorrect JSON" in {
     val body = """invalid json"""
 
-    assertThrows[DeserializationException[Exception]] {
+    assertThrows[DeserializationException] {
       RunResponseAs(asJsonOrFail[Outer])(body)
     }
   }

--- a/json/spray-json/src/test/scala/sttp/client4/sprayJson/SprayJsonTests.scala
+++ b/json/spray-json/src/test/scala/sttp/client4/sprayJson/SprayJsonTests.scala
@@ -11,9 +11,9 @@ import sttp.client4.basicRequest
 import sttp.client4.PartialRequest
 import sttp.client4.StringBody
 import sttp.client4.Request
-import sttp.client4.DeserializationException
 import spray.json.JsonParser.ParsingException
 import sttp.client4.json.RunResponseAs
+import sttp.client4.ResponseException.DeserializationException
 
 class SprayJsonTests extends AnyFlatSpec with Matchers with EitherValues {
   import SprayJsonTests._

--- a/json/tethys-json/src/main/scala/sttp/client4/tethysJson/SttpTethysApi.scala
+++ b/json/tethys-json/src/main/scala/sttp/client4/tethysJson/SttpTethysApi.scala
@@ -9,6 +9,8 @@ import tethys.readers.ReaderError
 import tethys.readers.tokens.TokenIteratorProducer
 import tethys.writers.tokens.TokenWriterProducer
 import sttp.client4.ResponseAs.deserializeEitherWithErrorOrThrow
+import sttp.client4.ResponseException.UnexpectedStatusCode
+import sttp.client4.ResponseException.DeserializationException
 
 trait SttpTethysApi {
 
@@ -20,7 +22,8 @@ trait SttpTethysApi {
 
   /** If the response is successful (2xx), tries to deserialize the body from a string into JSON. Returns:
     *   - `Right(b)` if the parsing was successful
-    *   - `Left(HttpError(String))` if the response code was other than 2xx (deserialization is not attempted)
+    *   - `Left(UnexpectedStatusCode(String))` if the response code was other than 2xx (deserialization is not
+    *     attempted)
     *   - `Left(DeserializationException)` if there's an error during deserialization
     */
   def asJson[B: JsonReader: IsOption](implicit

--- a/json/tethys-json/src/main/scala/sttp/client4/tethysJson/SttpTethysApi.scala
+++ b/json/tethys-json/src/main/scala/sttp/client4/tethysJson/SttpTethysApi.scala
@@ -25,7 +25,7 @@ trait SttpTethysApi {
     */
   def asJson[B: JsonReader: IsOption](implicit
       producer: TokenIteratorProducer
-  ): ResponseAs[Either[ResponseException[String, ReaderError], B]] =
+  ): ResponseAs[Either[ResponseException[String], B]] =
     asString.mapWithMetadata(ResponseAs.deserializeRightWithError(deserializeJson)).showAsJson
 
   /** If the response is successful (2xx), tries to deserialize the body from a string into JSON. Otherwise, if the
@@ -42,8 +42,8 @@ trait SttpTethysApi {
     */
   def asJsonAlways[B: JsonReader: IsOption](implicit
       producer: TokenIteratorProducer
-  ): ResponseAs[Either[DeserializationException[ReaderError], B]] =
-    asStringAlways.map(ResponseAs.deserializeWithError(deserializeJson)).showAsJsonAlways
+  ): ResponseAs[Either[DeserializationException, B]] =
+    asStringAlways.mapWithMetadata(ResponseAs.deserializeWithError(deserializeJson)).showAsJsonAlways
 
   /** Deserializes the body from a string into JSON, using different deserializers depending on the status code. If a
     * deserialization error occurs, throws a [[DeserializationException]] / returns a failed effect.

--- a/json/tethys-json/src/test/scala/sttp/client4/tethysJson/TethysTests.scala
+++ b/json/tethys-json/src/test/scala/sttp/client4/tethysJson/TethysTests.scala
@@ -58,7 +58,7 @@ class TethysTests extends AnyFlatSpec with Matchers with EitherValues {
   it should "fail to decode from empty input" in {
     val responseAs = asJson[Inner]
 
-    RunResponseAs(responseAs)("") should matchPattern { case Left(DeserializationException("", _: ReaderError)) =>
+    RunResponseAs(responseAs)("") should matchPattern { case Left(DeserializationException("", _: ReaderError, _)) =>
     }
   }
 
@@ -67,7 +67,7 @@ class TethysTests extends AnyFlatSpec with Matchers with EitherValues {
 
     val responseAs = asJson[Outer]
 
-    val Left(DeserializationException(original, _)) = RunResponseAs(responseAs)(body)
+    val Left(DeserializationException(original, _, _)) = RunResponseAs(responseAs)(body)
     original shouldBe body
   }
 
@@ -108,7 +108,7 @@ class TethysTests extends AnyFlatSpec with Matchers with EitherValues {
   it should "fail when using asJsonOrFail for incorrect JSON" in {
     val body = """invalid json"""
 
-    assertThrows[DeserializationException[ReaderError]] {
+    assertThrows[DeserializationException] {
       RunResponseAs(asJsonOrFail[Outer])(body)
     }
   }

--- a/json/tethys-json/src/test/scala/sttp/client4/tethysJson/TethysTests.scala
+++ b/json/tethys-json/src/test/scala/sttp/client4/tethysJson/TethysTests.scala
@@ -12,6 +12,7 @@ import tethys.readers.tokens.TokenIterator
 import tethys.readers.{FieldName, ReaderError}
 import tethys.{JsonReader, JsonWriter}
 import sttp.client4.json.RunResponseAs
+import sttp.client4.ResponseException.DeserializationException
 
 import scala.util.{Failure, Success, Try}
 

--- a/json/upickle/src/test/scala/sttp/client4/upicklejson/UpickleTests.scala
+++ b/json/upickle/src/test/scala/sttp/client4/upicklejson/UpickleTests.scala
@@ -8,6 +8,7 @@ import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import ujson.Obj
 import sttp.client4.json.RunResponseAs
+import sttp.client4.ResponseException.DeserializationException
 
 class UpickleTests extends AnyFlatSpec with Matchers with EitherValues {
   "The upickle module" should "encode arbitrary bodies given an encoder" in {

--- a/json/upickle/src/test/scala/sttp/client4/upicklejson/UpickleTests.scala
+++ b/json/upickle/src/test/scala/sttp/client4/upicklejson/UpickleTests.scala
@@ -67,7 +67,7 @@ class UpickleTests extends AnyFlatSpec with Matchers with EitherValues {
 
     val responseAs = asJson[Inner]
 
-    RunResponseAs(responseAs)("").left.value should matchPattern { case DeserializationException(_, _) => }
+    RunResponseAs(responseAs)("").left.value should matchPattern { case DeserializationException(_, _, _) => }
   }
 
   it should "fail to decode invalid json" in {
@@ -78,7 +78,7 @@ class UpickleTests extends AnyFlatSpec with Matchers with EitherValues {
 
     val responseAs = asJson[Outer]
 
-    val Left(DeserializationException(original, _)) = RunResponseAs(responseAs)(body)
+    val Left(DeserializationException(original, _, _)) = RunResponseAs(responseAs)(body)
     original shouldBe body
   }
 
@@ -169,7 +169,7 @@ class UpickleTests extends AnyFlatSpec with Matchers with EitherValues {
 
     val body = """invalid json"""
 
-    assertThrows[DeserializationException[Exception]] {
+    assertThrows[DeserializationException] {
       RunResponseAs(asJsonOrFail[Outer])(body)
     }
   }

--- a/json/zio-json/src/main/scala/sttp/client4/ziojson/SttpZioJsonApi.scala
+++ b/json/zio-json/src/main/scala/sttp/client4/ziojson/SttpZioJsonApi.scala
@@ -1,7 +1,5 @@
 package sttp.client4.ziojson
 
-import sttp.client4.DeserializationException
-import sttp.client4.HttpError
 import sttp.client4.IsOption
 import sttp.client4.JsonInput
 import sttp.client4.ResponseAs
@@ -12,6 +10,8 @@ import sttp.client4.asStringAlways
 import sttp.client4.internal.Utf8
 import sttp.client4.json.RichResponseAs
 import sttp.model.MediaType
+import sttp.client4.ResponseException.DeserializationException
+import sttp.client4.ResponseException.UnexpectedStatusCode
 
 trait SttpZioJsonApi extends SttpZioJsonApiExtensions {
   import zio.json._
@@ -21,7 +21,8 @@ trait SttpZioJsonApi extends SttpZioJsonApiExtensions {
 
   /** If the response is successful (2xx), tries to deserialize the body from a string into JSON. Returns:
     *   - `Right(b)` if the parsing was successful
-    *   - `Left(HttpError(String))` if the response code was other than 2xx (deserialization is not attempted)
+    *   - `Left(UnexpectedStatusCode(String))` if the response code was other than 2xx (deserialization is not
+    *     attempted)
     *   - `Left(DeserializationException)` if there's an error during deserialization
     */
   def asJson[B: JsonDecoder: IsOption]: ResponseAs[Either[ResponseException[String], B]] =
@@ -43,14 +44,14 @@ trait SttpZioJsonApi extends SttpZioJsonApiExtensions {
   /** Tries to deserialize the body from a string into JSON, using different deserializers depending on the status code.
     * Returns:
     *   - `Right(B)` if the response was 2xx and parsing was successful
-    *   - `Left(HttpError(E))` if the response was other than 2xx and parsing was successful
+    *   - `Left(UnexpectedStatusCode(E))` if the response was other than 2xx and parsing was successful
     *   - `Left(DeserializationException)` if there's an error during deserialization
     */
   def asJsonEither[E: JsonDecoder: IsOption, B: JsonDecoder: IsOption]: ResponseAs[Either[ResponseException[E], B]] =
     asJson[B].mapLeft { (l: ResponseException[String]) =>
       l match {
-        case HttpError(e, meta) =>
-          deserializeJson[E].apply(e).fold(DeserializationException(e, _, meta), HttpError(_, meta))
+        case UnexpectedStatusCode(e, meta) =>
+          deserializeJson[E].apply(e).fold(DeserializationException(e, _, meta), UnexpectedStatusCode(_, meta))
         case de: DeserializationException => de
       }
     }.showAsJsonEither

--- a/json/zio-json/src/main/scalajvm/sttp/client4/ziojson/SttpZioJsonApiExtensions.scala
+++ b/json/zio-json/src/main/scalajvm/sttp/client4/ziojson/SttpZioJsonApiExtensions.scala
@@ -2,8 +2,6 @@ package sttp.client4.ziojson
 
 import sttp.capabilities.Effect
 import sttp.capabilities.zio.ZioStreams
-import sttp.client4.DeserializationException
-import sttp.client4.HttpError
 import sttp.client4.ResponseException
 import sttp.client4.StreamResponseAs
 import sttp.client4.asStreamWithMetadata
@@ -11,6 +9,8 @@ import zio.Task
 import zio.ZIO
 import zio.json.JsonDecoder
 import zio.stream.ZPipeline
+import sttp.client4.ResponseException.UnexpectedStatusCode
+import sttp.client4.ResponseException.DeserializationException
 
 trait SttpZioJsonApiExtensions { this: SttpZioJsonApi =>
   def asJsonStream[B: JsonDecoder]
@@ -21,7 +21,7 @@ trait SttpZioJsonApiExtensions { this: SttpZioJsonApi =>
         .map(Right(_))
         .catchSome { case e: Exception => ZIO.left(DeserializationException("", e, meta)) }
     ).mapWithMetadata {
-      case (Left(s), meta) => Left(HttpError(s, meta))
+      case (Left(s), meta) => Left(UnexpectedStatusCode(s, meta))
       case (Right(s), _)   => s
     }
 }

--- a/json/zio-json/src/main/scalajvm/sttp/client4/ziojson/SttpZioJsonApiExtensions.scala
+++ b/json/zio-json/src/main/scalajvm/sttp/client4/ziojson/SttpZioJsonApiExtensions.scala
@@ -6,7 +6,7 @@ import sttp.client4.DeserializationException
 import sttp.client4.HttpError
 import sttp.client4.ResponseException
 import sttp.client4.StreamResponseAs
-import sttp.client4.asStream
+import sttp.client4.asStreamWithMetadata
 import zio.Task
 import zio.ZIO
 import zio.json.JsonDecoder
@@ -14,14 +14,14 @@ import zio.stream.ZPipeline
 
 trait SttpZioJsonApiExtensions { this: SttpZioJsonApi =>
   def asJsonStream[B: JsonDecoder]
-      : StreamResponseAs[Either[ResponseException[String, String], B], ZioStreams with Effect[Task]] =
-    asStream(ZioStreams)(s =>
+      : StreamResponseAs[Either[ResponseException[String], B], ZioStreams with Effect[Task]] =
+    asStreamWithMetadata(ZioStreams)((s, meta) =>
       JsonDecoder[B]
         .decodeJsonStream(ZPipeline.utf8Decode.apply(s).mapChunks(_.flatMap(_.toCharArray)))
         .map(Right(_))
-        .catchSome { case e => ZIO.left(DeserializationException("", e.getMessage)) }
+        .catchSome { case e: Exception => ZIO.left(DeserializationException("", e, meta)) }
     ).mapWithMetadata {
-      case (Left(s), meta) => Left(HttpError(s, meta.code))
+      case (Left(s), meta) => Left(HttpError(s, meta))
       case (Right(s), _)   => s
     }
 }

--- a/json/zio-json/src/test/scala/sttp/client4/ziojson/ZioJsonTests.scala
+++ b/json/zio-json/src/test/scala/sttp/client4/ziojson/ZioJsonTests.scala
@@ -54,14 +54,14 @@ class ZioJsonTests extends AnyFlatSpec with Matchers with EitherValues {
 
     val responseAs = asJson[Outer]
 
-    val Left(DeserializationException(original, _)) = RunResponseAs(responseAs)(body)
+    val Left(DeserializationException(original, _, _)) = RunResponseAs(responseAs)(body)
     original shouldBe body
   }
 
   it should "fail to decode from empty input" in {
     val responseAs = asJson[Inner]
 
-    RunResponseAs(responseAs)("").left.value should matchPattern { case DeserializationException("", _: String) =>
+    RunResponseAs(responseAs)("").left.value should matchPattern { case DeserializationException("", _, _) =>
     }
   }
 
@@ -117,7 +117,7 @@ class ZioJsonTests extends AnyFlatSpec with Matchers with EitherValues {
   it should "fail when using asJsonOrFail for incorrect JSON" in {
     val body = """invalid json"""
 
-    assertThrows[DeserializationException[Exception]] {
+    assertThrows[DeserializationException] {
       RunResponseAs(asJsonOrFail[Outer])(body)
     }
   }

--- a/json/zio-json/src/test/scala/sttp/client4/ziojson/ZioJsonTests.scala
+++ b/json/zio-json/src/test/scala/sttp/client4/ziojson/ZioJsonTests.scala
@@ -10,6 +10,7 @@ import sttp.model._
 import zio.Chunk
 import zio.json.ast.Json
 import sttp.client4.json.RunResponseAs
+import sttp.client4.ResponseException.DeserializationException
 
 class ZioJsonTests extends AnyFlatSpec with Matchers with EitherValues {
 

--- a/json/zio1-json/src/main/scala/sttp/client4/ziojson/SttpZioJsonApi.scala
+++ b/json/zio1-json/src/main/scala/sttp/client4/ziojson/SttpZioJsonApi.scala
@@ -1,7 +1,5 @@
 package sttp.client4.ziojson
 
-import sttp.client4.DeserializationException
-import sttp.client4.HttpError
 import sttp.client4.IsOption
 import sttp.client4.JsonInput
 import sttp.client4.ResponseAs
@@ -12,6 +10,8 @@ import sttp.client4.asStringAlways
 import sttp.client4.internal.Utf8
 import sttp.client4.json.RichResponseAs
 import sttp.model.MediaType
+import sttp.client4.ResponseException.DeserializationException
+import sttp.client4.ResponseException.UnexpectedStatusCode
 
 trait SttpZioJsonApi extends SttpZioJsonApiExtensions {
   import zio.json._
@@ -21,7 +21,8 @@ trait SttpZioJsonApi extends SttpZioJsonApiExtensions {
 
   /** If the response is successful (2xx), tries to deserialize the body from a string into JSON. Returns:
     *   - `Right(b)` if the parsing was successful
-    *   - `Left(HttpError(String))` if the response code was other than 2xx (deserialization is not attempted)
+    *   - `Left(UnexpectedStatusCode(String))` if the response code was other than 2xx (deserialization is not
+    *     attempted)
     *   - `Left(DeserializationException)` if there's an error during deserialization
     */
   def asJson[B: JsonDecoder: IsOption]: ResponseAs[Either[ResponseException[String], B]] =
@@ -43,14 +44,14 @@ trait SttpZioJsonApi extends SttpZioJsonApiExtensions {
   /** Tries to deserialize the body from a string into JSON, using different deserializers depending on the status code.
     * Returns:
     *   - `Right(B)` if the response was 2xx and parsing was successful
-    *   - `Left(HttpError(E))` if the response was other than 2xx and parsing was successful
+    *   - `Left(UnexpectedStatusCode(E))` if the response was other than 2xx and parsing was successful
     *   - `Left(DeserializationException)` if there's an error during deserialization
     */
   def asJsonEither[E: JsonDecoder: IsOption, B: JsonDecoder: IsOption]: ResponseAs[Either[ResponseException[E], B]] =
     asJson[B].mapLeft { (l: ResponseException[String]) =>
       l match {
-        case HttpError(e, meta) =>
-          deserializeJson[E].apply(e).fold(DeserializationException(e, _, meta), HttpError(_, meta))
+        case UnexpectedStatusCode(e, meta) =>
+          deserializeJson[E].apply(e).fold(DeserializationException(e, _, meta), UnexpectedStatusCode(_, meta))
         case de: DeserializationException => de
       }
     }.showAsJsonEither

--- a/json/zio1-json/src/main/scalajvm/sttp/client4/ziojson/SttpZioJsonApiExtensions.scala
+++ b/json/zio1-json/src/main/scalajvm/sttp/client4/ziojson/SttpZioJsonApiExtensions.scala
@@ -6,7 +6,7 @@ import sttp.client4.DeserializationException
 import sttp.client4.HttpError
 import sttp.client4.ResponseException
 import sttp.client4.StreamResponseAs
-import sttp.client4.asStream
+import sttp.client4.asStreamWithMetadata
 import zio.RIO
 import zio.ZIO
 import zio.blocking.Blocking
@@ -15,14 +15,14 @@ import zio.stream.ZTransducer
 
 trait SttpZioJsonApiExtensions { this: SttpZioJsonApi =>
   def asJsonStream[B: JsonDecoder]
-      : StreamResponseAs[Either[ResponseException[String, String], B], ZioStreams with Effect[RIO[Blocking, *]]] =
-    asStream(ZioStreams)(s =>
+      : StreamResponseAs[Either[ResponseException[String], B], ZioStreams with Effect[RIO[Blocking, *]]] =
+    asStreamWithMetadata(ZioStreams)((s, meta) =>
       JsonDecoder[B]
         .decodeJsonStream(s >>> ZTransducer.utf8Decode.mapChunks(_.flatMap(_.toCharArray)))
         .map(Right(_))
-        .catchSome { case e => ZIO.left(DeserializationException("", e.getMessage)) }
+        .catchSome { case e: Exception => ZIO.left(DeserializationException("", e, meta)) }
     ).mapWithMetadata {
-      case (Left(s), meta) => Left(HttpError(s, meta.code))
+      case (Left(s), meta) => Left(HttpError(s, meta))
       case (Right(s), _)   => s
     }
 }

--- a/json/zio1-json/src/main/scalajvm/sttp/client4/ziojson/SttpZioJsonApiExtensions.scala
+++ b/json/zio1-json/src/main/scalajvm/sttp/client4/ziojson/SttpZioJsonApiExtensions.scala
@@ -2,8 +2,6 @@ package sttp.client4.ziojson
 
 import sttp.capabilities.Effect
 import sttp.capabilities.zio.ZioStreams
-import sttp.client4.DeserializationException
-import sttp.client4.HttpError
 import sttp.client4.ResponseException
 import sttp.client4.StreamResponseAs
 import sttp.client4.asStreamWithMetadata
@@ -12,6 +10,8 @@ import zio.ZIO
 import zio.blocking.Blocking
 import zio.json.JsonDecoder
 import zio.stream.ZTransducer
+import sttp.client4.ResponseException.DeserializationException
+import sttp.client4.ResponseException.UnexpectedStatusCode
 
 trait SttpZioJsonApiExtensions { this: SttpZioJsonApi =>
   def asJsonStream[B: JsonDecoder]
@@ -22,7 +22,7 @@ trait SttpZioJsonApiExtensions { this: SttpZioJsonApi =>
         .map(Right(_))
         .catchSome { case e: Exception => ZIO.left(DeserializationException("", e, meta)) }
     ).mapWithMetadata {
-      case (Left(s), meta) => Left(HttpError(s, meta))
+      case (Left(s), meta) => Left(UnexpectedStatusCode(s, meta))
       case (Right(s), _)   => s
     }
 }

--- a/json/zio1-json/src/test/scala/sttp/client4/ziojson/ZioJsonTests.scala
+++ b/json/zio1-json/src/test/scala/sttp/client4/ziojson/ZioJsonTests.scala
@@ -54,14 +54,14 @@ class ZioJsonTests extends AnyFlatSpec with Matchers with EitherValues {
 
     val responseAs = asJson[Outer]
 
-    val Left(DeserializationException(original, _)) = RunResponseAs(responseAs)(body)
+    val Left(DeserializationException(original, _, _)) = RunResponseAs(responseAs)(body)
     original shouldBe body
   }
 
   it should "fail to decode from empty input" in {
     val responseAs = asJson[Inner]
 
-    RunResponseAs(responseAs)("").left.value should matchPattern { case DeserializationException("", _: String) =>
+    RunResponseAs(responseAs)("").left.value should matchPattern { case DeserializationException("", _, _) =>
     }
   }
 
@@ -117,7 +117,7 @@ class ZioJsonTests extends AnyFlatSpec with Matchers with EitherValues {
   it should "fail when using asJsonOrFail for incorrect JSON" in {
     val body = """invalid json"""
 
-    assertThrows[DeserializationException[Exception]] {
+    assertThrows[DeserializationException] {
       RunResponseAs(asJsonOrFail[Outer])(body)
     }
   }

--- a/json/zio1-json/src/test/scala/sttp/client4/ziojson/ZioJsonTests.scala
+++ b/json/zio1-json/src/test/scala/sttp/client4/ziojson/ZioJsonTests.scala
@@ -10,6 +10,7 @@ import sttp.model._
 import zio.Chunk
 import zio.json.ast.Json
 import sttp.client4.json.RunResponseAs
+import sttp.client4.ResponseException.DeserializationException
 
 class ZioJsonTests extends AnyFlatSpec with Matchers with EitherValues {
 

--- a/logging/scribe/src/main/scala/sttp/client4/logging/scribe/ScribeLogger.scala
+++ b/logging/scribe/src/main/scala/sttp/client4/logging/scribe/ScribeLogger.scala
@@ -21,8 +21,8 @@ case class ScribeLogger[F[_]](monad: MonadError[F]) extends Logger[F] {
       context: Map[String, Any]
   ): F[Unit] =
     throwable match {
-      case Some(t) => monad.eval(scribe.log(levelMap(level), MDC.global, message, data(context), throwable))
-      case None    => scribe.log(levelMap(level), MDC.global, message, data(context))
+      case Some(t) => monad.eval(scribe.log(levelMap(level), MDC.global, message, data(context), t))
+      case None    => monad.eval(scribe.log(levelMap(level), MDC.global, message, data(context)))
     }
 
 }

--- a/logging/scribe/src/main/scala/sttp/client4/logging/scribe/ScribeLogger.scala
+++ b/logging/scribe/src/main/scala/sttp/client4/logging/scribe/ScribeLogger.scala
@@ -14,12 +14,15 @@ case class ScribeLogger[F[_]](monad: MonadError[F]) extends Logger[F] {
     LogLevel.Error -> scribe.Level.Error
   )
 
-  override def apply(level: LogLevel, message: => String, context: Map[String, Any]): F[Unit] = monad.eval(
-    scribe.log(levelMap(level), MDC.global, message, data(context))
-  )
+  override def apply(
+      level: LogLevel,
+      message: => String,
+      throwable: Option[Throwable],
+      context: Map[String, Any]
+  ): F[Unit] =
+    throwable match {
+      case Some(t) => monad.eval(scribe.log(levelMap(level), MDC.global, message, data(context), throwable))
+      case None    => scribe.log(levelMap(level), MDC.global, message, data(context))
+    }
 
-  override def apply(level: LogLevel, message: => String, throwable: Throwable, context: Map[String, Any]): F[Unit] =
-    monad.eval(
-      scribe.log(levelMap(level), MDC.global, message, data(context), throwable)
-    )
 }

--- a/logging/slf4j/src/main/scala/sttp/client4/logging/slf4j/Slf4jLogger.scala
+++ b/logging/slf4j/src/main/scala/sttp/client4/logging/slf4j/Slf4jLogger.scala
@@ -20,51 +20,42 @@ class Slf4jLogger[F[_]](name: String, monad: MonadError[F]) extends Logger[F] {
   override def apply(
       level: LogLevel,
       message: => String,
+      throwable: Option[Throwable],
       context: Map[String, Any]
-  ): F[Unit] = monad.eval {
-    setContext(context)
-    try
-      level match {
-        case LogLevel.Trace if underlying.isTraceEnabled =>
-          underlying.trace(message)
-
-        case LogLevel.Debug if underlying.isDebugEnabled =>
-          underlying.debug(message)
-
-        case LogLevel.Info if underlying.isInfoEnabled =>
-          underlying.info(message)
-
-        case LogLevel.Warn if underlying.isWarnEnabled =>
-          underlying.warn(message)
-
-        case LogLevel.Error if underlying.isErrorEnabled =>
-          underlying.error(message)
-
-        case _ => ()
-      }
-    finally
-      clearContext(context)
-  }
-
-  override def apply(level: LogLevel, message: => String, throwable: Throwable, context: Map[String, Any]): F[Unit] =
+  ): F[Unit] =
     monad.eval {
       setContext(context)
       try
         level match {
           case LogLevel.Trace if underlying.isTraceEnabled =>
-            underlying.trace(message, throwable)
+            throwable match {
+              case Some(t) => underlying.trace(message, throwable)
+              case None    => underlying.trace(message)
+            }
 
           case LogLevel.Debug if underlying.isDebugEnabled =>
-            underlying.debug(message, throwable)
+            throwable match {
+              case Some(t) => underlying.debug(message, throwable)
+              case None    => underlying.debug(message)
+            }
 
           case LogLevel.Info if underlying.isInfoEnabled =>
-            underlying.info(message, throwable)
+            throwable match {
+              case Some(t) => underlying.info(message, throwable)
+              case None    => underlying.info(message)
+            }
 
           case LogLevel.Warn if underlying.isWarnEnabled =>
-            underlying.warn(message, throwable)
+            throwable match {
+              case Some(t) => underlying.warn(message, throwable)
+              case None    => underlying.warn(message)
+            }
 
           case LogLevel.Error if underlying.isErrorEnabled =>
-            underlying.error(message, throwable)
+            throwable match {
+              case Some(t) => underlying.error(message, throwable)
+              case None    => underlying.error(message)
+            }
 
           case _ => ()
         }

--- a/observability/opentelemetry-metrics-backend/src/main/scala/sttp/client4/opentelemetry/OpenTelemetryMetricsBackend.scala
+++ b/observability/opentelemetry-metrics-backend/src/main/scala/sttp/client4/opentelemetry/OpenTelemetryMetricsBackend.scala
@@ -138,9 +138,9 @@ private class OpenTelemetryMetricsListener(
     val requestAttributes = createRequestAttributes(request)
     val errorAttributes = createErrorAttributes(e)
 
-    HttpError.find(e) match {
-      case Some(HttpError(body, meta)) =>
-        requestSuccessful(request, Response(body, meta.code, request.onlyMetadata), tag)
+    ResponseException.find(e) match {
+      case Some(re) =>
+        requestSuccessful(request, Response((), re.response.code, request.onlyMetadata), tag)
       case _ =>
         incrementCounter(requestToFailureCounterMapper(request, e), errorAttributes)
         recordHistogram(requestToLatencyHistogramMapper(request), tag.map(clock.millis() - _), errorAttributes)

--- a/observability/opentelemetry-metrics-backend/src/main/scala/sttp/client4/opentelemetry/OpenTelemetryMetricsBackend.scala
+++ b/observability/opentelemetry-metrics-backend/src/main/scala/sttp/client4/opentelemetry/OpenTelemetryMetricsBackend.scala
@@ -139,8 +139,8 @@ private class OpenTelemetryMetricsListener(
     val errorAttributes = createErrorAttributes(e)
 
     HttpError.find(e) match {
-      case Some(HttpError(body, statusCode)) =>
-        requestSuccessful(request, Response(body, statusCode, request.onlyMetadata), tag)
+      case Some(HttpError(body, meta)) =>
+        requestSuccessful(request, Response(body, meta.code, request.onlyMetadata), tag)
       case _ =>
         incrementCounter(requestToFailureCounterMapper(request, e), errorAttributes)
         recordHistogram(requestToLatencyHistogramMapper(request), tag.map(clock.millis() - _), errorAttributes)
@@ -162,7 +162,7 @@ private class OpenTelemetryMetricsListener(
 
   private def incrementCounter(collectorConfig: Option[CollectorConfig], attributes: Attributes): Unit =
     collectorConfig
-      .foreach(config => getOrCreateMetric(counters, config, createNewCounter).add(1, config.attributes))
+      .foreach(config => getOrCreateMetric(counters, config, createNewCounter).add(1, attributes))
 
   private def getOrCreateMetric[T](
       cache: ConcurrentHashMap[String, T],

--- a/observability/opentelemetry-metrics-backend/src/test/scala/sttp/client4/opentelemetry/OpenTelemetryMetricsBackendTest.scala
+++ b/observability/opentelemetry-metrics-backend/src/test/scala/sttp/client4/opentelemetry/OpenTelemetryMetricsBackendTest.scala
@@ -4,7 +4,7 @@ import io.opentelemetry.sdk.OpenTelemetrySdk
 import io.opentelemetry.sdk.metrics.SdkMeterProvider
 import io.opentelemetry.sdk.metrics.data.{HistogramPointData, MetricData}
 import io.opentelemetry.sdk.testing.exporter.InMemoryMetricReader
-import io.opentelemetry.api.common.{AttributeKey, Attributes}
+import io.opentelemetry.api.common.AttributeKey
 import org.scalatest.OptionValues
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
@@ -212,7 +212,11 @@ class OpenTelemetryMetricsBackendTest extends AnyFlatSpec with Matchers with Opt
     assertThrows[SttpClientException] {
       basicRequest
         .get(uri"http://127.0.0.1/foo")
-        .response(asString.map(_ => throw DeserializationException("Unknown body", new Exception("Unable to parse"))))
+        .response(
+          asString.mapWithMetadata((_, meta) =>
+            throw DeserializationException("Unknown body", new Exception("Unable to parse"), meta)
+          )
+        )
         .send(backend)
     }
 

--- a/observability/opentelemetry-metrics-backend/src/test/scala/sttp/client4/opentelemetry/OpenTelemetryMetricsBackendTest.scala
+++ b/observability/opentelemetry-metrics-backend/src/test/scala/sttp/client4/opentelemetry/OpenTelemetryMetricsBackendTest.scala
@@ -209,13 +209,11 @@ class OpenTelemetryMetricsBackendTest extends AnyFlatSpec with Matchers with Opt
     val backend = OpenTelemetryMetricsBackend(backendStub, spawnNewOpenTelemetry(reader))
 
     // when
-    assertThrows[SttpClientException] {
+    assertThrows[IllegalStateException] {
       basicRequest
         .get(uri"http://127.0.0.1/foo")
         .response(
-          asString.mapWithMetadata((_, meta) =>
-            throw DeserializationException("Unknown body", new Exception("Unable to parse"), meta)
-          )
+          asString.mapWithMetadata((_, meta) => throw new IllegalStateException())
         )
         .send(backend)
     }

--- a/observability/opentelemetry-metrics-backend/src/test/scala/sttp/client4/opentelemetry/OpenTelemetryMetricsBackendTest.scala
+++ b/observability/opentelemetry-metrics-backend/src/test/scala/sttp/client4/opentelemetry/OpenTelemetryMetricsBackendTest.scala
@@ -9,7 +9,7 @@ import org.scalatest.OptionValues
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import sttp.client4.testing.{ResponseStub, SyncBackendStub}
-import sttp.client4.{asString, basicRequest, DeserializationException, SttpClientException, UriContext}
+import sttp.client4.{asString, basicRequest, SttpClientException, UriContext}
 import sttp.model.{Header, StatusCode}
 
 import scala.collection.JavaConverters._

--- a/observability/prometheus-backend/src/main/scala/sttp/client4/prometheus/PrometheusBackend.scala
+++ b/observability/prometheus-backend/src/main/scala/sttp/client4/prometheus/PrometheusBackend.scala
@@ -204,8 +204,8 @@ class PrometheusListener(
       e: Exception
   ): Unit =
     HttpError.find(e) match {
-      case Some(HttpError(body, statusCode)) =>
-        requestSuccessful(request, Response(body, statusCode, request.onlyMetadata), requestCollectors)
+      case Some(HttpError(body, meta)) =>
+        requestSuccessful(request, Response(body, meta.code, request.onlyMetadata), requestCollectors)
       case _ =>
         requestCollectors.maybeTimer.foreach(_.observeDuration())
         requestCollectors.maybeGauge.foreach(_.dec())

--- a/observability/prometheus-backend/src/main/scala/sttp/client4/prometheus/PrometheusBackend.scala
+++ b/observability/prometheus-backend/src/main/scala/sttp/client4/prometheus/PrometheusBackend.scala
@@ -203,9 +203,9 @@ class PrometheusListener(
       requestCollectors: RequestCollectors,
       e: Exception
   ): Unit =
-    HttpError.find(e) match {
-      case Some(HttpError(body, meta)) =>
-        requestSuccessful(request, Response(body, meta.code, request.onlyMetadata), requestCollectors)
+    ResponseException.find(e) match {
+      case Some(re) =>
+        requestSuccessful(request, Response((), re.response.code, request.onlyMetadata), requestCollectors)
       case _ =>
         requestCollectors.maybeTimer.foreach(_.observeDuration())
         requestCollectors.maybeGauge.foreach(_.dec())

--- a/observability/prometheus-backend/src/test/scala/sttp/client4/prometheus/PrometheusBackendTest.scala
+++ b/observability/prometheus-backend/src/test/scala/sttp/client4/prometheus/PrometheusBackendTest.scala
@@ -376,7 +376,11 @@ class PrometheusBackendTest
     assertThrows[SttpClientException] {
       basicRequest
         .get(uri"http://127.0.0.1/foo")
-        .response(asString.map(_ => throw DeserializationException("Unknown body", new Exception("Unable to parse"))))
+        .response(
+          asString.mapWithMetadata((_, meta) =>
+            throw DeserializationException("Unknown body", new Exception("Unable to parse"), meta)
+          )
+        )
         .send(backend)
     }
 
@@ -420,7 +424,9 @@ class PrometheusBackendTest
   it should "report correct host when it is extracted from the response" in {
     // given
     val backendStub =
-      SyncBackendStub.whenAnyRequest.thenRespondF(_ => throw new HttpError("boom", StatusCode.BadRequest))
+      SyncBackendStub.whenAnyRequest.thenRespondF(_ =>
+        throw new HttpError("boom", ResponseStub("", StatusCode.BadRequest))
+      )
 
     import sttp.client4.prometheus.PrometheusBackend.{DefaultFailureCounterName, addMethodLabel}
 

--- a/observability/prometheus-backend/src/test/scala/sttp/client4/prometheus/PrometheusBackendTest.scala
+++ b/observability/prometheus-backend/src/test/scala/sttp/client4/prometheus/PrometheusBackendTest.scala
@@ -373,13 +373,11 @@ class PrometheusBackendTest
     val backend = PrometheusBackend(backendStub)
 
     // when
-    assertThrows[SttpClientException] {
+    assertThrows[IllegalStateException] {
       basicRequest
         .get(uri"http://127.0.0.1/foo")
         .response(
-          asString.mapWithMetadata((_, meta) =>
-            throw DeserializationException("Unknown body", new Exception("Unable to parse"), meta)
-          )
+          asString.map(_ => throw new IllegalStateException())
         )
         .send(backend)
     }

--- a/observability/prometheus-backend/src/test/scala/sttp/client4/prometheus/PrometheusBackendTest.scala
+++ b/observability/prometheus-backend/src/test/scala/sttp/client4/prometheus/PrometheusBackendTest.scala
@@ -423,7 +423,7 @@ class PrometheusBackendTest
     // given
     val backendStub =
       SyncBackendStub.whenAnyRequest.thenRespondF(_ =>
-        throw new HttpError("boom", ResponseStub("", StatusCode.BadRequest))
+        throw new ResponseException.UnexpectedStatusCode("boom", ResponseStub("", StatusCode.BadRequest))
       )
 
     import sttp.client4.prometheus.PrometheusBackend.{DefaultFailureCounterName, addMethodLabel}


### PR DESCRIPTION
* the parametrization of `ResponseException` is simplified, `DeserializationException` does not have a type parameter, always requiring an `Exception` as the cause instead
* when a `ResponseException` is thrown in the response handling specification, this will be logged as a successful response (as the response was received correctly), and counted as a success in the metrics as well
* `HttpError` is renamed to `UnexpectedStatusCode`, and along with `DeserializationException`, both types are nested within `ResponseException`

Closes #1097