### PR TITLE
Change quickRequest to always read the response body as a string, instead of throwing an exception on http errors

### DIFF
--- a/core/src/main/scala/sttp/client4/SttpApi.scala
+++ b/core/src/main/scala/sttp/client4/SttpApi.scala
@@ -56,10 +56,8 @@ trait SttpApi extends SttpExtensions with UriInterpolator {
   val basicRequest: PartialRequest[Either[String, String]] =
     emptyRequest.acceptEncoding("gzip, deflate")
 
-  /** A starting request which always reads the response body as a string, if the response code is successful (2xx), and
-    * fails (throws an exception, or returns a failed effect) otherwise.
-    */
-  val quickRequest: PartialRequest[String] = basicRequest.response(asStringOrFail)
+  /** A starting request which always reads the response body as a string, regardless of the status code. */
+  val quickRequest: PartialRequest[String] = basicRequest.response(asStringAlways)
 
   // response descriptions
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -150,8 +150,8 @@ quickRequest.get(uri"http://httpbin.org/ip").send()
 ```
 
 Additionally, above we're using `quickRequest`, instead of `basicRequest`, to build the request description. 
-`quickRequest` is pre-configured to read successful HTTP responses as a `String`, and to throw an exception 
-otherwise. You can read more about the initial request definitions [here](requests/basics.md).
+`quickRequest` is pre-configured to always read HTTP responses as a `String`, regardless of the status code. 
+You can read more about the initial request definitions [here](requests/basics.md).
 
 ## Next steps
 

--- a/docs/requests/basics.md
+++ b/docs/requests/basics.md
@@ -52,6 +52,6 @@ sttp provides three initial requests:
 
 * `basicRequest`, which is an empty request with the `Accept-Encoding: gzip, deflate` header added. That's the one that is most commonly used. By default reads the response as a `Either[String, String]` (indicating HTTP 4xx/5xx failure or 2xx success).
 * `emptyRequest`, a completely empty request, with no headers at all.
-* `quickRequest`, which by default reads the response as a `String` in case of a success, and throws an exception / returns a failed effect in case of a 4xx/5xx HTTP error response.
+* `quickRequest`, which always reads the response as a `String`, regardless of the status code
 
 How the response body is handled can be (and very often is) customized. See the section on [response body specifications](../responses/body.md) for more details.


### PR DESCRIPTION
Closes #2506