### PR TITLE
#1802: Handle empty GZIP streams gracefully

### DIFF
--- a/core/src/main/scalajvm/sttp/client4/compression/defaultDecompressors.scala
+++ b/core/src/main/scalajvm/sttp/client4/compression/defaultDecompressors.scala
@@ -1,13 +1,14 @@
 package sttp.client4.compression
 
+import sttp.client4.internal.SafeGZIPInputStream
 import sttp.model.Encodings
+
 import java.io.InputStream
-import java.util.zip.GZIPInputStream
 import java.util.zip.InflaterInputStream
 
 object GZipInputStreamDecompressor extends Decompressor[InputStream] {
   override val encoding: String = Encodings.Gzip
-  override def apply(body: InputStream): InputStream = new GZIPInputStream(body)
+  override def apply(body: InputStream): InputStream = SafeGZIPInputStream.apply(body)
 }
 
 object DeflateInputStreamDecompressor extends Decompressor[InputStream] {

--- a/core/src/main/scalajvm/sttp/client4/internal/SafeGZIPInputStream.scala
+++ b/core/src/main/scalajvm/sttp/client4/internal/SafeGZIPInputStream.scala
@@ -42,6 +42,7 @@ class SafeGZIPInputStream(in: InputStream, bufferSize: Int) extends FilterInputS
       new GZIPInputStream(in, bufferSize)
     } catch {
       case _: EOFException => SafeGZIPInputStream.noOpStream
+      case e               => throw e // we do not suppress other exceptions
     }
 
   override def read(): Int = stream.read()

