### PR TITLE
Add an option to limit the response length for JVM backends

### DIFF
--- a/akka-http-backend/src/main/scala/sttp/client4/akkahttp/AkkaHttpBackend.scala
+++ b/akka-http-backend/src/main/scala/sttp/client4/akkahttp/AkkaHttpBackend.scala
@@ -131,11 +131,18 @@ class AkkaHttpBackend private (
     val body = bodyFromAkka(
       r.response,
       responseMetadata,
-      wsFlow.map(Right(_)).getOrElse(Left(decodeAkkaResponse(hr, r.autoDecompressionEnabled)))
+      wsFlow
+        .map(Right(_))
+        .getOrElse(
+          Left(decodeAkkaResponse(limitPekkoResponseIfNeeded(hr, r.maxResponseBodyLength), r.autoDecompressionEnabled))
+        )
     )
 
     body.map(sttp.client4.Response(_, code, statusText, headers, Nil, r.onlyMetadata))
   }
+
+  private def limitPekkoResponseIfNeeded(response: HttpResponse, limit: Option[Long]): HttpResponse =
+    limit.fold(response)(l => response.withEntity(response.entity.withSizeLimit(l)))
 
   // http://doc.akka.io/docs/akka-http/10.0.7/scala/http/common/de-coding.html
   private def decodeAkkaResponse(response: HttpResponse, autoDecompressionEnabled: Boolean): HttpResponse =

--- a/akka-http-backend/src/main/scala/sttp/client4/akkahttp/FromAkka.scala
+++ b/akka-http-backend/src/main/scala/sttp/client4/akkahttp/FromAkka.scala
@@ -1,6 +1,7 @@
 package sttp.client4.akkahttp
 
 import akka.http.scaladsl.model.HttpResponse
+import akka.http.scaladsl.model.EntityStreamSizeException
 import sttp.client4.{GenericRequest, SttpClientException}
 import sttp.model.{Header, HeaderNames}
 
@@ -25,6 +26,7 @@ private[akkahttp] object FromAkka {
           case _ => Some(new SttpClientException.ReadException(request, e))
         }
       case e: akka.stream.scaladsl.TcpIdleTimeoutException => Some(new SttpClientException.TimeoutException(request, e))
+      case e: EntityStreamSizeException                    => Some(new SttpClientException.ReadException(request, e))
       case e: Exception => SttpClientException.defaultExceptionToSttpClientException(request, e)
     }
 }

--- a/core/src/main/scala/sttp/client4/RequestOptions.scala
+++ b/core/src/main/scala/sttp/client4/RequestOptions.scala
@@ -16,6 +16,10 @@ import sttp.client4.logging.LoggingOptions
   *   [[sttp.model.Encodings.Gzip]] and [[sttp.model.Encodings.Deflate]] encodings, but others might available as well;
   *   refer to the backend documentation for details. If an encoding is not supported, an exception is thrown / a failed
   *   effect returned, when sending the request.
+  * @param maxResponseBodyLength
+  *   The maximum length of the response body (in bytes). When sending the request, if the response body is longer, an
+  *   exception is thrown / a failed effect is returned. By default, when `None`, the is no limit on the response body's
+  *   length.
   */
 case class RequestOptions(
     followRedirects: Boolean,
@@ -25,5 +29,6 @@ case class RequestOptions(
     decompressResponseBody: Boolean,
     compressRequestBody: Option[String],
     httpVersion: Option[HttpVersion],
-    loggingOptions: LoggingOptions
+    loggingOptions: LoggingOptions,
+    maxResponseBodyLength: Option[Long]
 )

--- a/core/src/main/scala/sttp/client4/SttpApi.scala
+++ b/core/src/main/scala/sttp/client4/SttpApi.scala
@@ -34,7 +34,8 @@ trait SttpApi extends SttpExtensions with UriInterpolator {
         decompressResponseBody = true,
         compressRequestBody = None,
         httpVersion = None,
-        loggingOptions = LoggingOptions()
+        loggingOptions = LoggingOptions(),
+        maxResponseBodyLength = None
       ),
       AttributeMap.Empty
     )

