### PR TITLE
Fix #1465: No way to send continuous WebSocketFrame with Fs2 stream pipes

### DIFF
--- a/core/src/main/scala/sttp/client4/wrappers/CookieStorage.scala
+++ b/core/src/main/scala/sttp/client4/wrappers/CookieStorage.scala
@@ -18,16 +18,16 @@ import sttp.model.Uri
   * Cookies are represented as plain name/value pairs rather than [[sttp.model.headers.CookieWithMeta]]. That type is
   * available on all platforms, but its `Set-Cookie` rendering and parsing reach `java.time` date formatting (for
   * `Expires`, via `ZoneId`/`DateTimeFormatter`), a subset of `java.time` not supported on Scala Native; referencing it
-  * from this shared code pulls those symbols in and breaks the Native link. Time-based expiry (`Max-Age` > 0, `Expires`)
-  * is not tracked anyway, as the storage has no notion of the current time; a `Set-Cookie` with `Max-Age` <= 0 removes a
-  * matching cookie, so a server can still clear cookies within a chain.
+  * from this shared code pulls those symbols in and breaks the Native link. Time-based expiry (`Max-Age` > 0,
+  * `Expires`) is not tracked anyway, as the storage has no notion of the current time; a `Set-Cookie` with `Max-Age` <=
+  * 0 removes a matching cookie, so a server can still clear cookies within a chain.
   */
 final class CookieStorage private (private val entries: Map[CookieStorage.Key, CookieStorage.Stored]) {
   import CookieStorage._
 
-  /** A new storage updated with the cookies parsed from the `Set-Cookie` header values received from `setBy`.
-    * Following RFC 6265, a cookie whose `Domain` attribute does not domain-match `setBy` is rejected (to prevent a
-    * host setting cookies for unrelated domains). A cookie with `Max-Age` <= 0 removes a matching stored cookie.
+  /** A new storage updated with the cookies parsed from the `Set-Cookie` header values received from `setBy`. Following
+    * RFC 6265, a cookie whose `Domain` attribute does not domain-match `setBy` is rejected (to prevent a host setting
+    * cookies for unrelated domains). A cookie with `Max-Age` <= 0 removes a matching stored cookie.
     */
   def setFromSetCookieHeaders(setBy: Uri, setCookieHeaders: Iterable[String]): CookieStorage = {
     val host = hostOf(setBy)

--- a/core/src/test/scala/sttp/client4/wrappers/CookieStorageTest.scala
+++ b/core/src/test/scala/sttp/client4/wrappers/CookieStorageTest.scala
@@ -18,7 +18,8 @@ class CookieStorageTest extends AnyFunSuite with Matchers {
   }
 
   test("sends a domain cookie to matching subdomains, but not to unrelated domains") {
-    val storage = CookieStorage.empty.setFromSetCookieHeaders(uri"https://example.com/", List("s=1; Domain=example.com"))
+    val storage =
+      CookieStorage.empty.setFromSetCookieHeaders(uri"https://example.com/", List("s=1; Domain=example.com"))
     names(storage.cookiesFor(uri"https://sub.example.com/")) shouldBe Set("s")
     storage.cookiesFor(uri"https://other.com/") shouldBe empty
   }

--- a/docs/other/websockets.md
+++ b/docs/other/websockets.md
@@ -94,6 +94,10 @@ effect type      class name
 ================ ==========================================
 ```
 
+Fragmented messages can also be sent: when using fs2, if the pipe emits a frame with `finalFragment = false`, all
+subsequent frames, up to and including the next frame with `finalFragment = true`, are automatically sent as
+continuations of that message.
+
 ## Using blocking, synchronous Ox streams
 
 [Ox](https://ox.softwaremill.com) is a Scala 3 toolkit that allows you to handle concurrency and resiliency in direct

--- a/docs/other/websockets.md
+++ b/docs/other/websockets.md
@@ -94,9 +94,9 @@ effect type      class name
 ================ ==========================================
 ```
 
-Fragmented messages can also be sent: when using fs2, if the pipe emits a frame with `finalFragment = false`, all
-subsequent frames, up to and including the next frame with `finalFragment = true`, are automatically sent as
-continuations of that message.
+Fragmented messages can also be sent: if the pipe emits a frame with `finalFragment = false`, all subsequent frames,
+up to and including the next frame with `finalFragment = true`, are automatically sent as continuations of that
+message.
 
 ## Using blocking, synchronous Ox streams
 

--- a/effects/fs2-ce2/src/main/scala/sttp/client4/impl/fs2/Fs2WebSockets.scala
+++ b/effects/fs2-ce2/src/main/scala/sttp/client4/impl/fs2/Fs2WebSockets.scala
@@ -3,6 +3,7 @@ package sttp.client4.impl.fs2
 import cats.effect.ConcurrentEffect
 import cats.effect.concurrent.Ref
 import cats.effect.implicits._
+import cats.syntax.all._
 import fs2.{Pipe, Stream}
 import sttp.ws.{WebSocket, WebSocketClosed, WebSocketFrame}
 
@@ -24,38 +25,47 @@ object Fs2WebSockets {
   def handleThroughPipe[F[_]: ConcurrentEffect](
       ws: WebSocket[F]
   )(pipe: Pipe[F, WebSocketFrame.Data[_], WebSocketFrame]): F[Unit] =
-    Stream
-      .eval(Ref.of[F, Option[WebSocketFrame.Close]](None))
-      .flatMap { closeRef =>
-        Stream
-          .repeatEval(ws.receive()) // read incoming messages
-          .flatMap[F, Option[WebSocketFrame.Data[_]]] {
-            case WebSocketFrame.Close(code, reason) =>
-              Stream.eval(closeRef.set(Some(WebSocketFrame.Close(code, reason)))).as(None)
-            case WebSocketFrame.Ping(payload) =>
-              Stream.eval(ws.send(WebSocketFrame.Pong(payload))).drain
-            case WebSocketFrame.Pong(_) =>
-              Stream.empty // ignore
-            case in: WebSocketFrame.Data[_] => Stream.emit(Some(in))
-          }
-          .handleErrorWith {
-            case _: WebSocketClosed => Stream.eval(closeRef.set(None)).as(None)
-            case e                  => Stream.eval(ConcurrentEffect[F].raiseError(e))
-          }
-          .unNoneTerminate // terminate once we got a Close
-          .through(pipe)
-          // end with matching Close or user-provided Close or no Close at all
-          .append(Stream.eval(closeRef.get).unNone)
-          // a data frame following a non-final fragment is a continuation; a Close never is
-          .mapAccumulate(false) {
-            case (afterNonFinal, frame: WebSocketFrame.Data[_]) => (!frame.finalFragment, frame -> afterNonFinal)
-            case (afterNonFinal, frame)                         => (afterNonFinal, frame -> false)
-          }
-          .evalMap { case (_, (frame, isContinuation)) => ws.send(frame, isContinuation) } // send messages
-      }
-      .compile
-      .drain
-      .guarantee(ws.close())
+    Ref.of[F, Boolean](false).flatMap { closeSent =>
+      Stream
+        .eval(Ref.of[F, Option[WebSocketFrame.Close]](None))
+        .flatMap { closeRef =>
+          Stream
+            .repeatEval(ws.receive()) // read incoming messages
+            .flatMap[F, Option[WebSocketFrame.Data[_]]] {
+              case WebSocketFrame.Close(code, reason) =>
+                Stream.eval(closeRef.set(Some(WebSocketFrame.Close(code, reason)))).as(None)
+              case WebSocketFrame.Ping(payload) =>
+                Stream.eval(ws.send(WebSocketFrame.Pong(payload))).drain
+              case WebSocketFrame.Pong(_) =>
+                Stream.empty // ignore
+              case in: WebSocketFrame.Data[_] => Stream.emit(Some(in))
+            }
+            .handleErrorWith {
+              case _: WebSocketClosed => Stream.eval(closeRef.set(None)).as(None)
+              case e                  => Stream.eval(ConcurrentEffect[F].raiseError(e))
+            }
+            .unNoneTerminate // terminate once we got a Close
+            .through(pipe)
+            // end with matching Close or user-provided Close or no Close at all
+            .append(Stream.eval(closeRef.get).unNone)
+            // a data frame following a non-final fragment is a continuation; a Close never is
+            .mapAccumulate(false) {
+              case (afterNonFinal, frame: WebSocketFrame.Data[_]) => (!frame.finalFragment, frame -> afterNonFinal)
+              case (afterNonFinal, frame)                         => (afterNonFinal, frame -> false)
+            }
+            .evalMap { case (_, (frame, isContinuation)) =>
+              ws.send(frame, isContinuation) *> (frame match {
+                case _: WebSocketFrame.Close => closeSent.set(true)
+                case _                       => ().pure[F]
+              })
+            } // send messages
+        }
+        .compile
+        .drain
+        // the stream already emits a matching/user Close when appropriate; only fall back to a
+        // default Close if none was sent (e.g. the pipe finished without one)
+        .guarantee(closeSent.get.flatMap(sent => if (sent) ().pure[F] else ws.close()))
+    }
 
   def fromTextPipe[F[_]]: (String => WebSocketFrame) => fs2.Pipe[F, WebSocketFrame, WebSocketFrame] =
     f => fromTextPipeF(_.map(f))

--- a/effects/fs2-ce2/src/main/scala/sttp/client4/impl/fs2/Fs2WebSockets.scala
+++ b/effects/fs2-ce2/src/main/scala/sttp/client4/impl/fs2/Fs2WebSockets.scala
@@ -45,8 +45,13 @@ object Fs2WebSockets {
           .unNoneTerminate // terminate once we got a Close
           .through(pipe)
           // end with matching Close or user-provided Close or no Close at all
-          .append(Stream.eval(closeRef.get).unNone) // A Close isn't a continuation
-          .evalMap(ws.send(_)) // send messages
+          .append(Stream.eval(closeRef.get).unNone)
+          // a data frame following a non-final fragment is a continuation; a Close never is
+          .mapAccumulate(false) {
+            case (afterNonFinal, frame: WebSocketFrame.Data[_]) => (!frame.finalFragment, frame -> afterNonFinal)
+            case (afterNonFinal, frame)                         => (afterNonFinal, frame -> false)
+          }
+          .evalMap { case (_, (frame, isContinuation)) => ws.send(frame, isContinuation) } // send messages
       }
       .compile
       .drain

--- a/effects/fs2-ce2/src/test/scalajvm/sttp/client4/impl/fs2/Fs2WebSocketsTest.scala
+++ b/effects/fs2-ce2/src/test/scalajvm/sttp/client4/impl/fs2/Fs2WebSocketsTest.scala
@@ -1,0 +1,106 @@
+package sttp.client4.impl.fs2
+
+import cats.effect.concurrent.Ref
+import cats.effect.{ContextShift, IO}
+import fs2.{Pipe, Stream}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import sttp.client4.impl.cats.CatsMonadAsyncError
+import sttp.model.Headers
+import sttp.monad.MonadError
+import sttp.ws.{WebSocket, WebSocketClosed, WebSocketFrame}
+
+import scala.concurrent.ExecutionContext
+
+class Fs2WebSocketsTest extends AnyFlatSpec with Matchers {
+
+  behavior of "Fs2WebSockets.handleThroughPipe"
+
+  private implicit val contextShift: ContextShift[IO] = IO.contextShift(ExecutionContext.global)
+
+  private val serverClose = WebSocketFrame.Close(1000, "normal")
+
+  /** Records all sent frames together with their `isContinuation` flag. `receive()` returns the given frames in order,
+    * then fails with [[WebSocketClosed]], as a real web socket would.
+    */
+  private class RecordingWebSocket(
+      incoming: Ref[IO, List[WebSocketFrame]],
+      sent: Ref[IO, List[(WebSocketFrame, Boolean)]]
+  ) extends WebSocket[IO] {
+    override def receive(): IO[WebSocketFrame] =
+      incoming
+        .modify {
+          case head :: tail => (tail, IO.pure(head))
+          case Nil          => (Nil, IO.raiseError[WebSocketFrame](WebSocketClosed(None)))
+        }
+        .flatMap(identity)
+
+    override def send(frame: WebSocketFrame, isContinuation: Boolean): IO[Unit] =
+      sent.update(_ :+ (frame -> isContinuation))
+
+    override def isOpen(): IO[Boolean] = IO.pure(true)
+    override lazy val upgradeHeaders: Headers = Headers(Nil)
+    override implicit def monad: MonadError[IO] = new CatsMonadAsyncError[IO]
+  }
+
+  private def sentFrames(incoming: List[WebSocketFrame])(
+      pipe: Pipe[IO, WebSocketFrame.Data[_], WebSocketFrame]
+  ): List[(WebSocketFrame, Boolean)] =
+    (for {
+      incomingRef <- Ref.of[IO, List[WebSocketFrame]](incoming)
+      sentRef <- Ref.of[IO, List[(WebSocketFrame, Boolean)]](Nil)
+      ws = new RecordingWebSocket(incomingRef, sentRef)
+      _ <- Fs2WebSockets.handleThroughPipe(ws)(pipe)
+      sent <- sentRef.get
+    } yield sent).unsafeRunSync()
+
+  it should "mark non-final fragments emitted by the pipe as continuations of the previous frame" in {
+    val first = WebSocketFrame.Text("Hel", finalFragment = false, None)
+    val middle = WebSocketFrame.Text("lo, ", finalFragment = false, None)
+    val last = WebSocketFrame.Text("world!", finalFragment = true, None)
+    val separate = WebSocketFrame.text("Bye!")
+
+    val sent = sentFrames(List(serverClose))(in => in.drain ++ Stream(first, middle, last, separate))
+
+    sent shouldBe List(
+      first -> false,
+      middle -> true,
+      last -> true,
+      separate -> false,
+      serverClose -> false
+    )
+  }
+
+  it should "echo a server-initiated Close exactly once, without a duplicate close frame" in {
+    val message = WebSocketFrame.text("hello")
+
+    val sent = sentFrames(List(serverClose))(in => in.drain ++ Stream(message))
+
+    sent shouldBe List(message -> false, serverClose -> false)
+  }
+
+  it should "send a Close frame emitted by the pipe exactly once" in {
+    val userClose = WebSocketFrame.Close(4000, "user-initiated")
+
+    val sent = sentFrames(Nil)(in => in.drain ++ Stream(userClose))
+
+    sent shouldBe List(userClose -> false)
+  }
+
+  it should "not mark a Close frame following a non-final fragment as a continuation" in {
+    val fragment = WebSocketFrame.Text("partial", finalFragment = false, None)
+    val userClose = WebSocketFrame.Close(4000, "abort")
+
+    val sent = sentFrames(Nil)(in => in.drain ++ Stream(fragment, userClose))
+
+    sent shouldBe List(fragment -> false, userClose -> false)
+  }
+
+  it should "fall back to a default Close frame if neither the server nor the pipe provided one" in {
+    val message = WebSocketFrame.text("hello")
+
+    val sent = sentFrames(Nil)(in => in.drain ++ Stream(message))
+
+    sent shouldBe List(message -> false, WebSocketFrame.close -> false)
+  }
+}

--- a/effects/fs2/src/main/scala/sttp/client4/impl/fs2/Fs2WebSockets.scala
+++ b/effects/fs2/src/main/scala/sttp/client4/impl/fs2/Fs2WebSockets.scala
@@ -2,6 +2,7 @@ package sttp.client4.impl.fs2
 
 import cats.effect.kernel.{Concurrent, Ref}
 import cats.effect.kernel.syntax.monadCancel._
+import cats.syntax.all._
 import fs2.{Pipe, Stream}
 import sttp.ws.{WebSocket, WebSocketClosed, WebSocketFrame}
 
@@ -23,38 +24,47 @@ object Fs2WebSockets {
   def handleThroughPipe[F[_]: Concurrent](
       ws: WebSocket[F]
   )(pipe: Pipe[F, WebSocketFrame.Data[_], WebSocketFrame]): F[Unit] =
-    Stream
-      .eval(Ref.of[F, Option[WebSocketFrame.Close]](None))
-      .flatMap { closeRef =>
-        Stream
-          .repeatEval(ws.receive()) // read incoming messages
-          .flatMap[F, Option[WebSocketFrame.Data[_]]] {
-            case WebSocketFrame.Close(code, reason) =>
-              Stream.eval(closeRef.set(Some(WebSocketFrame.Close(code, reason)))).as(None)
-            case WebSocketFrame.Ping(payload) =>
-              Stream.eval(ws.send(WebSocketFrame.Pong(payload))).drain
-            case WebSocketFrame.Pong(_) =>
-              Stream.empty // ignore
-            case in: WebSocketFrame.Data[_] => Stream.emit(Some(in))
-          }
-          .handleErrorWith {
-            case _: WebSocketClosed => Stream.eval(closeRef.set(None)).as(None)
-            case e                  => Stream.eval(Concurrent[F].raiseError(e))
-          }
-          .unNoneTerminate // terminate once we got a Close
-          .through(pipe)
-          // end with matching Close or user-provided Close or no Close at all
-          .append(Stream.eval(closeRef.get).unNone)
-          // a data frame following a non-final fragment is a continuation; a Close never is
-          .mapAccumulate(false) {
-            case (afterNonFinal, frame: WebSocketFrame.Data[_]) => (!frame.finalFragment, frame -> afterNonFinal)
-            case (afterNonFinal, frame)                         => (afterNonFinal, frame -> false)
-          }
-          .evalMap { case (_, (frame, isContinuation)) => ws.send(frame, isContinuation) } // send messages
-      }
-      .compile
-      .drain
-      .guarantee(ws.close())
+    Ref.of[F, Boolean](false).flatMap { closeSent =>
+      Stream
+        .eval(Ref.of[F, Option[WebSocketFrame.Close]](None))
+        .flatMap { closeRef =>
+          Stream
+            .repeatEval(ws.receive()) // read incoming messages
+            .flatMap[F, Option[WebSocketFrame.Data[_]]] {
+              case WebSocketFrame.Close(code, reason) =>
+                Stream.eval(closeRef.set(Some(WebSocketFrame.Close(code, reason)))).as(None)
+              case WebSocketFrame.Ping(payload) =>
+                Stream.eval(ws.send(WebSocketFrame.Pong(payload))).drain
+              case WebSocketFrame.Pong(_) =>
+                Stream.empty // ignore
+              case in: WebSocketFrame.Data[_] => Stream.emit(Some(in))
+            }
+            .handleErrorWith {
+              case _: WebSocketClosed => Stream.eval(closeRef.set(None)).as(None)
+              case e                  => Stream.eval(Concurrent[F].raiseError(e))
+            }
+            .unNoneTerminate // terminate once we got a Close
+            .through(pipe)
+            // end with matching Close or user-provided Close or no Close at all
+            .append(Stream.eval(closeRef.get).unNone)
+            // a data frame following a non-final fragment is a continuation; a Close never is
+            .mapAccumulate(false) {
+              case (afterNonFinal, frame: WebSocketFrame.Data[_]) => (!frame.finalFragment, frame -> afterNonFinal)
+              case (afterNonFinal, frame)                         => (afterNonFinal, frame -> false)
+            }
+            .evalMap { case (_, (frame, isContinuation)) =>
+              ws.send(frame, isContinuation) *> (frame match {
+                case _: WebSocketFrame.Close => closeSent.set(true)
+                case _                       => ().pure[F]
+              })
+            } // send messages
+        }
+        .compile
+        .drain
+        // the stream already emits a matching/user Close when appropriate; only fall back to a
+        // default Close if none was sent (e.g. the pipe finished without one)
+        .guarantee(closeSent.get.flatMap(sent => if (sent) ().pure[F] else ws.close()))
+    }
 
   def fromTextPipe[F[_]]: (String => WebSocketFrame) => fs2.Pipe[F, WebSocketFrame, WebSocketFrame] =
     f => fromTextPipeF(_.map(f))

--- a/effects/fs2/src/main/scala/sttp/client4/impl/fs2/Fs2WebSockets.scala
+++ b/effects/fs2/src/main/scala/sttp/client4/impl/fs2/Fs2WebSockets.scala
@@ -44,8 +44,13 @@ object Fs2WebSockets {
           .unNoneTerminate // terminate once we got a Close
           .through(pipe)
           // end with matching Close or user-provided Close or no Close at all
-          .append(Stream.eval(closeRef.get).unNone) // A Close isn't a continuation
-          .evalMap(ws.send(_)) // send messages
+          .append(Stream.eval(closeRef.get).unNone)
+          // a data frame following a non-final fragment is a continuation; a Close never is
+          .mapAccumulate(false) {
+            case (afterNonFinal, frame: WebSocketFrame.Data[_]) => (!frame.finalFragment, frame -> afterNonFinal)
+            case (afterNonFinal, frame)                         => (afterNonFinal, frame -> false)
+          }
+          .evalMap { case (_, (frame, isContinuation)) => ws.send(frame, isContinuation) } // send messages
       }
       .compile
       .drain

--- a/effects/fs2/src/test/scalajvm/sttp/client4/impl/fs2/Fs2WebSocketsTest.scala
+++ b/effects/fs2/src/test/scalajvm/sttp/client4/impl/fs2/Fs2WebSocketsTest.scala
@@ -1,0 +1,103 @@
+package sttp.client4.impl.fs2
+
+import cats.effect.IO
+import cats.effect.kernel.Ref
+import cats.effect.unsafe.implicits.global
+import fs2.{Pipe, Stream}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import sttp.client4.impl.cats.CatsMonadAsyncError
+import sttp.model.Headers
+import sttp.monad.MonadError
+import sttp.ws.{WebSocket, WebSocketClosed, WebSocketFrame}
+
+class Fs2WebSocketsTest extends AnyFlatSpec with Matchers {
+
+  behavior of "Fs2WebSockets.handleThroughPipe"
+
+  private val serverClose = WebSocketFrame.Close(1000, "normal")
+
+  /** Records all sent frames together with their `isContinuation` flag. `receive()` returns the given frames in order,
+    * then fails with [[WebSocketClosed]], as a real web socket would.
+    */
+  private class RecordingWebSocket(
+      incoming: Ref[IO, List[WebSocketFrame]],
+      sent: Ref[IO, List[(WebSocketFrame, Boolean)]]
+  ) extends WebSocket[IO] {
+    override def receive(): IO[WebSocketFrame] =
+      incoming
+        .modify {
+          case head :: tail => (tail, IO.pure(head))
+          case Nil          => (Nil, IO.raiseError[WebSocketFrame](WebSocketClosed(None)))
+        }
+        .flatMap(identity)
+
+    override def send(frame: WebSocketFrame, isContinuation: Boolean): IO[Unit] =
+      sent.update(_ :+ (frame -> isContinuation))
+
+    override def isOpen(): IO[Boolean] = IO.pure(true)
+    override lazy val upgradeHeaders: Headers = Headers(Nil)
+    override implicit def monad: MonadError[IO] = new CatsMonadAsyncError[IO]
+  }
+
+  private def sentFrames(incoming: List[WebSocketFrame])(
+      pipe: Pipe[IO, WebSocketFrame.Data[_], WebSocketFrame]
+  ): List[(WebSocketFrame, Boolean)] =
+    (for {
+      incomingRef <- Ref.of[IO, List[WebSocketFrame]](incoming)
+      sentRef <- Ref.of[IO, List[(WebSocketFrame, Boolean)]](Nil)
+      ws = new RecordingWebSocket(incomingRef, sentRef)
+      _ <- Fs2WebSockets.handleThroughPipe(ws)(pipe)
+      sent <- sentRef.get
+    } yield sent).unsafeRunSync()
+
+  it should "mark non-final fragments emitted by the pipe as continuations of the previous frame" in {
+    val first = WebSocketFrame.Text("Hel", finalFragment = false, None)
+    val middle = WebSocketFrame.Text("lo, ", finalFragment = false, None)
+    val last = WebSocketFrame.Text("world!", finalFragment = true, None)
+    val separate = WebSocketFrame.text("Bye!")
+
+    val sent = sentFrames(List(serverClose))(in => in.drain ++ Stream(first, middle, last, separate))
+
+    sent shouldBe List(
+      first -> false,
+      middle -> true,
+      last -> true,
+      separate -> false,
+      serverClose -> false
+    )
+  }
+
+  it should "echo a server-initiated Close exactly once, without a duplicate close frame" in {
+    val message = WebSocketFrame.text("hello")
+
+    val sent = sentFrames(List(serverClose))(in => in.drain ++ Stream(message))
+
+    sent shouldBe List(message -> false, serverClose -> false)
+  }
+
+  it should "send a Close frame emitted by the pipe exactly once" in {
+    val userClose = WebSocketFrame.Close(4000, "user-initiated")
+
+    val sent = sentFrames(Nil)(in => in.drain ++ Stream(userClose))
+
+    sent shouldBe List(userClose -> false)
+  }
+
+  it should "not mark a Close frame following a non-final fragment as a continuation" in {
+    val fragment = WebSocketFrame.Text("partial", finalFragment = false, None)
+    val userClose = WebSocketFrame.Close(4000, "abort")
+
+    val sent = sentFrames(Nil)(in => in.drain ++ Stream(fragment, userClose))
+
+    sent shouldBe List(fragment -> false, userClose -> false)
+  }
+
+  it should "fall back to a default Close frame if neither the server nor the pipe provided one" in {
+    val message = WebSocketFrame.text("hello")
+
+    val sent = sentFrames(Nil)(in => in.drain ++ Stream(message))
+
+    sent shouldBe List(message -> false, WebSocketFrame.close -> false)
+  }
+}

--- a/effects/monix/src/main/scala/sttp/client4/impl/monix/MonixWebSockets.scala
+++ b/effects/monix/src/main/scala/sttp/client4/impl/monix/MonixWebSockets.scala
@@ -1,5 +1,6 @@
 package sttp.client4.impl.monix
 
+import cats.effect.concurrent.Ref
 import monix.eval.Task
 import monix.execution.cancelables.BooleanCancelable
 import monix.reactive.Observable
@@ -12,25 +13,51 @@ object MonixWebSockets {
       pipe: Observable[WebSocketFrame.Data[_]] => Observable[WebSocketFrame]
   ): Task[Unit] =
     Task(BooleanCancelable()).flatMap { wsClosed =>
-      val onClose = Task(wsClosed.cancel()).map(_ => None)
-      pipe(
-        Observable
-          .repeatEvalF(ws.receive().flatMap[Option[WebSocketFrame.Data[_]]] {
-            case WebSocketFrame.Close(_, _)   => onClose
-            case WebSocketFrame.Ping(payload) => ws.send(WebSocketFrame.Pong(payload)).map(_ => None)
-            case WebSocketFrame.Pong(_)       => Task.now(None)
-            case in: WebSocketFrame.Data[_]   => Task.now(Some(in))
-          })
-          .onErrorRecoverWith { case _: WebSocketClosed => Observable.from(onClose) }
-          .takeWhileNotCanceled(wsClosed)
-          .flatMap {
-            case None    => Observable.empty
-            case Some(f) => Observable(f)
-          }
-      )
-        .mapEval(ws.send(_))
-        .completedL
-        .guarantee(ws.close())
+      Ref.of[Task, Option[WebSocketFrame.Close]](None).flatMap { closeRef =>
+        Ref.of[Task, Boolean](false).flatMap { closeSent =>
+          // set the close to echo (a received Close) or none (the connection is already gone),
+          // then terminate the stream
+          def onClose(close: Option[WebSocketFrame.Close]): Task[Option[WebSocketFrame.Data[_]]] =
+            closeRef.set(close) >> Task {
+              wsClosed.cancel()
+              None
+            }
+          pipe(
+            Observable
+              .repeatEvalF(ws.receive().flatMap[Option[WebSocketFrame.Data[_]]] {
+                case WebSocketFrame.Close(code, reason) => onClose(Some(WebSocketFrame.Close(code, reason)))
+                case WebSocketFrame.Ping(payload)       => ws.send(WebSocketFrame.Pong(payload)).map(_ => None)
+                case WebSocketFrame.Pong(_)             => Task.now(None)
+                case in: WebSocketFrame.Data[_]         => Task.now(Some(in))
+              })
+              .onErrorRecoverWith { case _: WebSocketClosed => Observable.from(onClose(None)) }
+              .takeWhileNotCanceled(wsClosed)
+              .flatMap {
+                case None    => Observable.empty
+                case Some(f) => Observable(f)
+              }
+          )
+            // end with matching Close or user-provided Close or no Close at all
+            .++(Observable.fromTask(closeRef.get).flatMap {
+              case Some(close) => Observable(close: WebSocketFrame)
+              case None        => Observable.empty
+            })
+            // a data frame following a non-final fragment is a continuation; a Close never is
+            .mapAccumulate(false) {
+              case (afterNonFinal, frame: WebSocketFrame.Data[_]) => (!frame.finalFragment, (frame, afterNonFinal))
+              case (afterNonFinal, frame)                         => (afterNonFinal, (frame, false))
+            }
+            .mapEval { case (frame, isContinuation) =>
+              ws.send(frame, isContinuation) >> (frame match {
+                case _: WebSocketFrame.Close => closeSent.set(true)
+                case _                       => Task.unit
+              })
+            }
+            .completedL
+            // the stream already emits a Close when appropriate; only fall back to a default Close if none was sent
+            .guarantee(closeSent.get.flatMap(sent => if (sent) Task.unit else ws.close()))
+        }
+      }
     }
   def fromTextPipe: (String => WebSocketFrame) => MonixStreams.Pipe[WebSocketFrame, WebSocketFrame] =
     f => fromTextPipeF(_.map(f))

--- a/effects/monix/src/test/scalajvm/sttp/client4/impl/monix/MonixWebSocketsTest.scala
+++ b/effects/monix/src/test/scalajvm/sttp/client4/impl/monix/MonixWebSocketsTest.scala
@@ -1,0 +1,106 @@
+package sttp.client4.impl.monix
+
+import monix.eval.Task
+import monix.execution.Scheduler.Implicits.global
+import monix.reactive.Observable
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import sttp.model.Headers
+import sttp.monad.MonadError
+import sttp.ws.{WebSocket, WebSocketClosed, WebSocketFrame}
+
+import scala.concurrent.duration._
+
+class MonixWebSocketsTest extends AnyFlatSpec with Matchers {
+
+  behavior of "MonixWebSockets.compilePipe"
+
+  private val serverClose = WebSocketFrame.Close(1000, "normal")
+
+  /** Records all sent frames together with their `isContinuation` flag. `receive()` returns the given frames in order,
+    * then fails with [[WebSocketClosed]], as a real web socket would.
+    */
+  private class RecordingWebSocket(incoming: List[WebSocketFrame]) extends WebSocket[Task] {
+    private var remaining = incoming
+    private val recorded = scala.collection.mutable.ListBuffer.empty[(WebSocketFrame, Boolean)]
+    def sent: List[(WebSocketFrame, Boolean)] = synchronized(recorded.toList)
+
+    override def receive(): Task[WebSocketFrame] = Task.defer {
+      synchronized {
+        remaining match {
+          case head :: tail => remaining = tail; Task.now(head)
+          case Nil          => Task.raiseError(WebSocketClosed(None))
+        }
+      }
+    }
+
+    override def send(frame: WebSocketFrame, isContinuation: Boolean): Task[Unit] =
+      Task { synchronized { recorded += (frame -> isContinuation) }; () }
+
+    override def isOpen(): Task[Boolean] = Task.now(true)
+    override lazy val upgradeHeaders: Headers = Headers(Nil)
+    override implicit def monad: MonadError[Task] = TaskMonadAsyncError
+  }
+
+  private def sentFrames(incoming: List[WebSocketFrame])(
+      pipe: Observable[WebSocketFrame.Data[_]] => Observable[WebSocketFrame]
+  ): List[(WebSocketFrame, Boolean)] = {
+    val ws = new RecordingWebSocket(incoming)
+    MonixWebSockets.compilePipe(ws, pipe).runSyncUnsafe(5.seconds)
+    ws.sent
+  }
+
+  // drains the incoming frames (as compilePipe requires), then emits the given frames
+  private def drainThen(frames: WebSocketFrame*): Observable[WebSocketFrame.Data[_]] => Observable[WebSocketFrame] =
+    in => Observable.fromTask(in.completedL).flatMap(_ => Observable(frames: _*))
+
+  it should "mark non-final fragments emitted by the pipe as continuations of the previous frame" in {
+    val first = WebSocketFrame.Text("Hel", finalFragment = false, None)
+    val middle = WebSocketFrame.Text("lo, ", finalFragment = false, None)
+    val last = WebSocketFrame.Text("world!", finalFragment = true, None)
+    val separate = WebSocketFrame.text("Bye!")
+
+    val sent = sentFrames(List(serverClose))(drainThen(first, middle, last, separate))
+
+    sent shouldBe List(
+      first -> false,
+      middle -> true,
+      last -> true,
+      separate -> false,
+      serverClose -> false
+    )
+  }
+
+  it should "echo a server-initiated Close exactly once, without a duplicate close frame" in {
+    val message = WebSocketFrame.text("hello")
+
+    val sent = sentFrames(List(serverClose))(drainThen(message))
+
+    sent shouldBe List(message -> false, serverClose -> false)
+  }
+
+  it should "send a Close frame emitted by the pipe exactly once" in {
+    val userClose = WebSocketFrame.Close(4000, "user-initiated")
+
+    val sent = sentFrames(Nil)(drainThen(userClose))
+
+    sent shouldBe List(userClose -> false)
+  }
+
+  it should "not mark a Close frame following a non-final fragment as a continuation" in {
+    val fragment = WebSocketFrame.Text("partial", finalFragment = false, None)
+    val userClose = WebSocketFrame.Close(4000, "abort")
+
+    val sent = sentFrames(Nil)(drainThen(fragment, userClose))
+
+    sent shouldBe List(fragment -> false, userClose -> false)
+  }
+
+  it should "fall back to a default Close frame if neither the server nor the pipe provided one" in {
+    val message = WebSocketFrame.text("hello")
+
+    val sent = sentFrames(Nil)(drainThen(message))
+
+    sent shouldBe List(message -> false, WebSocketFrame.close -> false)
+  }
+}

--- a/effects/zio/src/main/scala/sttp/client4/impl/zio/ZioWebSockets.scala
+++ b/effects/zio/src/main/scala/sttp/client4/impl/zio/ZioWebSockets.scala
@@ -9,25 +9,43 @@ object ZioWebSockets {
       ws: WebSocket[ZIO[R, Throwable, *]],
       pipe: ZStream[R, Throwable, WebSocketFrame.Data[_]] => ZStream[R, Throwable, WebSocketFrame]
   ): ZIO[R, Throwable, Unit] =
-    Ref.make(true).flatMap { open =>
-      val onClose = ZStream.fromZIO(open.set(false).map(_ => None: Option[WebSocketFrame.Data[_]]))
-      pipe(
-        ZStream
-          .repeatZIO(ws.receive())
-          .flatMap {
-            case WebSocketFrame.Close(_, _)   => onClose
-            case WebSocketFrame.Ping(payload) =>
-              ZStream.fromZIO(ws.send(WebSocketFrame.Pong(payload))).flatMap(_ => ZStream.empty)
-            case WebSocketFrame.Pong(_)     => ZStream.empty
-            case in: WebSocketFrame.Data[_] => ZStream(Some(in))
+    for {
+      closeRef <- Ref.make(Option.empty[WebSocketFrame.Close])
+      closeSent <- Ref.make(false)
+      // set the close to echo (a received Close) or none (the connection is already gone), then terminate the stream
+      onClose = (close: Option[WebSocketFrame.Close]) =>
+        ZStream.fromZIO(closeRef.set(close).as(Option.empty[WebSocketFrame.Data[_]]))
+      _ <-
+        pipe(
+          ZStream
+            .repeatZIO(ws.receive())
+            .flatMap {
+              case WebSocketFrame.Close(code, reason) => onClose(Some(WebSocketFrame.Close(code, reason)))
+              case WebSocketFrame.Ping(payload)       =>
+                ZStream.fromZIO(ws.send(WebSocketFrame.Pong(payload))).flatMap(_ => ZStream.empty)
+              case WebSocketFrame.Pong(_)     => ZStream.empty
+              case in: WebSocketFrame.Data[_] => ZStream(Some(in))
+            }
+            .catchSome { case _: WebSocketClosed => onClose(None) }
+            .collectWhileSome
+        )
+          // end with matching Close or user-provided Close or no Close at all
+          .concat(ZStream.fromZIO(closeRef.get).collect { case Some(close) => close })
+          // a data frame following a non-final fragment is a continuation; a Close never is
+          .mapAccum(false) {
+            case (afterNonFinal, frame: WebSocketFrame.Data[_]) => (!frame.finalFragment, (frame, afterNonFinal))
+            case (afterNonFinal, frame)                         => (afterNonFinal, (frame, false))
           }
-          .catchSome { case _: WebSocketClosed => onClose }
-          .collectWhileSome
-      )
-        .mapZIO(ws.send(_))
-        .foreach(_ => ZIO.unit)
-        .ensuring(ws.close().catchAll(_ => ZIO.unit))
-    }
+          .mapZIO { case (frame, isContinuation) =>
+            ws.send(frame, isContinuation) *> (frame match {
+              case _: WebSocketFrame.Close => closeSent.set(true)
+              case _                       => ZIO.unit
+            })
+          }
+          .runDrain
+          // the stream already emits a Close when appropriate; only fall back to a default Close if none was sent
+          .ensuring(closeSent.get.flatMap(sent => if (sent) ZIO.unit else ws.close().catchAll(_ => ZIO.unit)))
+    } yield ()
 
   type PipeR[R, A, B] = ZStream[R, Throwable, A] => ZStream[R, Throwable, B]
 

--- a/effects/zio/src/test/scalajvm/sttp/client4/impl/zio/ZioWebSocketsTest.scala
+++ b/effects/zio/src/test/scalajvm/sttp/client4/impl/zio/ZioWebSocketsTest.scala
@@ -1,0 +1,98 @@
+package sttp.client4.impl.zio
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import sttp.model.Headers
+import sttp.monad.MonadError
+import sttp.ws.{WebSocket, WebSocketClosed, WebSocketFrame}
+import zio.stream.ZStream
+import zio.{Ref, Task, ZIO}
+
+class ZioWebSocketsTest extends AnyFlatSpec with Matchers with ZioTestBase {
+
+  behavior of "ZioWebSockets.compilePipe"
+
+  private val serverClose = WebSocketFrame.Close(1000, "normal")
+
+  /** Records all sent frames together with their `isContinuation` flag. `receive()` returns the given frames in order,
+    * then fails with [[WebSocketClosed]], as a real web socket would.
+    */
+  private class RecordingWebSocket(
+      incoming: Ref[List[WebSocketFrame]],
+      sent: Ref[List[(WebSocketFrame, Boolean)]]
+  ) extends WebSocket[Task] {
+    override def receive(): Task[WebSocketFrame] =
+      incoming.modify {
+        case head :: tail => (ZIO.succeed(head): Task[WebSocketFrame], tail)
+        case Nil          => (ZIO.fail(WebSocketClosed(None)): Task[WebSocketFrame], Nil)
+      }.flatten
+
+    override def send(frame: WebSocketFrame, isContinuation: Boolean): Task[Unit] =
+      sent.update(_ :+ (frame -> isContinuation))
+
+    override def isOpen(): Task[Boolean] = ZIO.succeed(true)
+    override lazy val upgradeHeaders: Headers = Headers(Nil)
+    override implicit def monad: MonadError[Task] = new RIOMonadAsyncError[Any]
+  }
+
+  private def sentFrames(incoming: List[WebSocketFrame])(
+      pipe: ZStream[Any, Throwable, WebSocketFrame.Data[_]] => ZStream[Any, Throwable, WebSocketFrame]
+  ): List[(WebSocketFrame, Boolean)] =
+    unsafeRunSyncOrThrow(for {
+      incomingRef <- Ref.make(incoming)
+      sentRef <- Ref.make(List.empty[(WebSocketFrame, Boolean)])
+      ws = new RecordingWebSocket(incomingRef, sentRef)
+      _ <- ZioWebSockets.compilePipe[Any](ws, pipe)
+      sent <- sentRef.get
+    } yield sent)
+
+  it should "mark non-final fragments emitted by the pipe as continuations of the previous frame" in {
+    val first = WebSocketFrame.Text("Hel", finalFragment = false, None)
+    val middle = WebSocketFrame.Text("lo, ", finalFragment = false, None)
+    val last = WebSocketFrame.Text("world!", finalFragment = true, None)
+    val separate = WebSocketFrame.text("Bye!")
+
+    val sent = sentFrames(List(serverClose))(in => in.drain ++ ZStream(first, middle, last, separate))
+
+    sent shouldBe List(
+      first -> false,
+      middle -> true,
+      last -> true,
+      separate -> false,
+      serverClose -> false
+    )
+  }
+
+  it should "echo a server-initiated Close exactly once, without a duplicate close frame" in {
+    val message = WebSocketFrame.text("hello")
+
+    val sent = sentFrames(List(serverClose))(in => in.drain ++ ZStream(message))
+
+    sent shouldBe List(message -> false, serverClose -> false)
+  }
+
+  it should "send a Close frame emitted by the pipe exactly once" in {
+    val userClose = WebSocketFrame.Close(4000, "user-initiated")
+
+    val sent = sentFrames(Nil)(in => in.drain ++ ZStream(userClose))
+
+    sent shouldBe List(userClose -> false)
+  }
+
+  it should "not mark a Close frame following a non-final fragment as a continuation" in {
+    val fragment = WebSocketFrame.Text("partial", finalFragment = false, None)
+    val userClose = WebSocketFrame.Close(4000, "abort")
+
+    val sent = sentFrames(Nil)(in => in.drain ++ ZStream(fragment, userClose))
+
+    sent shouldBe List(fragment -> false, userClose -> false)
+  }
+
+  it should "fall back to a default Close frame if neither the server nor the pipe provided one" in {
+    val message = WebSocketFrame.text("hello")
+
+    val sent = sentFrames(Nil)(in => in.drain ++ ZStream(message))
+
+    sent shouldBe List(message -> false, WebSocketFrame.close -> false)
+  }
+}

--- a/effects/zio1/src/main/scala/sttp/client4/impl/zio/ZioWebSockets.scala
+++ b/effects/zio1/src/main/scala/sttp/client4/impl/zio/ZioWebSockets.scala
@@ -9,25 +9,43 @@ object ZioWebSockets {
       ws: WebSocket[ZIO[R, Throwable, *]],
       pipe: ZStream[R, Throwable, WebSocketFrame.Data[_]] => ZStream[R, Throwable, WebSocketFrame]
   ): ZIO[R, Throwable, Unit] =
-    Ref.make(true).flatMap { open =>
-      val onClose = Stream.fromEffect(open.set(false).map(_ => None: Option[WebSocketFrame.Data[_]]))
-      pipe(
-        Stream
-          .repeatEffect(ws.receive())
-          .flatMap {
-            case WebSocketFrame.Close(_, _)   => onClose
-            case WebSocketFrame.Ping(payload) =>
-              Stream.fromEffect(ws.send(WebSocketFrame.Pong(payload))).flatMap(_ => Stream.empty)
-            case WebSocketFrame.Pong(_)     => Stream.empty
-            case in: WebSocketFrame.Data[_] => Stream(Some(in))
+    for {
+      closeRef <- Ref.make(Option.empty[WebSocketFrame.Close])
+      closeSent <- Ref.make(false)
+      // set the close to echo (a received Close) or none (the connection is already gone), then terminate the stream
+      onClose = (close: Option[WebSocketFrame.Close]) =>
+        Stream.fromEffect(closeRef.set(close).as(Option.empty[WebSocketFrame.Data[_]]))
+      _ <-
+        pipe(
+          Stream
+            .repeatEffect(ws.receive())
+            .flatMap {
+              case WebSocketFrame.Close(code, reason) => onClose(Some(WebSocketFrame.Close(code, reason)))
+              case WebSocketFrame.Ping(payload)       =>
+                Stream.fromEffect(ws.send(WebSocketFrame.Pong(payload))).flatMap(_ => Stream.empty)
+              case WebSocketFrame.Pong(_)     => Stream.empty
+              case in: WebSocketFrame.Data[_] => Stream(Some(in))
+            }
+            .catchSome { case _: WebSocketClosed => onClose(None) }
+            .collectWhileSome
+        )
+          // end with matching Close or user-provided Close or no Close at all
+          .concat(Stream.fromEffect(closeRef.get).collect { case Some(close) => close })
+          // a data frame following a non-final fragment is a continuation; a Close never is
+          .mapAccum(false) {
+            case (afterNonFinal, frame: WebSocketFrame.Data[_]) => (!frame.finalFragment, (frame, afterNonFinal))
+            case (afterNonFinal, frame)                         => (afterNonFinal, (frame, false))
           }
-          .catchSome { case _: WebSocketClosed => onClose }
-          .collectWhileSome
-      )
-        .mapM(ws.send(_))
-        .foreach(_ => ZIO.unit)
-        .ensuring(ws.close().catchAll(_ => ZIO.unit))
-    }
+          .mapM { case (frame, isContinuation) =>
+            ws.send(frame, isContinuation) *> (frame match {
+              case _: WebSocketFrame.Close => closeSent.set(true)
+              case _                       => ZIO.unit
+            })
+          }
+          .foreach(_ => ZIO.unit)
+          // the stream already emits a Close when appropriate; only fall back to a default Close if none was sent
+          .ensuring(closeSent.get.flatMap(sent => if (sent) ZIO.unit else ws.close().catchAll(_ => ZIO.unit)))
+    } yield ()
 
   type PipeR[R, A, B] = ZStream[R, Throwable, A] => ZStream[R, Throwable, B]
 

--- a/effects/zio1/src/test/scalajvm/sttp/client4/impl/zio/ZioWebSocketsTest.scala
+++ b/effects/zio1/src/test/scalajvm/sttp/client4/impl/zio/ZioWebSocketsTest.scala
@@ -1,0 +1,98 @@
+package sttp.client4.impl.zio
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import sttp.model.Headers
+import sttp.monad.MonadError
+import sttp.ws.{WebSocket, WebSocketClosed, WebSocketFrame}
+import zio.stream.ZStream
+import zio.{Ref, Task, ZIO}
+
+class ZioWebSocketsTest extends AnyFlatSpec with Matchers with ZioTestBase {
+
+  behavior of "ZioWebSockets.compilePipe"
+
+  private val serverClose = WebSocketFrame.Close(1000, "normal")
+
+  /** Records all sent frames together with their `isContinuation` flag. `receive()` returns the given frames in order,
+    * then fails with [[WebSocketClosed]], as a real web socket would.
+    */
+  private class RecordingWebSocket(
+      incoming: Ref[List[WebSocketFrame]],
+      sent: Ref[List[(WebSocketFrame, Boolean)]]
+  ) extends WebSocket[Task] {
+    override def receive(): Task[WebSocketFrame] =
+      incoming.modify {
+        case head :: tail => (ZIO.succeed(head): Task[WebSocketFrame], tail)
+        case Nil          => (ZIO.fail(WebSocketClosed(None)): Task[WebSocketFrame], Nil)
+      }.flatten
+
+    override def send(frame: WebSocketFrame, isContinuation: Boolean): Task[Unit] =
+      sent.update(_ :+ (frame -> isContinuation))
+
+    override def isOpen(): Task[Boolean] = ZIO.succeed(true)
+    override lazy val upgradeHeaders: Headers = Headers(Nil)
+    override implicit def monad: MonadError[Task] = new RIOMonadAsyncError[Any]
+  }
+
+  private def sentFrames(incoming: List[WebSocketFrame])(
+      pipe: ZStream[Any, Throwable, WebSocketFrame.Data[_]] => ZStream[Any, Throwable, WebSocketFrame]
+  ): List[(WebSocketFrame, Boolean)] =
+    runtime.unsafeRun(for {
+      incomingRef <- Ref.make(incoming)
+      sentRef <- Ref.make(List.empty[(WebSocketFrame, Boolean)])
+      ws = new RecordingWebSocket(incomingRef, sentRef)
+      _ <- ZioWebSockets.compilePipe[Any](ws, pipe)
+      sent <- sentRef.get
+    } yield sent)
+
+  it should "mark non-final fragments emitted by the pipe as continuations of the previous frame" in {
+    val first = WebSocketFrame.Text("Hel", finalFragment = false, None)
+    val middle = WebSocketFrame.Text("lo, ", finalFragment = false, None)
+    val last = WebSocketFrame.Text("world!", finalFragment = true, None)
+    val separate = WebSocketFrame.text("Bye!")
+
+    val sent = sentFrames(List(serverClose))(in => in.drain ++ ZStream(first, middle, last, separate))
+
+    sent shouldBe List(
+      first -> false,
+      middle -> true,
+      last -> true,
+      separate -> false,
+      serverClose -> false
+    )
+  }
+
+  it should "echo a server-initiated Close exactly once, without a duplicate close frame" in {
+    val message = WebSocketFrame.text("hello")
+
+    val sent = sentFrames(List(serverClose))(in => in.drain ++ ZStream(message))
+
+    sent shouldBe List(message -> false, serverClose -> false)
+  }
+
+  it should "send a Close frame emitted by the pipe exactly once" in {
+    val userClose = WebSocketFrame.Close(4000, "user-initiated")
+
+    val sent = sentFrames(Nil)(in => in.drain ++ ZStream(userClose))
+
+    sent shouldBe List(userClose -> false)
+  }
+
+  it should "not mark a Close frame following a non-final fragment as a continuation" in {
+    val fragment = WebSocketFrame.Text("partial", finalFragment = false, None)
+    val userClose = WebSocketFrame.Close(4000, "abort")
+
+    val sent = sentFrames(Nil)(in => in.drain ++ ZStream(fragment, userClose))
+
+    sent shouldBe List(fragment -> false, userClose -> false)
+  }
+
+  it should "fall back to a default Close frame if neither the server nor the pipe provided one" in {
+    val message = WebSocketFrame.text("hello")
+
+    val sent = sentFrames(Nil)(in => in.drain ++ ZStream(message))
+
+    sent shouldBe List(message -> false, WebSocketFrame.close -> false)
+  }
+}

--- a/examples-ce2/src/main/scala/sttp/client4/examples/GetAndParseJsonOrFailMonixCirce.scala
+++ b/examples-ce2/src/main/scala/sttp/client4/examples/GetAndParseJsonOrFailMonixCirce.scala
@@ -24,7 +24,7 @@ object GetAndParseJsonOrFailMonixCirce extends App {
   HttpClientMonixBackend
     .resource()
     .use { backend =>
-      request.send(backend).map { response: Response[HttpBinResponse] =>
+      request.send(backend).map { (response: Response[HttpBinResponse]) =>
         println(s"Got response code: ${response.code}")
         println(response.body)
       }


### PR DESCRIPTION
Updates `Fs2WebSocket.handleThroughPipe` to mark continuation frames. I think this was a regression introduced in [afd307744](https://github.com/softwaremill/sttp/commit/afd307744#diff-f6c63a5db0d17a07ce7182efc57b8ca6dec36126427c12ef06ac8da8ffc07e8bL43).

When writing tests, I encountered an issue with duplicate Close frames, so I fixed that as well.

---
Before submitting pull request:
- [X] Check if the project compiles by running `sbt compile`
- [X] Verify docs compilation by running `sbt compileDocs`
- [X] Check if tests pass by running `sbt test`
- [X] Format code by running `sbt scalafmt`
---
Closes #1465