--- a/core/src/main/scalajvm/sttp/client4/internal/SafeGZIPInputStream.scala
+++ b/core/src/main/scalajvm/sttp/client4/internal/SafeGZIPInputStream.scala
@@ -19,7 +19,7 @@ object SafeGZIPInputStream {
     */
   def apply(in: InputStream, bufferSize: Int = 512): SafeGZIPInputStream = new SafeGZIPInputStream(in, bufferSize)
 
-  /** Used as a fallback when the input stream is empty or invalid.
+  /** Used as a fallback when the input stream is empty.
     */
   private lazy val noOpStream: InputStream = new InputStream {
     val endOfStream: Int = -1

--- a/core/src/main/scalajvm/sttp/client4/internal/SafeGZIPInputStream.scala
+++ b/core/src/main/scalajvm/sttp/client4/internal/SafeGZIPInputStream.scala
@@ -28,8 +28,8 @@ object SafeGZIPInputStream {
   }
 }
 
-/** A safe wrapper for GZIPInputStream that handles empty streams gracefully. This class prevents EOFException when
-  * reading empty GZIP streams by falling back to a no-op stream.
+/** A safe wrapper for GZIPInputStream that handles empty streams gracefully. Prevents EOFException when reading empty
+  * GZIP streams by falling back to a no-op stream. All other exceptions are propagated as-is.
   *
   * @param in
   *   The input stream to wrap
@@ -42,7 +42,6 @@ class SafeGZIPInputStream(in: InputStream, bufferSize: Int) extends FilterInputS
       new GZIPInputStream(in, bufferSize)
     } catch {
       case _: EOFException => SafeGZIPInputStream.noOpStream
-      case e               => throw e // we do not suppress other exceptions
     }
 
   override def read(): Int = stream.read()

--- a/core/src/main/scalajvm/sttp/client4/internal/SafeGZIPInputStream.scala
+++ b/core/src/main/scalajvm/sttp/client4/internal/SafeGZIPInputStream.scala
@@ -5,6 +5,9 @@ import java.util.zip.GZIPInputStream
 
 /** Creates GZIPInputStream instances that handle empty streams gracefully, replacing exception-based control flow
   * regarding EOFException with a more principled approach.
+  *
+  * It addresses a scenario where some HTTP servers may omit the Content-Length header for empty responses with status
+  * code 202 (Accepted), preventing issues when content length cannot be determined in advance.
   */
 object SafeGZIPInputStream {
 

--- a/core/src/main/scalajvm/sttp/client4/internal/SafeGZIPInputStream.scala
+++ b/core/src/main/scalajvm/sttp/client4/internal/SafeGZIPInputStream.scala
@@ -1,0 +1,55 @@
+package sttp.client4.internal
+
+import java.io.{EOFException, FilterInputStream, InputStream}
+import java.util.zip.GZIPInputStream
+
+/** Creates GZIPInputStream instances that handle empty streams gracefully, replacing exception-based control flow
+  * regarding EOFException with a more principled approach.
+  */
+object SafeGZIPInputStream {
+
+  /** Creates a new SafeGZIPInputStream instance.
+    *
+    * @param in
+    *   The input stream to wrap
+    * @param bufferSize
+    *   The buffer size to use for the GZIP stream (default: 512)
+    * @return
+    *   A new SafeGZIPInputStream instance
+    */
+  def apply(in: InputStream, bufferSize: Int = 512): SafeGZIPInputStream = new SafeGZIPInputStream(in, bufferSize)
+
+  /** Used as a fallback when the input stream is empty or invalid.
+    */
+  private lazy val noOpStream: InputStream = new InputStream {
+    val endOfStream: Int = -1
+    override def read(): Int = endOfStream
+    override def read(b: Array[Byte], off: Int, len: Int): Int = endOfStream
+  }
+}
+
+/** A safe wrapper for GZIPInputStream that handles empty streams gracefully. This class prevents EOFException when
+  * reading empty or invalid GZIP streams by falling back to a no-op stream.
+  *
+  * @param in
+  *   The input stream to wrap
+  * @param bufferSize
+  *   The buffer size to use for the GZIP stream
+  */
+class SafeGZIPInputStream(in: InputStream, bufferSize: Int) extends FilterInputStream(in) {
+  private lazy val stream: InputStream =
+    try {
+      new GZIPInputStream(in, bufferSize)
+    } catch {
+      case _: EOFException => SafeGZIPInputStream.noOpStream
+    }
+
+  override def read(): Int = stream.read()
+
+  override def read(b: Array[Byte], off: Int, len: Int): Int = stream.read(b, off, len)
+
+  override def close(): Unit = {
+    stream.close()
+    super.close()
+  }
+}

--- a/core/src/main/scalajvm/sttp/client4/internal/SafeGZIPInputStream.scala
+++ b/core/src/main/scalajvm/sttp/client4/internal/SafeGZIPInputStream.scala
@@ -29,7 +29,7 @@ object SafeGZIPInputStream {
 }
 
 /** A safe wrapper for GZIPInputStream that handles empty streams gracefully. This class prevents EOFException when
-  * reading empty or invalid GZIP streams by falling back to a no-op stream.
+  * reading empty GZIP streams by falling back to a no-op stream.
   *
   * @param in
   *   The input stream to wrap

--- a/core/src/main/scalajvm/sttp/client4/internal/SafeGZIPInputStream.scala
+++ b/core/src/main/scalajvm/sttp/client4/internal/SafeGZIPInputStream.scala
@@ -40,7 +40,7 @@ object SafeGZIPInputStream {
   *   The buffer size to use for the GZIP stream
   */
 class SafeGZIPInputStream(in: InputStream, bufferSize: Int) extends FilterInputStream(in) {
-  private lazy val stream: InputStream =
+  private val stream: InputStream =
     try {
       new GZIPInputStream(in, bufferSize)
     } catch {

--- a/core/src/test/scala/sttp/client4/testing/HttpTest.scala
+++ b/core/src/test/scala/sttp/client4/testing/HttpTest.scala
@@ -337,6 +337,20 @@ trait HttpTest[F[_]]
       }
     }
 
+    "should gracefully handle empty GZipped 202 response without Content-Length header" in {
+      // A scenario for https://github.com/softwaremill/sttp/issues/1802
+      basicRequest
+        .get(uri"${HttpTest.endpoint}/compress-empty-gzip-accepted-no-content")
+        .response(asStringAlways)
+        .acceptEncoding("gzip")
+        .send(backend)
+        .toFuture()
+        .map { response =>
+          response.code shouldBe StatusCode.Accepted
+          response.body shouldBe ""
+        }
+    }
+
     if (supportsHostHeaderOverride) {
       "should not send the URL's hostname as the host header" in {
         basicRequest

--- a/core/src/test/scalajvm/sttp/client4/internal/SafeGZIPInputStreamTest.scala
+++ b/core/src/test/scalajvm/sttp/client4/internal/SafeGZIPInputStreamTest.scala
@@ -9,7 +9,7 @@ import java.util.zip.{GZIPInputStream, GZIPOutputStream}
 class SafeGZIPInputStreamTest extends AnyFlatSpec with Matchers {
 
   "A safe GZIP stream" should "handle empty stream without throwing EOFException" in {
-    val emptyStream = new ByteArrayInputStream(Array.empty[Byte])
+    val emptyStream = new ByteArrayInputStream(Array.emptyByteArray)
 
     val _ = assertThrows[EOFException] { // a working problem reproducer for a regular GZIPInputStream failure
       new java.util.zip.GZIPInputStream(emptyStream)
@@ -39,7 +39,7 @@ class SafeGZIPInputStreamTest extends AnyFlatSpec with Matchers {
   }
 
   it should "propagate end of the compressed data" in {
-    val testMessage = "Hello, world!"
+    val testMessage = "Hello!"
     val data = createGzippedContent(testMessage)
     val gzippedContent = new ByteArrayInputStream(data)
     val safeStream = SafeGZIPInputStream.apply(gzippedContent)
@@ -49,7 +49,9 @@ class SafeGZIPInputStreamTest extends AnyFlatSpec with Matchers {
     val secondRead = safeStream.read(buffer)
 
     val decompressedContent = new String(buffer, 0, firstRead, "UTF-8")
-    (firstRead, decompressedContent, secondRead) shouldBe (13, testMessage, -1)
+    firstRead shouldBe testMessage.size
+    decompressedContent shouldBe testMessage
+    secondRead shouldBe -1
   }
 
   it should "handle non-empty gzipped content correctly" in {

--- a/core/src/test/scalajvm/sttp/client4/internal/SafeGZIPInputStreamTest.scala
+++ b/core/src/test/scalajvm/sttp/client4/internal/SafeGZIPInputStreamTest.scala
@@ -1,0 +1,71 @@
+package sttp.client4.internal
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import java.io.{ByteArrayInputStream, ByteArrayOutputStream, EOFException}
+import java.util.zip.GZIPOutputStream
+
+class SafeGZIPInputStreamTest extends AnyFlatSpec with Matchers {
+
+  "A safe GZIP stream" should "handle empty stream without throwing EOFException" in {
+    val emptyStream = new ByteArrayInputStream(Array.empty[Byte])
+
+    val _ = assertThrows[EOFException] { // regular GZIPInputStream fails and we have a working problem reproducer
+      new java.util.zip.GZIPInputStream(emptyStream)
+    }
+
+    val safeStream = SafeGZIPInputStream.apply(emptyStream)
+    val result = safeStream.read()
+
+    result shouldBe -1
+  }
+
+  it should "handle non-empty gzipped content correctly" in {
+    val testMessage = "Hello, world!"
+    val data = createGzippedContent(testMessage)
+    val gzippedContent = new ByteArrayInputStream(data)
+    val safeStream = SafeGZIPInputStream.apply(gzippedContent)
+
+    // Read the entire content
+    val buffer = new Array[Byte](1024)
+    val bytesRead = safeStream.read(buffer)
+
+    val decompressedContent = new String(buffer, 0, bytesRead, "UTF-8")
+    decompressedContent shouldBe testMessage
+  }
+
+  private def createGzippedContent(content: String): Array[Byte] = {
+    val baos = new ByteArrayOutputStream()
+    val gzipOut = new GZIPOutputStream(baos)
+    gzipOut.write(content.getBytes("UTF-8"))
+    gzipOut.close()
+    baos.toByteArray
+  }
+
+  it should "let callers handle other failures" in {
+    val invalidData = Array[Byte](1, 2, 3, 4)
+    val invalidStream = new ByteArrayInputStream(invalidData)
+    val safeStream = SafeGZIPInputStream.apply(invalidStream)
+
+    val error = intercept[java.util.zip.ZipException] {
+      safeStream.read()
+    }
+    error.getMessage shouldBe "Not in GZIP format"
+  }
+
+  it should "require callers to handle stream lifecycle states" in {
+    val content = "Test content"
+    val data = createGzippedContent(content)
+    val gzippedContent = new ByteArrayInputStream(data)
+    val safeStream = SafeGZIPInputStream.apply(gzippedContent)
+
+    safeStream.close()
+
+    val error = intercept[java.io.IOException] {
+      safeStream.read()
+    }
+    error.getMessage shouldBe "Stream closed"
+  }
+
+}

--- a/core/src/test/scalajvm/sttp/client4/internal/SafeGZIPInputStreamTest.scala
+++ b/core/src/test/scalajvm/sttp/client4/internal/SafeGZIPInputStreamTest.scala
@@ -2,6 +2,7 @@ package sttp.client4.internal
 
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
+import sttp.client4.compression.GZipInputStreamDecompressor
 
 import java.io.{ByteArrayInputStream, ByteArrayOutputStream, EOFException}
 import java.util.zip.{GZIPInputStream, GZIPOutputStream}
@@ -15,7 +16,7 @@ class SafeGZIPInputStreamTest extends AnyFlatSpec with Matchers {
       new java.util.zip.GZIPInputStream(emptyStream)
     }
 
-    val safeStream = SafeGZIPInputStream.apply(emptyStream)
+    val safeStream = GZipInputStreamDecompressor.apply(emptyStream)
     val result = safeStream.read()
 
     result shouldBe -1
@@ -30,7 +31,7 @@ class SafeGZIPInputStreamTest extends AnyFlatSpec with Matchers {
 
     val invalidGzipData = baos.toByteArray
     val corruptedStream = new ByteArrayInputStream(invalidGzipData)
-    val safeStream = SafeGZIPInputStream.apply(corruptedStream)
+    val safeStream = GZipInputStreamDecompressor.apply(corruptedStream)
 
     val error = intercept[EOFException] {
       safeStream.read()
@@ -42,7 +43,7 @@ class SafeGZIPInputStreamTest extends AnyFlatSpec with Matchers {
     val testMessage = "Hello!"
     val data = createGzippedContent(testMessage)
     val gzippedContent = new ByteArrayInputStream(data)
-    val safeStream = SafeGZIPInputStream.apply(gzippedContent)
+    val safeStream = GZipInputStreamDecompressor.apply(gzippedContent)
 
     val buffer = new Array[Byte](1024)
     val firstRead = safeStream.read(buffer) // read the entire content
@@ -58,7 +59,7 @@ class SafeGZIPInputStreamTest extends AnyFlatSpec with Matchers {
     val testMessage = "Hello!"
     val data = createGzippedContent(testMessage)
     val gzippedContent = new ByteArrayInputStream(data)
-    val safeStream = SafeGZIPInputStream.apply(gzippedContent)
+    val safeStream = GZipInputStreamDecompressor.apply(gzippedContent)
 
     val buffer = new Array[Byte](1024)
     val bytesRead = safeStream.read(buffer)
@@ -78,7 +79,7 @@ class SafeGZIPInputStreamTest extends AnyFlatSpec with Matchers {
   it should "let callers handle other failures" in {
     val invalidData = Array[Byte](1, 2, 3, 4)
     val invalidStream = new ByteArrayInputStream(invalidData)
-    val safeStream = SafeGZIPInputStream.apply(invalidStream)
+    val safeStream = GZipInputStreamDecompressor.apply(invalidStream)
 
     val error = intercept[java.util.zip.ZipException] {
       safeStream.read()
@@ -90,7 +91,7 @@ class SafeGZIPInputStreamTest extends AnyFlatSpec with Matchers {
     val content = "Test content"
     val data = createGzippedContent(content)
     val gzippedContent = new ByteArrayInputStream(data)
-    val safeStream = SafeGZIPInputStream.apply(gzippedContent)
+    val safeStream = GZipInputStreamDecompressor.apply(gzippedContent)
 
     safeStream.close()
 

--- a/core/src/test/scalajvm/sttp/client4/internal/SafeGZIPInputStreamTest.scala
+++ b/core/src/test/scalajvm/sttp/client4/internal/SafeGZIPInputStreamTest.scala
@@ -79,10 +79,9 @@ class SafeGZIPInputStreamTest extends AnyFlatSpec with Matchers {
   it should "let callers handle other failures" in {
     val invalidData = Array[Byte](1, 2, 3, 4)
     val invalidStream = new ByteArrayInputStream(invalidData)
-    val safeStream = GZipInputStreamDecompressor.apply(invalidStream)
 
     val error = intercept[java.util.zip.ZipException] {
-      safeStream.read()
+      GZipInputStreamDecompressor.apply(invalidStream)
     }
     error.getMessage shouldBe "Not in GZIP format"
   }

--- a/http4s-backend/src/main/scala/sttp/client4/http4s/Http4sBackend.scala
+++ b/http4s-backend/src/main/scala/sttp/client4/http4s/Http4sBackend.scala
@@ -212,9 +212,11 @@ class Http4sBackend[F[_]: Async](
     )
 
   private def decompressResponseBody(hr: http4s.Response[F]): http4s.Response[F] = {
+    val isEmptyBody: Boolean =
+      hr.headers.get[http4s.headers.`Content-Length`].contains(http4s.headers.`Content-Length`.zero)
     val body = hr.headers
       .get[http4s.headers.`Content-Encoding`]
-      .filterNot(_ => hr.status.equals(Status.NoContent))
+      .filterNot(_ => hr.status.equals(Status.NoContent) || isEmptyBody)
       .map(e => Decompressor.decompressIfPossible(hr.body, e.contentCoding.coding, compressionHandlers.decompressors))
       .getOrElse(hr.body)
     hr.copy(body = body)

--- a/http4s-ce2-backend/src/main/scala/sttp/client4/http4s/Http4sBackend.scala
+++ b/http4s-ce2-backend/src/main/scala/sttp/client4/http4s/Http4sBackend.scala
@@ -211,9 +211,11 @@ class Http4sBackend[F[_]: ConcurrentEffect: ContextShift](
     if (m == Method.HEAD || !autoDecompressionEnabled) hr else decompressResponseBody(hr)
 
   private def decompressResponseBody(hr: http4s.Response[F]): http4s.Response[F] = {
+    val isEmptyBody: Boolean =
+      hr.headers.get[http4s.headers.`Content-Length`].contains(http4s.headers.`Content-Length`.zero)
     val body = hr.headers
       .get[`Content-Encoding`]
-      .filterNot(_ => hr.status.equals(Status.NoContent))
+      .filterNot(_ => hr.status.equals(Status.NoContent) || isEmptyBody)
       .map(e => Decompressor.decompressIfPossible(hr.body, e.contentCoding.coding, compressionHandlers.decompressors))
       .getOrElse(hr.body)
     hr.copy(body = body)

--- a/testing/server/src/main/scala/sttp/client4/testing/server/HttpServer.scala
+++ b/testing/server/src/main/scala/sttp/client4/testing/server/HttpServer.scala
@@ -309,6 +309,11 @@ private class HttpServer(port: Int, info: String => Unit) extends AutoCloseable 
           complete(204, HttpEntity.Empty)
         }
       }
+    } ~ path("compress-empty-gzip-accepted-no-content") {
+      encodeResponseWith(Gzip) {
+        respondWithHeader(RawHeader("Content-Encoding", "gzip")) {
+          complete(202, HttpEntity.Empty)
+        }
     } ~ path("compress-empty-deflate") {
       encodeResponseWith(Deflate) {
         respondWithHeader(RawHeader("Content-Encoding", "deflate")) {

--- a/testing/server/src/main/scala/sttp/client4/testing/server/HttpServer.scala
+++ b/testing/server/src/main/scala/sttp/client4/testing/server/HttpServer.scala
@@ -314,6 +314,7 @@ private class HttpServer(port: Int, info: String => Unit) extends AutoCloseable 
         respondWithHeader(RawHeader("Content-Encoding", "gzip")) {
           complete(202, HttpEntity.Empty)
         }
+      }
     } ~ path("compress-empty-deflate") {
       encodeResponseWith(Deflate) {
         respondWithHeader(RawHeader("Content-Encoding", "deflate")) {


### PR DESCRIPTION
Prevents EOFException when processing empty streams in 204 responses and when Content-Length header is absent.

Closes #1802

- [x] Check if the project compiles by running `sbt compile`
- [x] Verify docs compilation by running `sbt compileDocs`
- [x] Check if tests pass by running `sbt test`
- [x] Format code by running `sbt scalafmt`

