### PR TITLE
fix warning in build.sbt

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -113,7 +113,7 @@ val testServerSettings = Seq(
     .evaluated,
   Test / testOptions += Tests.Setup { () =>
     val port = (testServer2_13 / testServerPort).value
-    PollingUtils.waitUntilServerAvailable(new URL(s"http://localhost:$port"))
+    PollingUtils.waitUntilServerAvailable(url(s"http://localhost:$port"))
   }
 )
 


### PR DESCRIPTION
avoid deprecated `java.net.URL` constructor

- https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/net/URL.html#%3Cinit%3E(java.lang.String)
- https://bugs.openjdk.org/browse/JDK-8295949
- https://github.com/openjdk/jdk/commit/4338f527aa81350e3636dcfbcd2eb17ddaad3914