### PR TITLE
Select a single supported qop from a comma-separated advertised list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,7 @@ lowered.hnir
 
 .orca
 work.txt
+
+# TraceVault — local only, do not commit
+.tracevault/
+.claude/settings.local.json

--- a/core/src/main/scala/sttp/client4/internal/DigestAuthenticator.scala
+++ b/core/src/main/scala/sttp/client4/internal/DigestAuthenticator.scala
@@ -59,7 +59,7 @@ private[client4] class DigestAuthenticator private (
         true
       }
     if (isFirstOrShouldRetry) {
-      val qualityOfProtection = wwwAuthHeader.qop
+      val qualityOfProtection = selectQop(wwwAuthHeader.qop)
       val algorithm = wwwAuthHeader.algorithm.getOrElse("MD5")
       val messageDigest = new MessageDigestCompatibility(algorithm)
       val digestUri =
@@ -101,6 +101,19 @@ private[client4] class DigestAuthenticator private (
       None
     }
   }
+
+  // Picks a single qop value from a possibly comma-separated `qop` directive (RFC 7616 allows e.g. `qop="auth,auth-int"`).
+  // Prefers `auth` over `auth-int` per the RFC's recommendation. Returns the input unchanged for a single-value qop,
+  // and `None` when no qop was advertised so the no-qop digest branch is preserved. If only unsupported tokens are
+  // advertised, the first one is returned and the downstream match fails fast with `IllegalArgumentException`.
+  private def selectQop(advertised: Option[String]): Option[String] =
+    advertised.map { raw =>
+      val tokens = raw.split(",").iterator.map(_.trim).toList
+      tokens
+        .find(_ == QualityOfProtectionAuth)
+        .orElse(tokens.find(_ == QualityOfProtectionAuthInt))
+        .getOrElse(tokens.head)
+    }
 
   private def calculateResponseChallenge(
       request: GenericRequest[_, _],

--- a/core/src/main/scala/sttp/client4/internal/DigestAuthenticator.scala
+++ b/core/src/main/scala/sttp/client4/internal/DigestAuthenticator.scala
@@ -108,7 +108,7 @@ private[client4] class DigestAuthenticator private (
   // advertised, the first one is returned and the downstream match fails fast with `IllegalArgumentException`.
   private def selectQop(advertised: Option[String]): Option[String] =
     advertised.map { raw =>
-      val tokens = raw.split(",").iterator.map(_.trim).toList
+      val tokens = raw.split(",").map(_.trim).toList
       tokens
         .find(_ == QualityOfProtectionAuth)
         .orElse(tokens.find(_ == QualityOfProtectionAuthInt))

--- a/core/src/main/scala/sttp/client4/internal/package.scala
+++ b/core/src/main/scala/sttp/client4/internal/package.scala
@@ -41,8 +41,8 @@ package object internal {
   private[client4] def emptyInputStream(): InputStream = new ByteArrayInputStream(Array[Byte]())
 
   /** Returns the bytes between the buffer's current `position` and `limit` as an `Array[Byte]`. Safe for direct,
-    * read-only, partially-consumed, and sliced buffers. The source buffer's `position` and `limit` are preserved. For
-    * a fresh, full heap buffer the backing array is returned directly (no copy); otherwise a new array is allocated.
+    * read-only, partially-consumed, and sliced buffers. The source buffer's `position` and `limit` are preserved. For a
+    * fresh, full heap buffer the backing array is returned directly (no copy); otherwise a new array is allocated.
     */
   private[client4] def byteBufferToArray(b: ByteBuffer): Array[Byte] =
     if (b.hasArray && b.arrayOffset() == 0 && b.position() == 0 && b.remaining() == b.array().length)
@@ -95,6 +95,7 @@ package object internal {
   private[client4] val IOBufferSize = 1024
 
   implicit class RichByteBuffer(byteBuffer: ByteBuffer) {
+
     /** Reads the buffer's remaining bytes into a fresh array, advancing the buffer's `position` to `limit`. Use
       * [[byteBufferToArray]] instead when the buffer's position should be preserved.
       */

--- a/core/src/test/scala/sttp/client4/internal/DigestAuthenticatorTest.scala
+++ b/core/src/test/scala/sttp/client4/internal/DigestAuthenticatorTest.scala
@@ -24,6 +24,19 @@ class DigestAuthenticatorTest extends AnyFreeSpec with Matchers with OptionValue
     header.value.value should fullyMatch regex """Digest username="admin", realm="myrealm", uri="/", nonce="BBBBBB", qop=auth, response="[0-9a-f]+", cnonce="[0-9a-f]+", nc=000000\d\d, algorithm=MD5"""
   }
 
+  "pick a supported qop when the server advertises a comma-separated list" in {
+    val request = basicRequest
+      .get(uri"http://google.com")
+      .auth
+      .digest("admin", "password")
+
+    val r =
+      responseWithAuthenticateHeader("""Digest realm="myrealm", nonce="BBBBBB", algorithm=MD5, qop="auth,auth-int"""")
+    val header = DigestAuthenticator(DigestAuthData("admin", "password")).authenticate(request, r)
+    header.value.name shouldBe HeaderNames.Authorization
+    header.value.value should fullyMatch regex """Digest username="admin", realm="myrealm", uri="/", nonce="BBBBBB", qop=auth, response="[0-9a-f]+", cnonce="[0-9a-f]+", nc=000000\d\d, algorithm=MD5"""
+  }
+
   "throw exception when wwAuth header is invalid (missing nonce)" in {
     val request = basicRequest
       .get(uri"http://google.com")

--- a/core/src/test/scala/sttp/client4/internal/DigestAuthenticatorTest.scala
+++ b/core/src/test/scala/sttp/client4/internal/DigestAuthenticatorTest.scala
@@ -37,6 +37,18 @@ class DigestAuthenticatorTest extends AnyFreeSpec with Matchers with OptionValue
     header.value.value should fullyMatch regex """Digest username="admin", realm="myrealm", uri="/", nonce="BBBBBB", qop=auth, response="[0-9a-f]+", cnonce="[0-9a-f]+", nc=000000\d\d, algorithm=MD5"""
   }
 
+  "tolerate whitespace around commas in the advertised qop list" in {
+    val request = basicRequest
+      .get(uri"http://google.com")
+      .auth
+      .digest("admin", "password")
+
+    val r =
+      responseWithAuthenticateHeader("""Digest realm="myrealm", nonce="BBBBBB", algorithm=MD5, qop="auth-int , auth"""")
+    val header = DigestAuthenticator(DigestAuthData("admin", "password")).authenticate(request, r)
+    header.value.value should fullyMatch regex """Digest username="admin", realm="myrealm", uri="/", nonce="BBBBBB", qop=auth, response="[0-9a-f]+", cnonce="[0-9a-f]+", nc=000000\d\d, algorithm=MD5"""
+  }
+
   "throw exception when wwAuth header is invalid (missing nonce)" in {
     val request = basicRequest
       .get(uri"http://google.com")


### PR DESCRIPTION
Fixes handling of the `qop` directive when a server advertises multiple values as a comma-separated list (e.g. `qop="auth,auth-int"`, which RFC 7616 allows).

Previously the whole raw string was passed downstream and matched against the exact `auth`/`auth-int` constants, so a list value fell through to `throw new IllegalArgumentException("Unknown qop: ...")`.

`DigestAuthenticator` now selects a single token from the advertised list, preferring `auth` over `auth-int` per the RFC's recommendation, before computing the challenge. Whitespace around commas is tolerated. A single-value qop is unchanged, and an absent qop still uses the no-qop digest branch.

Tests cover the comma-separated list and whitespace-tolerance cases.

Closes softwaremill/sttp#2882.