### PR TITLE
Add Scala Native build for jsoniter

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -764,6 +764,7 @@ lazy val jsoniter = (projectMatrix in file("json/jsoniter"))
     settings = commonJvmSettings
   )
   .jsPlatform(scalaVersions = scala2And3, settings = commonJsSettings)
+  .nativePlatform(scalaVersions = scala2And3, settings = commonNativeSettings)
   .dependsOn(core, jsonCommon % compileAndTest)
 
 lazy val zioJson = (projectMatrix in file("json/zio-json"))


### PR DESCRIPTION
While trying to upgrade to sttp4 in Caliban, I found that the jsoniter module was not published for Scala Native (it was in sttp3 since https://github.com/softwaremill/sttp/pull/1796).


Before submitting pull request:
- [x] Check if the project compiles by running `sbt compile`
- [x] Verify docs compilation by running `sbt compileDocs`
- [x] Check if tests pass by running `sbt test`
- [x] Format code by running `sbt scalafmt`
