### PR TITLE
Redirection cookie handling tests for issue #2671

### DIFF
--- a/core/src/test/scala/sttp/client4/FollowRedirectsBackendTest.scala
+++ b/core/src/test/scala/sttp/client4/FollowRedirectsBackendTest.scala
@@ -7,6 +7,8 @@ import sttp.client4.testing.{BackendStub, ResponseStub}
 import sttp.client4.wrappers.{FollowRedirectsBackend, FollowRedirectsConfig}
 import sttp.model.internal.Rfc3986
 import sttp.model.{Header, StatusCode, Uri}
+import sttp.model.headers.CookieWithMeta
+import sttp.model.Method
 
 class FollowRedirectsBackendTest extends AnyFunSuite with Matchers with EitherValues {
   val testData = List(
@@ -53,4 +55,38 @@ class FollowRedirectsBackendTest extends AnyFunSuite with Matchers with EitherVa
     result.body.value shouldBe "All good!"
   }
 
+  test("should pass cookies during redirections") {
+
+    val url0 = uri"https://example.com/0"
+    val url1 = uri"https://example.com/1"
+
+    val response0 = ResponseStub
+      .adjust(
+        "",
+        StatusCode.Found,
+        Vector(
+          Header.location(url1),
+          Header.setCookie(CookieWithMeta("session", "one"))
+        )
+      )
+
+    val stub0 = BackendStub.synchronous
+      .whenRequestMatches { r => r.uri == url0 && r.method == Method.POST }
+      .thenRespond(response0)
+      .whenRequestMatches { r => r.uri == url1 && r.method == Method.GET && r.unsafeCookies.isEmpty }
+      .thenRespondUnauthorized()
+      .whenRequestMatches { r =>
+        r.uri == url1 && r.method == Method.GET && r.unsafeCookies.map(_.name).contains("session")
+      }
+      .thenRespondOk()
+      .whenAnyRequest
+      .thenRespondNotFound()
+
+    val redirectsBackend =
+      wrappers.FollowRedirectsBackend(stub0, config = FollowRedirectsConfig(sensitiveHeaders = Set.empty))
+    val result = basicRequest.redirectToGet(true).post(url0).send(redirectsBackend)
+
+    result.unsafeCookies.size shouldEqual 1
+    result.code shouldBe StatusCode.Ok
+  }
 }


### PR DESCRIPTION
Tests for #2671 which are now failing with the following output:

```
- should pass cookies during redirections *** FAILED *** (13 milliseconds)
  Vector() did not contain element "session" (in Checkpoint) at FollowRedirectsBackendTest.scala:90
  Vector() did not contain element "session" (in Checkpoint) at FollowRedirectsBackendTest.scala:90
  Vector() did not contain element "session" (in Checkpoint) at FollowRedirectsBackendTest.scala:90
  Vector() did not contain element "session" (in Checkpoint) at FollowRedirectsBackendTest.scala:90
  Vector() did not contain element "session" (in Checkpoint) at FollowRedirectsBackendTest.scala:90
  Vector(session=final) did not equal List(0-fuzz=, 1-fuzz=, 2-fuzz=, 3-fuzz=, 4-fuzz=, session=final) (in Checkpoint) 

at FollowRedirectsBackendTest.scala:118 (FollowRedirectsBackendTest.scala:119)
```

Before submitting pull request:
- [x] Check if the project compiles by running `sbt compile`
- [x] Verify docs compilation by running `sbt compileDocs`
- [ ] Check if tests pass by running `sbt test`
- [x] Format code by running `sbt scalafmt`