--- a/core/src/main/scala/sttp/client4/internal/LimitedInputStream.scala
+++ b/core/src/main/scala/sttp/client4/internal/LimitedInputStream.scala
@@ -1,0 +1,77 @@
+package sttp.tapir.server.jdkhttp.internal
+
+import sttp.capabilities.StreamMaxLengthExceededException
+import java.io.FilterInputStream
+import java.io.InputStream
+import java.io.IOException
+
+class FailingLimitedInputStream(in: InputStream, limit: Long) extends LimitedInputStream(in, limit) {
+  override def onLimit: Int = {
+    throw new StreamMaxLengthExceededException(limit)
+  }
+}
+
+/** Based on Guava's https://github.com/google/guava/blob/master/guava/src/com/google/common/io/ByteStreams.java */
+class LimitedInputStream(in: InputStream, limit: Long) extends FilterInputStream(in) {
+  protected var left: Long = limit
+  private var mark: Long = -1L
+
+  override def available(): Int = Math.min(in.available(), left.toInt)
+
+  override def mark(readLimit: Int): Unit = {
+    in.mark(readLimit)
+    mark = left
+  }
+
+  override def read(): Int = {
+    if (left == 0) {
+      onLimit
+    } else {
+      val result = in.read()
+      if (result != -1) {
+        left -= 1
+      }
+      result
+    }
+  }
+
+  override def read(b: Array[Byte], off: Int, len: Int): Int = {
+    if (left == 0) {
+      // Temporarily perform a read to check if more bytes are available
+      val checkRead = in.read()
+      if (checkRead == -1) {
+        -1 // No more bytes available in the stream
+      } else {
+        onLimit
+      }
+    } else {
+      val adjustedLen = Math.min(len, left.toInt)
+      val result = in.read(b, off, adjustedLen)
+      if (result != -1) {
+        left -= result
+      }
+      result
+    }
+  }
+
+  override def reset(): Unit = {
+    if (!in.markSupported) {
+      throw new IOException("Mark not supported")
+    }
+    if (mark == -1) {
+      throw new IOException("Mark not set")
+    }
+
+    in.reset()
+    left = mark
+  }
+
+  override def skip(n: Long): Long = {
+    val toSkip = Math.min(n, left)
+    val skipped = in.skip(toSkip)
+    left -= skipped
+    skipped
+  }
+
+  protected def onLimit: Int = -1
+}

--- a/core/src/main/scala/sttp/client4/requestBuilder.scala
+++ b/core/src/main/scala/sttp/client4/requestBuilder.scala
@@ -371,6 +371,14 @@ trait PartialRequestBuilder[+PR <: PartialRequestBuilder[PR, R], +R]
     */
   def loggingOptions: LoggingOptions = options.loggingOptions
 
+  /** Set the maximum response body length. When sending the request, if the response body is longer, an exception is
+    * thrown / a failed effect is returned. By default, there's no limit on the response body's length.
+    */
+  def maxResponseBodyLength(limit: Long): PR = withOptions(options.copy(maxResponseBodyLength = Some(limit)))
+
+  /** The maximum response body length, if any. */
+  def maxResponseBodyLength: Option[Long] = options.maxResponseBodyLength
+
   /** Reads a per-request attribute for the given key, if present. */
   def attribute[T](k: AttributeKey[T]): Option[T] = attributes.get(k)
 

--- a/core/src/main/scalajvm/sttp/client4/SttpClientExceptionExtensions.scala
+++ b/core/src/main/scalajvm/sttp/client4/SttpClientExceptionExtensions.scala
@@ -5,6 +5,7 @@ import sttp.client4.ws.{GotAWebSocketException, NotAWebSocketException}
 
 import scala.annotation.tailrec
 import sttp.client4.SttpClientException.ResponseHandlingException
