### PR TITLE
Render multipart filename, content-type, and per-part headers in toCurl

### DIFF
--- a/core/src/main/scala/sttp/client4/internal/ToCurlConverter.scala
+++ b/core/src/main/scala/sttp/client4/internal/ToCurlConverter.scala
@@ -58,13 +58,27 @@ private[client4] object ToCurlConverter {
   def handleMultipartBody(parts: Seq[Part[GenericRequestBody[_]]]): String =
     parts
       .map { p =>
-        p.body match {
-          case StringBody(s, _, _) => s"--form '${p.name}=$s'"
-          case FileBody(f, _)      => s"--form '${p.name}=@${f.name}'"
-          case _                   => s"--data-binary <PLACEHOLDER>"
+        val formValue = p.body match {
+          case StringBody(s, _, _) => s"${p.name}=${escapeSingleQuotes(s)}"
+          case FileBody(f, _)      => s"${p.name}=@${escapeSingleQuotes(f.name)}"
+          case _                   => s"${p.name}=<PLACEHOLDER>"
         }
+        s"--form '$formValue${partMetadata(p)}'"
       }
       .mkString(newline)
+
+  private def partMetadata(p: Part[GenericRequestBody[_]]): String = {
+    val fileName = p.fileName.fold("")(n => s";filename=${escapeSingleQuotes(n)}")
+    val contentType = p.contentType.fold("")(ct => s";type=${escapeSingleQuotes(ct)}")
+    // Content-Type is already emitted via ;type= so it is filtered out here to avoid duplication.
+    val extraHeaders = p.headers
+      .filterNot(_.is(HeaderNames.ContentType))
+      .map(h => s""";headers="${escapeSingleQuotes(s"${h.name}: ${h.value}")}"""")
+      .mkString
+    fileName + contentType + extraHeaders
+  }
+
+  private def escapeSingleQuotes(text: String): String = text.replace("'", "\\'")
 
   private def extractOptions(r: GenericRequest[_, _]): String =
     if (r.options.followRedirects) {

--- a/core/src/test/scala/sttp/client4/ToCurlConverterTest.scala
+++ b/core/src/test/scala/sttp/client4/ToCurlConverterTest.scala
@@ -106,7 +106,45 @@ class ToCurlConverterTest extends AnyFlatSpec with Matchers with ToCurlConverter
 
   it should "render multipart form data if content is a plain string" in {
     basicRequest.multipartBody(multipart("k1", "v1"), multipart("k2", "v2")).post(localhost).toCurl should include(
-      "--form 'k1=v1' \\\n  --form 'k2=v2'"
+      "--form 'k1=v1;type=text/plain; charset=utf-8' \\\n  --form 'k2=v2;type=text/plain; charset=utf-8'"
+    )
+  }
+
+  it should "render multipart string part with filename and content type metadata" in {
+    basicRequest
+      .multipartBody(multipart("file", "file content").fileName("document.pdf").contentType("application/pdf"))
+      .post(localhost)
+      .toCurl should include(
+      "--form 'file=file content;filename=document.pdf;type=application/pdf'"
+    )
+  }
+
+  it should "escape single quotes in multipart string value, filename, content type and headers" in {
+    basicRequest
+      .multipartBody(
+        multipart("k", "v'1").fileName("a'b.txt").contentType("text/p'lain").header("X-T'ag", "v'al")
+      )
+      .post(localhost)
+      .toCurl should include(
+      """--form 'k=v\'1;filename=a\'b.txt;type=text/p\'lain;headers="X-T\'ag: v\'al"'"""
+    )
+  }
+
+  it should "render multipart part headers other than Content-Type via the ;headers= extension" in {
+    basicRequest
+      .multipartBody(multipart("k1", "v1").header("X-Custom", "abc").header("X-Other", "xyz"))
+      .post(localhost)
+      .toCurl should include(
+      """--form 'k1=v1;type=text/plain; charset=utf-8;headers="X-Custom: abc";headers="X-Other: xyz"'"""
+    )
+  }
+
+  it should "render multipart binary part with form framing and metadata" in {
+    basicRequest
+      .multipartBody(multipart("payload", "ignored".getBytes("UTF-8")).fileName("blob.bin"))
+      .post(localhost)
+      .toCurl should include(
+      "--form 'payload=<PLACEHOLDER>;filename=blob.bin;type=application/octet-stream'"
     )
   }
 }

--- a/core/src/test/scalajvm/sttp/client4/ToCurlConverterTestExtension.scala
+++ b/core/src/test/scalajvm/sttp/client4/ToCurlConverterTestExtension.scala
@@ -13,7 +13,20 @@ trait ToCurlConverterTestExtension { suit: Suite with AnyFlatSpec with Matchers 
       .multipartBody(multipartSttpFile("upload", SttpFile.fromPath(new File("myDataSet").toPath)))
       .post(uri"http://localhost")
       .toCurl should include(
-      """--form 'upload=@myDataSet'"""
+      """--form 'upload=@myDataSet;filename=myDataSet;type=application/octet-stream'"""
+    )
+  }
+
+  it should "render multipart file part with overridden filename and content type" in {
+    basicRequest
+      .multipartBody(
+        multipartSttpFile("upload", SttpFile.fromPath(new File("data.bin").toPath))
+          .fileName("renamed.pdf")
+          .contentType("application/pdf")
+      )
+      .post(uri"http://localhost")
+      .toCurl should include(
+      """--form 'upload=@data.bin;filename=renamed.pdf;type=application/pdf'"""
     )
   }
 }


### PR DESCRIPTION
Fixes #2881. The toCurl converter was dropping multipart metadata (filename, content-type, and custom headers) when generating curl command output. This made the generated curl commands incomplete and unable to faithfully reproduce the original HTTP request.

This change adds support for emitting multipart metadata using curl's form-field extensions:
- Filenames via the `;filename=` parameter
- Content-Type via the `;type=` parameter
- Custom headers via the `;headers=` parameter (Content-Type is filtered to avoid duplication)

Values containing single quotes are escaped with backslashes to ensure proper shell syntax. Tests cover all metadata combinations including edge cases with special characters.

Closes softwaremill/sttp#2881.