### PR TITLE
Use double colon in quickstart dependencies

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -9,7 +9,7 @@ The library is available for Scala 2.12, 2.13 and 3. Supported platforms are the
 Here's a quick example of sttp client in action, runnable using [scala-cli](https://scala-cli.virtuslab.org):
 
 ```scala
-//> using dep com.softwaremill.sttp.client4::core:@VERSION@
+//> using dep com.softwaremill.sttp.client4::core::@VERSION@
 
 import sttp.client4.quick.*
 
@@ -28,7 +28,7 @@ Additionally, sttp client seamlessly integrates with popular libraries for JSON 
 Some more features: URI interpolation, a self-managed backend, and type-safe HTTP error/success representation, are demonstrated by the below example:
 
 ```scala
-//> using dep com.softwaremill.sttp.client4::core:@VERSION@
+//> using dep com.softwaremill.sttp.client4::core::@VERSION@
 
 import sttp.client4.*
 


### PR DESCRIPTION
Otherwise the samples don't work on native
