### PR TITLE
Add support for RFC 10008 (QUERY HTTP method)

### DIFF
--- a/core/src/main/scala/sttp/client4/requestBuilder.scala
+++ b/core/src/main/scala/sttp/client4/requestBuilder.scala
@@ -72,6 +72,7 @@ trait PartialRequestBuilder[+PR <: PartialRequestBuilder[PR, R], +R]
   def delete(uri: Uri): R = method(Method.DELETE, uri)
   def options(uri: Uri): R = method(Method.OPTIONS, uri)
   def patch(uri: Uri): R = method(Method.PATCH, uri)
+  def query(uri: Uri): R = method(Method.QUERY, uri)
 
   def contentType(ct: String): PR = header(HeaderNames.ContentType, ct)
   def contentType(mt: MediaType): PR = header(HeaderNames.ContentType, mt.toString)

--- a/core/src/main/scala/sttp/client4/wrappers/FollowRedirectsBackend.scala
+++ b/core/src/main/scala/sttp/client4/wrappers/FollowRedirectsBackend.scala
@@ -112,11 +112,15 @@ abstract class FollowRedirectsBackend[F[_], P] private (
     )
 
   private def changePostPutToGet[T](r: GenericRequest[T, R], statusCode: StatusCode): GenericRequest[T, R] = {
-    val applicable = r.method == Method.POST || r.method == Method.PUT
+    val isPostPut = r.method == Method.POST || r.method == Method.PUT
+    val isQuery = r.method == Method.QUERY
     val alwaysChanged = statusCode == StatusCode.SeeOther
     val neverChanged = statusCode == StatusCode.TemporaryRedirect || statusCode == StatusCode.PermanentRedirect
-    if (applicable && (r.options.redirectToGet || alwaysChanged) && !neverChanged) {
-      // when transforming POST or PUT into a get, content is dropped, also filter out content-related request headers
+    val shouldRedirectToGet =
+      (isPostPut && (r.options.redirectToGet || alwaysChanged) && !neverChanged) ||
+        (isQuery && alwaysChanged)
+    if (shouldRedirectToGet) {
+      // when transforming POST, PUT or QUERY into a get, content is dropped, also filter out content-related request headers
       r.method(Method.GET, r.uri)
         .body(NoBody)
         .withHeaders(r.headers.filterNot(header => config.contentHeaders.contains(header.name.toLowerCase())))

--- a/core/src/test/scala/sttp/client4/ToCurlConverterTest.scala
+++ b/core/src/test/scala/sttp/client4/ToCurlConverterTest.scala
@@ -31,6 +31,7 @@ class ToCurlConverterTest extends AnyFlatSpec with Matchers with ToCurlConverter
     basicRequest.patch(localhost).toCurl should include("--request PATCH")
     basicRequest.head(localhost).toCurl should include("--request HEAD")
     basicRequest.options(localhost).toCurl should include("--request OPTIONS")
+    basicRequest.query(localhost).toCurl should include("--request QUERY")
   }
 
   it should "convert request with header" in {

--- a/core/src/test/scala/sttp/client4/ToRfc2616ConverterTest.scala
+++ b/core/src/test/scala/sttp/client4/ToRfc2616ConverterTest.scala
@@ -24,6 +24,7 @@ class ToRfc2616ConverterTest extends AnyFlatSpec with Matchers {
     basicRequest.patch(localhost).toRfc2616Format should startWith("PATCH")
     basicRequest.head(localhost).toRfc2616Format should startWith("HEAD")
     basicRequest.options(localhost).toRfc2616Format should startWith("OPTIONS")
+    basicRequest.query(localhost).toRfc2616Format should startWith("QUERY")
   }
 
   it should "convert request with sensitive query param" in {

--- a/core/src/test/scala/sttp/client4/testing/HttpTest.scala
+++ b/core/src/test/scala/sttp/client4/testing/HttpTest.scala
@@ -37,6 +37,7 @@ trait HttpTest[F[_]]
 
   protected def postEcho: Request[Either[String, String]] = basicRequest.post(uri"$endpoint/echo")
   protected def postEchoExact: Request[Either[String, String]] = basicRequest.post(uri"$endpoint/echo/exact")
+  protected def queryEcho: Request[Either[String, String]] = basicRequest.query(uri"$endpoint/echo")
   protected val testBody = "this is the body"
   protected val testBodyBytes: Array[Byte] = testBody.getBytes("UTF-8")
   protected val testBodySignedBytes: Array[Byte] = Array[Byte](-1)
@@ -60,6 +61,7 @@ trait HttpTest[F[_]]
   protected def supportsEmptyContentEncoding = true
   protected def supportsNonAsciiHeaderValues = true
   protected def supportsMaxResponseBodyLength = true
+  protected def supportsQuery = true
 
   "request parsing" - {
     "Inf timeout should not throw exception" in {
@@ -73,6 +75,14 @@ trait HttpTest[F[_]]
     "as string" in {
       postEcho.body(testBody).send(backend).toFuture().map { response =>
         response.body should be(Right(expectedPostEchoResponse))
+      }
+    }
+
+    if (supportsQuery) {
+      "as query" in {
+        queryEcho.body(testBody).send(backend).toFuture().map { response =>
+          response.body should be(Right(s"QUERY /echo $testBody"))
+        }
       }
     }
 

--- a/core/src/test/scalajvm/sttp/client4/HttpURLConnectionBackendHttpTest.scala
+++ b/core/src/test/scalajvm/sttp/client4/HttpURLConnectionBackendHttpTest.scala
@@ -24,6 +24,7 @@ class HttpURLConnectionBackendHttpTest extends HttpTest[Identity] {
   override def supportsHostHeaderOverride = false
   override def supportsCancellation = false
   override def supportsDeflateWrapperChecking = false
+  override def supportsQuery = false
 
   override def timeoutToNone[T](t: Identity[T], timeoutMillis: Int): Identity[Option[T]] = Some(t)
 }

--- a/core/src/test/scalajvm/sttp/client4/testing/HttpTestExtensions.scala
+++ b/core/src/test/scalajvm/sttp/client4/testing/HttpTestExtensions.scala
@@ -171,6 +171,33 @@ trait HttpTestExtensions[F[_]] extends AsyncFreeSpecLike { self: HttpTest[F] =>
           .map(resp => resp.body shouldBe expectedBody)
       }
 
+    if (supportsQuery) {
+      val redirectQueryTestData = List(
+        (301, false, "QUERYx"),
+        (302, false, "QUERYx"),
+        (303, false, "GET"),
+        (307, false, "QUERYx"),
+        (308, false, "QUERYx"),
+        (301, true, "QUERYx"),
+        (302, true, "QUERYx"),
+        (303, true, "GET"),
+        (307, true, "QUERYx"),
+        (308, true, "QUERYx")
+      )
+
+      for ((statusCode, redirectToGet, expectedBody) <- redirectQueryTestData)
+        yield s"for $statusCode redirect of QUERY, with redirect post to get = $redirectToGet, should return body $expectedBody" in {
+          basicRequest
+            .redirectToGet(redirectToGet)
+            .body("x")
+            .query(uri"$endpoint/redirect/get_after_query/r$statusCode")
+            .response(asStringAlways)
+            .send(backend)
+            .toFuture()
+            .map(resp => resp.body shouldBe expectedBody)
+        }
+    }
+
     "strip sensitive headers" - {
       val testData = List(
         Header(HeaderNames.Authorization, "secret"),

--- a/testing/server/src/main/scala/sttp/client4/testing/server/HttpServer.scala
+++ b/testing/server/src/main/scala/sttp/client4/testing/server/HttpServer.scala
@@ -54,6 +54,13 @@ private class HttpServer(port: Int, info: String => Unit) extends AutoCloseable 
   private val textWithSpecialCharacters = "Żółć!"
   private val retryTestCache = new ConcurrentHashMap[String, Int]()
 
+  private val QUERY = HttpMethod.custom(
+    name = "QUERY",
+    safe = true,
+    idempotent = true,
+    requestEntityAcceptance = RequestEntityAcceptance.Expected
+  )
+
   private val serverRoutes: Route =
     pathPrefix("echo") {
       pathPrefix("form_params") {
@@ -112,6 +119,16 @@ private class HttpServer(port: Int, info: String => Unit) extends AutoCloseable 
             entity(as[String]) { (body: String) =>
               complete(
                 List("PUT", "/echo", paramsToString(params), body)
+                  .filter(_.nonEmpty)
+                  .mkString(" ")
+              )
+            }
+          }
+        } ~ method(QUERY) {
+          parameterMap { params =>
+            entity(as[String]) { (body: String) =>
+              complete(
+                List("QUERY", "/echo", paramsToString(params), body)
                   .filter(_.nonEmpty)
                   .mkString(" ")
               )
@@ -413,6 +430,21 @@ private class HttpServer(port: Int, info: String => Unit) extends AutoCloseable 
             get(complete(s"GET")) ~
               entity(as[String])((body: String) => post(complete(s"POST$body")))
           }
+        } ~ pathPrefix("get_after_query") {
+          path("r301") {
+            discardEntity(redirect("/redirect/get_after_query/result", StatusCodes.MovedPermanently))
+          } ~ path("r302") {
+            discardEntity(redirect("/redirect/get_after_query/result", StatusCodes.Found))
+          } ~ path("r303") {
+            discardEntity(redirect("/redirect/get_after_query/result", StatusCodes.SeeOther))
+          } ~ path("r307") {
+            discardEntity(redirect("/redirect/get_after_query/result", StatusCodes.TemporaryRedirect))
+          } ~ path("r308") {
+            discardEntity(redirect("/redirect/get_after_query/result", StatusCodes.PermanentRedirect))
+          } ~ path("result") {
+            get(complete(s"GET")) ~
+              entity(as[String])((body: String) => method(QUERY)(complete(s"QUERY$body")))
+          }
         } ~ pathPrefix("strip_sensitive_headers") {
           path("r1") {
             discardEntity(redirect("/redirect/strip_sensitive_headers/result", StatusCodes.PermanentRedirect))
@@ -554,7 +586,10 @@ private class HttpServer(port: Int, info: String => Unit) extends AutoCloseable 
 
   def start(): Future[Http.ServerBinding] =
     unbindServer().flatMap { _ =>
-      val server = Http().bindAndHandle(corsServerRoutes, "localhost", port)
+      import akka.http.scaladsl.settings.{ParserSettings, ServerSettings}
+      val parserSettings = ParserSettings.forServer(actorSystem).withCustomMethods(QUERY)
+      val serverSettings = ServerSettings(actorSystem).withParserSettings(parserSettings)
+      val server = Http().bindAndHandle(corsServerRoutes, "localhost", port, settings = serverSettings)
       this.server = Some(server)
       server
     }


### PR DESCRIPTION
This change introduces support for RFC 1008, The HTTP QUERY Method. This is a follow-up of https://github.com/softwaremill/sttp-model/pull/465

Before submitting pull request:
- [x] Check if the project compiles by running `sbt compile`
- [x] Verify docs compilation by running `sbt compileDocs`
- [x] Check if tests pass by running `sbt test`
- [x] Format code by running `sbt scalafmt`