+import sttp.capabilities.StreamMaxLengthExceededException
 
 trait SttpClientExceptionExtensions {
   @tailrec
@@ -25,6 +26,7 @@ trait SttpClientExceptionExtensions {
       case e: java.io.IOException                   => Some(new ReadException(request, e))
       case e: NotAWebSocketException                => Some(new ReadException(request, e))
       case e: GotAWebSocketException                => Some(new ReadException(request, e))
+      case e: StreamMaxLengthExceededException      => Some(new ReadException(request, e))
       case e: ResponseException[_]                  => Some(new ResponseHandlingException(request, e))
       case e if e.getCause != null && e.getCause.isInstanceOf[Exception] =>
         defaultExceptionToSttpClientException(request, e.getCause.asInstanceOf[Exception])

--- a/core/src/main/scalajvm/sttp/client4/httpclient/HttpClientFutureBackend.scala
+++ b/core/src/main/scalajvm/sttp/client4/httpclient/HttpClientFutureBackend.scala
@@ -17,6 +17,7 @@ import scala.concurrent.{ExecutionContext, Future}
 import sttp.client4.compression.Compressor
 import sttp.client4.compression.CompressionHandlers
 import sttp.client4.compression.Decompressor
+import sttp.tapir.server.jdkhttp.internal.FailingLimitedInputStream
 
 class HttpClientFutureBackend private (
     client: HttpClient,
@@ -63,6 +64,9 @@ class HttpClientFutureBackend private (
   override protected def bodyHandlerBodyToBody(p: InputStream): InputStream = p
 
   override protected def emptyBody(): InputStream = emptyInputStream()
+
+  override protected def bodyToLimitedBody(b: InputStream, limit: Long): InputStream =
+    new FailingLimitedInputStream(b, limit)
 }
 
 object HttpClientFutureBackend {

--- a/core/src/main/scalajvm/sttp/client4/httpurlconnection/HttpURLConnectionBackend.scala
+++ b/core/src/main/scalajvm/sttp/client4/httpurlconnection/HttpURLConnectionBackend.scala
@@ -40,6 +40,7 @@ import scala.concurrent.duration.Duration
 import sttp.client4.GenericRequestBody
 import sttp.client4.compression.CompressionHandlers
 import sttp.client4.compression.Decompressor
+import sttp.tapir.server.jdkhttp.internal.FailingLimitedInputStream
 
 class HttpURLConnectionBackend private (
     opts: BackendOptions,
@@ -81,7 +82,8 @@ class HttpURLConnectionBackend private (
 
       try {
         val is = c.getInputStream
-        readResponse(c, is, r)
+        val limitedIs = r.options.maxResponseBodyLength.fold(is)(new FailingLimitedInputStream(is, _))
+        readResponse(c, limitedIs, r)
       } catch {
         case e: CharacterCodingException     => throw e
         case e: UnsupportedEncodingException => throw e

--- a/core/src/test/scala/sttp/client4/testing/HttpTest.scala
+++ b/core/src/test/scala/sttp/client4/testing/HttpTest.scala
@@ -739,6 +739,28 @@ trait HttpTest[F[_]]
     }
   }
 
+  "maxResponseBodyLength" - {
+    "should be enforced when set" in {
+      val req = postEchoExact
+        .body("01234567890123456789") // 20 bytes
+        .maxResponseBodyLength(10)
+
+      Future(req.send(backend)).flatMap(_.toFuture()).failed.map { e =>
+        e shouldBe a[SttpClientException.ReadException]
+      }
+    }
+
+    "should have no effect when the limit is not reached" in {
+      val req = postEchoExact
+        .body("0123456789")
+        .maxResponseBodyLength(10) // the limit is reached exactly
+
+      Future(req.send(backend)).flatMap(_.toFuture()).map { r =>
+        r.body shouldBe Right("0123456789")
+      }
+    }
+  }
+
   override protected def afterAll(): Unit = {
     backend.close().toFuture()
     super.afterAll()

--- a/core/src/test/scalajs/sttp/client4/testing/AbstractFetchHttpTest.scala
+++ b/core/src/test/scalajs/sttp/client4/testing/AbstractFetchHttpTest.scala
@@ -26,6 +26,9 @@ abstract class AbstractFetchHttpTest[F[_], +P] extends HttpTest[F] {
 
   override protected def supportsHostHeaderOverride = false
 
+  // not yet implemented
+  override protected def supportsMaxResponseBodyLength = false
+
   override def supportsCancellation: Boolean = false
 
   override def timeoutToNone[T](t: F[T], timeoutMillis: Int): F[Option[T]] = ???

--- a/docs/requests/body.md
+++ b/docs/requests/body.md
@@ -1,4 +1,4 @@
-# Body
+# Request body
 
 ## Text data
 

--- a/docs/responses/body.md
+++ b/docs/responses/body.md
@@ -1,4 +1,4 @@
-# Response body descriptions
+# Response body
 
 By default, the received response body will be read as a `Either[String, String]`, using the encoding specified in the `Content-Type` response header (and if none is specified, using `UTF-8`). This is of course configurable: response bodies can be ignored, deserialized into custom types, received as a stream or saved to a file.
 
@@ -251,7 +251,7 @@ val response: Future[Response[Either[String, Source[ByteString, Any]]]] =
 
 It's also possible to parse the received stream as server-sent events (SSE), using an implementation-specific mapping function. Refer to the documentation for particular backends for more details.
 
-## Decompressing bodies (handling the Conent-Encoding header)
+## Decompressing bodies (handling the Content-Encoding header)
 
 If the response body is compressed using `gzip` or `deflate` algorithms, it will be decompressed if the `decompressResponseBody` request option is set. By default this is set to `true`, and can be disabled using the `request.disableAutoDecompression` method.
 
@@ -260,4 +260,10 @@ The encoding of the response body is determined by the encodings that are accept
 If you'd like to use additional decompression algorithms, you'll need to:
 
 * amend the `Accept-Encoding` header that's set on the request
-* add a decompression algorithm to the backend; that can be done on backend creation time, by customising the `compressionHandlers` parameter, and adding a `Decompressor` implementation. Such an implementation has to specify the encoding, which it handles, as well as appropriate body transformation (which is backend-specific).
+* add a decompression algorithm to the backend; that can be done on backend creation time, by customizing the `compressionHandlers` parameter, and adding a `Decompressor` implementation. Such an implementation has to specify the encoding, which it handles, as well as appropriate body transformation (which is backend-specific).
+
+## Limiting the response body size
+
+To limit the size of the response body, use the `maxResponseBodyLength` method on the request description. This modified the `RequestOption`s associated with the request. By default, there's no limit set.
+
+When a limit is set and it is exceed, sending the request will fail with a `SttpClientException.ReadException`, with the cause being `StreamMaxLengthExceededException`.

--- a/docs/responses/body.md
+++ b/docs/responses/body.md
@@ -266,4 +266,4 @@ If you'd like to use additional decompression algorithms, you'll need to:
 
 To limit the size of the response body, use the `maxResponseBodyLength` method on the request description. This modified the `RequestOption`s associated with the request. By default, there's no limit set.
 
-When a limit is set and it is exceed, sending the request will fail with a `SttpClientException.ReadException`, with the cause being `StreamMaxLengthExceededException`.
+When a limit is set and it is exceed, sending the request will fail with a `SttpClientException.ReadException`.

--- a/docs/responses/body.md
+++ b/docs/responses/body.md
@@ -267,3 +267,5 @@ If you'd like to use additional decompression algorithms, you'll need to:
 To limit the size of the response body, use the `maxResponseBodyLength` method on the request description. This modified the `RequestOption`s associated with the request. By default, there's no limit set.
 
 When a limit is set and it is exceed, sending the request will fail with a `SttpClientException.ReadException`.
+
+This feature is currently available only for JVM backends.

--- a/effects/cats/src/main/scalajvm/sttp/client4/httpclient/cats/HttpClientCatsBackend.scala
+++ b/effects/cats/src/main/scalajvm/sttp/client4/httpclient/cats/HttpClientCatsBackend.scala
@@ -20,6 +20,7 @@ import java.net.http.{HttpClient, HttpRequest, HttpResponse}
 import sttp.client4.compression.CompressionHandlers
 import sttp.client4.compression.Compressor
 import sttp.client4.compression.Decompressor
+import sttp.tapir.server.jdkhttp.internal.FailingLimitedInputStream
 
 class HttpClientCatsBackend[F[_]: Async] private (
     client: HttpClient,
@@ -68,6 +69,9 @@ class HttpClientCatsBackend[F[_]: Async] private (
   override protected def bodyHandlerBodyToBody(p: InputStream): InputStream = p
 
   override protected def emptyBody(): InputStream = emptyInputStream()
+
+  override protected def bodyToLimitedBody(b: InputStream, limit: Long): InputStream =
+    new FailingLimitedInputStream(b, limit)
 }
 
 object HttpClientCatsBackend {

--- a/effects/fs2/src/main/scalajvm/sttp/client4/httpclient/fs2/HttpClientFs2Backend.scala
+++ b/effects/fs2/src/main/scalajvm/sttp/client4/httpclient/fs2/HttpClientFs2Backend.scala
@@ -82,6 +82,9 @@ class HttpClientFs2Backend[F[_]: Async] private (
       .flatMap(data => Stream.emits(data.asScala.map(Chunk.byteBuffer)).flatMap(Stream.chunk))
 
   override protected def emptyBody(): Stream[F, Byte] = Stream.empty
+
+  override protected def bodyToLimitedBody(b: Stream[F, Byte], limit: Long): Stream[F, Byte] =
+    Fs2Streams.limitBytes(b, limit)
 }
 
 object HttpClientFs2Backend {

--- a/effects/zio/src/main/scalajvm/sttp/client4/httpclient/zio/HttpClientZioBackend.scala
+++ b/effects/zio/src/main/scalajvm/sttp/client4/httpclient/zio/HttpClientZioBackend.scala
@@ -85,6 +85,9 @@ class HttpClientZioBackend private (
     } yield new ZioSimpleQueue(queue, runtime)
 
   override protected def createSequencer: Task[Sequencer[Task]] = ZioSequencer.create
+
+  override protected def bodyToLimitedBody(b: ZioStreams.BinaryStream, limit: Long): ZioStreams.BinaryStream =
+    ZioStreams.limitBytes(b, limit)
 }
 
 object HttpClientZioBackend {

--- a/http4s-backend/src/main/scala/sttp/client4/http4s/Http4sBackend.scala
+++ b/http4s-backend/src/main/scala/sttp/client4/http4s/Http4sBackend.scala
@@ -83,7 +83,7 @@ class Http4sBackend[F[_]: Async](
               val statusText = response.status.reason
               val responseMetadata = ResponseMetadata(code, statusText, headers)
 
-              val limitedResponse =
+              val limitedResponse: org.http4s.Response[F] =
                 r.options.maxResponseBodyLength.fold(response)(limit =>
                   response.copy(body = Fs2Streams.limitBytes(response.body, limit))
                 )

--- a/http4s-backend/src/main/scala/sttp/client4/http4s/Http4sBackend.scala
+++ b/http4s-backend/src/main/scala/sttp/client4/http4s/Http4sBackend.scala
@@ -83,6 +83,11 @@ class Http4sBackend[F[_]: Async](
               val statusText = response.status.reason
               val responseMetadata = ResponseMetadata(code, statusText, headers)
 
+              val limitedResponse =
+                r.options.maxResponseBodyLength.fold(response)(limit =>
+                  response.copy(body = Fs2Streams.limitBytes(response.body, limit))
+                )
+
               val signalBodyComplete = responseBodyCompleteVar.complete(()).map(_ => ())
               val body =
                 bodyFromResponseAs(signalBodyComplete)(
@@ -90,7 +95,7 @@ class Http4sBackend[F[_]: Async](
                   responseMetadata,
                   Left(
                     onFinalizeSignal(
-                      decompressResponseBodyIfNotHead(r.method, response, r.autoDecompressionEnabled),
+                      decompressResponseBodyIfNotHead(r.method, limitedResponse, r.autoDecompressionEnabled),
                       signalBodyComplete
                     )
                   )

--- a/http4s-ce2-backend/src/main/scala/sttp/client4/http4s/Http4sBackend.scala
+++ b/http4s-ce2-backend/src/main/scala/sttp/client4/http4s/Http4sBackend.scala
@@ -85,7 +85,7 @@ class Http4sBackend[F[_]: ConcurrentEffect: ContextShift](
               val statusText = response.status.reason
               val responseMetadata = ResponseMetadata(code, statusText, headers)
 
-              val limitedResponse =
+              val limitedResponse: org.http4s.Response[F] =
                 r.options.maxResponseBodyLength
                   .fold(response)(limit => response.copy(body = limitBytes(response.body, limit)))
 

--- a/http4s-ce2-backend/src/main/scala/sttp/client4/http4s/Http4sBackend.scala
+++ b/http4s-ce2-backend/src/main/scala/sttp/client4/http4s/Http4sBackend.scala
@@ -6,7 +6,7 @@ import cats.effect.concurrent.MVar
 import cats.effect.{Blocker, Concurrent, ConcurrentEffect, ContextShift, Resource, Sync}
 import cats.implicits._
 import cats.effect.implicits._
-import fs2.{Chunk, Stream}
+import fs2.{Chunk, Stream, Pull}
 import org.http4s.{EntityBody, Request => Http4sRequest, Status}
 import org.http4s
 import org.http4s.blaze.client.BlazeClientBuilder
@@ -27,6 +27,7 @@ import sttp.client4.compression.CompressionHandlers
 import sttp.client4.impl.fs2.GZipFs2Decompressor
 import sttp.client4.impl.fs2.DeflateFs2Decompressor
 import sttp.client4.compression.Decompressor
+import sttp.capabilities.StreamMaxLengthExceededException
 
 import scala.concurrent.ExecutionContext
 
@@ -84,6 +85,10 @@ class Http4sBackend[F[_]: ConcurrentEffect: ContextShift](
               val statusText = response.status.reason
               val responseMetadata = ResponseMetadata(code, statusText, headers)
 
+              val limitedResponse =
+                r.options.maxResponseBodyLength
+                  .fold(response)(limit => response.copy(body = limitBytes(response.body, limit)))
+
               val signalBodyComplete = responseBodyCompleteVar.tryPut(()).map(_ => ())
               val body =
                 bodyFromResponseAs(signalBodyComplete)(
@@ -91,7 +96,7 @@ class Http4sBackend[F[_]: ConcurrentEffect: ContextShift](
                   responseMetadata,
                   Left(
                     onFinalizeSignal(
-                      decompressResponseBodyIfNotHead(r.method, response, r.autoDecompressionEnabled),
+                      decompressResponseBodyIfNotHead(r.method, limitedResponse, r.autoDecompressionEnabled),
                       signalBodyComplete
                     )
                   )
@@ -259,6 +264,24 @@ class Http4sBackend[F[_]: ConcurrentEffect: ContextShift](
       case e: org.http4s.InvalidResponseException => Some(new SttpClientException.ReadException(request, e))
       case e: Exception => SttpClientException.defaultExceptionToSttpClientException(request, e)
     }
+
+  // based on Fs2Streams.limitBytes (for ce3)
+  private def limitBytes[F[_]](stream: Stream[F, Byte], maxBytes: Long): Stream[F, Byte] = {
+    def go(s: Stream[F, Byte], remaining: Long): Pull[F, Byte, Unit] = {
+      if (remaining < 0) throw new StreamMaxLengthExceededException(maxBytes)
+      else
+        s.pull.uncons.flatMap {
+          case Some((chunk, tail)) =>
+            val chunkSize = chunk.size.toLong
+            if (chunkSize <= remaining)
+              Pull.output(chunk) >> go(tail, remaining - chunkSize)
+            else
+              throw new StreamMaxLengthExceededException(maxBytes)
+          case None => Pull.done
+        }
+    }
+    go(stream, maxBytes).stream
+  }
 
   override implicit val monad: MonadError[F] = new CatsMonadAsyncError
 

--- a/pekko-http-backend/src/main/scala/sttp/client4/pekkohttp/FromPekko.scala
+++ b/pekko-http-backend/src/main/scala/sttp/client4/pekkohttp/FromPekko.scala
@@ -2,6 +2,7 @@ package sttp.client4.pekkohttp
 
 import org.apache.pekko
 import pekko.http.scaladsl.model.HttpResponse
+import pekko.http.scaladsl.model.EntityStreamSizeException
 import sttp.client4.{GenericRequest, SttpClientException}
 import sttp.model.{Header, HeaderNames}
 
@@ -27,6 +28,7 @@ private[pekkohttp] object FromPekko {
         }
       case e: pekko.stream.scaladsl.TcpIdleTimeoutException =>
         Some(new SttpClientException.TimeoutException(request, e))
-      case e: Exception => SttpClientException.defaultExceptionToSttpClientException(request, e)
+      case e: EntityStreamSizeException => Some(new SttpClientException.ReadException(request, e))
+      case e: Exception                 => SttpClientException.defaultExceptionToSttpClientException(request, e)
     }
 }


### PR DESCRIPTION
Available via `request.maxResponseBodyLength(limit)`

Closes #1954