### PR TITLE
Curl backend should set user agent

### DIFF
--- a/core/src/main/resources/scala-native/ffi.c
+++ b/core/src/main/resources/scala-native/ffi.c
@@ -1,9 +1,11 @@
 #if defined(STTP_CURL_FFI)
-#include <curl/curl.h> 
+#include <curl/curl.h>
 
 int sttp_curl_setopt_int(CURL *curl, CURLoption opt, int arg) {return curl_easy_setopt(curl, opt, arg); }
 int sttp_curl_setopt_long(CURL *curl, CURLoption opt, long arg) {return curl_easy_setopt(curl, opt, arg); }
 int sttp_curl_setopt_pointer(CURL *curl, CURLoption opt, void* arg) {return curl_easy_setopt(curl, opt, arg); }
-
+const char* sttp_curl_get_version() {
+    return curl_version_info(CURLVERSION_NOW)->version;
+}
 int sttp_curl_getinfo_pointer(CURL *curl, CURLINFO info, void* arg) {return curl_easy_getinfo(curl, info, arg); }
 #endif

--- a/core/src/main/scalanative/sttp/client4/curl/internal/CCurl.scala
+++ b/core/src/main/scalanative/sttp/client4/curl/internal/CCurl.scala
@@ -37,6 +37,9 @@ private[curl] trait CCurl {
   @name("sttp_curl_getinfo_pointer")
   def getInfo(handle: Ptr[Curl], info: CInt, parameter: Ptr[_]): CInt = extern
 
+  @name("sttp_curl_get_version")
+  def getVersion(): CString = extern
+
   @name("curl_easy_init")
   def init: Ptr[Curl] = extern
 

--- a/core/src/test/scalanative/sttp/client4/CurlBackendHttpTest.scala
+++ b/core/src/test/scalanative/sttp/client4/CurlBackendHttpTest.scala
@@ -1,8 +1,27 @@
 package sttp.client4
+package curl
 
 import sttp.client4.curl.CurlBackend
+import sttp.client4.curl.internal.CCurl
 import sttp.client4.testing.SyncHttpTest
+import scalanative.unsafe.fromCString
 
 class CurlBackendHttpTest extends SyncHttpTest {
   override implicit val backend: SyncBackend = CurlBackend(verbose = true)
+  "curl backend" - {
+    "set user agent in requests" in {
+      val response = basicRequest
+        .get(uri"$endpoint/echo/headers")
+        .send(backend)
+
+      val requestUserAgent = response.body
+        .fold(sys.error(_), identity)
+        .split(",")
+        .map(_.toLowerCase)
+        .find(_.startsWith("user-agent->"))
+        .map(_.stripPrefix("user-agent->"))
+
+      requestUserAgent should be(Some(s"sttp-curl/${fromCString(CCurl.getVersion())}"))
+    }
+  }
 }


### PR DESCRIPTION
This PR adds a reasonable default user agent for the curl native backend, because it's a better default behaviour, see explanation below.

---

Consider this simple usage of sttp:

```
> scala run -e 'import sttp.client4.*; println(basicRequest.get(uri"https://echo.free.beeceptor.com").send(DefaultSyncBackend()).body)' --dep com.softwaremill.sttp.client4::core::4.0.3
Compiling project (Scala 3.6.4, JVM (21))
Compiled project (Scala 3.6.4, JVM (21))
Right({
  "method": "GET",
  "protocol": "https",
  "host": "echo.free.beeceptor.com",
  "path": "/",
  "ip": "195.26.120.14:57130",
  "headers": {
    "Host": "echo.free.beeceptor.com",
    "User-Agent": "Java-http-client/21.0.3",
    "Accept-Encoding": "gzip, deflate"
  },
  "parsedQueryParams": {}
})
```

Notice how on JVM, `User-Agent` is added automatically by the client implementation.

Now, if you run this on Native:

```
> scala run --native -e 'import sttp.client4.*; println(basicRequest.get(uri"https://echo.free.beeceptor.com").send(DefaultSyncBackend()).body)' --dep com.softwaremill.sttp.client4::core::4.0.3

...
Right({
  "method": "GET",
  "protocol": "https",
  "host": "echo.free.beeceptor.com",
  "path": "/",
  "ip": "195.26.120.14:57259",
  "headers": {
    "Host": "echo.free.beeceptor.com",
    "Accept": "*/*",
    "Accept-Encoding": "gzip, deflate"
  },
  "parsedQueryParams": {}
})
```

There is no user agent, because libcurl does not add it by default.

Apparently there are some hosts that prohibit empty user agents – one of them being Scaladex!

```
# -A sets user agent
> curl -A "" 'https://index.scala-lang.org/api/project?organization=indoorvivants&repository=sn-bindgen'
<html>
<head><title>403 Forbidden</title></head>
<body>
<center><h1>403 Forbidden</h1></center>
<hr><center>nginx/1.24.0 (Ubuntu)</center>
</body>
</html>
```

Lack of user agent on native prevents parity between JVM and Native usage of sttp.
