### PR TITLE
feat: add closeFactory/closeClient parameter to usingClient/usingDefaultClient

### DIFF
--- a/armeria-backend/cats-ce2/src/main/scala/sttp/client4/armeria/cats/ArmeriaCatsBackend.scala
+++ b/armeria-backend/cats-ce2/src/main/scala/sttp/client4/armeria/cats/ArmeriaCatsBackend.scala
@@ -57,11 +57,11 @@ object ArmeriaCatsBackend {
   def resourceUsingClient[F[_]: Concurrent](client: WebClient): Resource[F, Backend[F]] =
     Resource.make(Sync[F].delay(apply(client, closeFactory = true)))(_.close())
 
-  def usingDefaultClient[F[_]: Concurrent](): Backend[F] =
-    apply(newClient(), closeFactory = false)
+  def usingDefaultClient[F[_]: Concurrent](closeFactory: Boolean = false): Backend[F] =
+    apply(newClient(), closeFactory = closeFactory)
 
-  def usingClient[F[_]: Concurrent](client: WebClient): Backend[F] =
-    apply(client, closeFactory = false)
+  def usingClient[F[_]: Concurrent](client: WebClient, closeFactory: Boolean = false): Backend[F] =
+    apply(client, closeFactory = closeFactory)
 
   private def apply[F[_]: Concurrent](
       client: WebClient,

--- a/armeria-backend/cats/src/main/scala/sttp/client4/armeria/cats/ArmeriaCatsBackend.scala
+++ b/armeria-backend/cats/src/main/scala/sttp/client4/armeria/cats/ArmeriaCatsBackend.scala
@@ -56,11 +56,11 @@ object ArmeriaCatsBackend {
   def resourceUsingClient[F[_]: Async](client: WebClient): Resource[F, Backend[F]] =
     Resource.make(Sync[F].delay(apply(client, closeFactory = true)))(_.close())
 
-  def usingDefaultClient[F[_]: Async](): Backend[F] =
-    apply(newClient(), closeFactory = false)
+  def usingDefaultClient[F[_]: Async](closeFactory: Boolean = false): Backend[F] =
+    apply(newClient(), closeFactory = closeFactory)
 
-  def usingClient[F[_]: Async](client: WebClient): Backend[F] =
-    apply(client, closeFactory = false)
+  def usingClient[F[_]: Async](client: WebClient, closeFactory: Boolean = false): Backend[F] =
+    apply(client, closeFactory = closeFactory)
 
   private def apply[F[_]: Async](
       client: WebClient,

--- a/armeria-backend/fs2-ce2/src/main/scala/sttp/client4/armeria/fs2/ArmeriaFs2Backend.scala
+++ b/armeria-backend/fs2-ce2/src/main/scala/sttp/client4/armeria/fs2/ArmeriaFs2Backend.scala
@@ -63,11 +63,11 @@ object ArmeriaFs2Backend {
   def resourceUsingClient[F[_]: ConcurrentEffect](client: WebClient): Resource[F, StreamBackend[F, Fs2Streams[F]]] =
     Resource.make(Sync[F].delay(apply(client, closeFactory = true)))(_.close())
 
-  def usingClient[F[_]: ConcurrentEffect](client: WebClient): StreamBackend[F, Fs2Streams[F]] =
-    apply(client, closeFactory = false)
+  def usingClient[F[_]: ConcurrentEffect](client: WebClient, closeFactory: Boolean = false): StreamBackend[F, Fs2Streams[F]] =
+    apply(client, closeFactory = closeFactory)
 
-  def usingDefaultClient[F[_]: ConcurrentEffect](): StreamBackend[F, Fs2Streams[F]] =
-    apply(newClient(), closeFactory = false)
+  def usingDefaultClient[F[_]: ConcurrentEffect](closeFactory: Boolean = false): StreamBackend[F, Fs2Streams[F]] =
+    apply(newClient(), closeFactory = closeFactory)
 
   private def apply[F[_]: ConcurrentEffect](
       client: WebClient,

--- a/armeria-backend/fs2/src/main/scala/sttp/client4/armeria/fs2/ArmeriaFs2Backend.scala
+++ b/armeria-backend/fs2/src/main/scala/sttp/client4/armeria/fs2/ArmeriaFs2Backend.scala
@@ -80,11 +80,11 @@ object ArmeriaFs2Backend {
       .parallel[F]
       .flatMap(dispatcher => Resource.make(Sync[F].delay(apply(client, closeFactory = true, dispatcher)))(_.close()))
 
-  def usingClient[F[_]: Async](client: WebClient, dispatcher: Dispatcher[F]): StreamBackend[F, Fs2Streams[F]] =
-    apply(client, closeFactory = false, dispatcher)
+  def usingClient[F[_]: Async](client: WebClient, dispatcher: Dispatcher[F], closeFactory: Boolean = false): StreamBackend[F, Fs2Streams[F]] =
+    apply(client, closeFactory = closeFactory, dispatcher)
 
-  def usingDefaultClient[F[_]: Async](dispatcher: Dispatcher[F]): StreamBackend[F, Fs2Streams[F]] =
-    apply(newClient(), closeFactory = false, dispatcher)
+  def usingDefaultClient[F[_]: Async](dispatcher: Dispatcher[F], closeFactory: Boolean = false): StreamBackend[F, Fs2Streams[F]] =
+    apply(newClient(), closeFactory = closeFactory, dispatcher)
 
   private def apply[F[_]: Async](
       client: WebClient,

--- a/armeria-backend/monix/src/main/scala/sttp/client4/armeria/monix/ArmeriaMonixBackend.scala
+++ b/armeria-backend/monix/src/main/scala/sttp/client4/armeria/monix/ArmeriaMonixBackend.scala
@@ -55,16 +55,16 @@ object ArmeriaMonixBackend {
     apply(newClient(options), closeFactory = true)
 
   /** @param scheduler The scheduler used for streaming request bodies. Defaults to the global scheduler. */
-  def usingClient(client: WebClient)(implicit
+  def usingClient(client: WebClient, closeFactory: Boolean = false)(implicit
       scheduler: Scheduler = Scheduler.global
   ): StreamBackend[Task, MonixStreams] =
-    apply(client, closeFactory = false)
+    apply(client, closeFactory = closeFactory)
 
   /** @param scheduler The scheduler used for streaming request bodies. Defaults to the global scheduler. */
-  def usingDefaultClient()(implicit
+  def usingDefaultClient(closeFactory: Boolean = false)(implicit
       scheduler: Scheduler = Scheduler.global
   ): StreamBackend[Task, MonixStreams] =
-    apply(newClient(), closeFactory = false)
+    apply(newClient(), closeFactory = closeFactory)
 
   private def apply(client: WebClient, closeFactory: Boolean)(implicit
       scheduler: Scheduler

--- a/armeria-backend/scalaz/src/main/scala/sttp/client4/armeria/scalaz/ArmeriaScalazBackend.scala
+++ b/armeria-backend/scalaz/src/main/scala/sttp/client4/armeria/scalaz/ArmeriaScalazBackend.scala
@@ -47,9 +47,9 @@ object ArmeriaScalazBackend {
   def apply(options: BackendOptions = BackendOptions.Default): Backend[Task] =
     apply(newClient(options), closeFactory = true)
 
-  def usingClient(client: WebClient): Backend[Task] = apply(client, closeFactory = false)
+  def usingClient(client: WebClient, closeFactory: Boolean = false): Backend[Task] = apply(client, closeFactory = closeFactory)
 
-  def usingDefaultClient(): Backend[Task] = apply(newClient(), closeFactory = false)
+  def usingDefaultClient(closeFactory: Boolean = false): Backend[Task] = apply(newClient(), closeFactory = closeFactory)
 
   private def apply(
       client: WebClient,

--- a/armeria-backend/src/main/scala/sttp/client4/armeria/future/ArmeriaFutureBackend.scala
+++ b/armeria-backend/src/main/scala/sttp/client4/armeria/future/ArmeriaFutureBackend.scala
@@ -48,11 +48,11 @@ object ArmeriaFutureBackend {
   def apply(options: BackendOptions = BackendOptions.Default): Backend[Future] =
     apply(newClient(options), closeFactory = true)
 
-  def usingClient(client: WebClient): Backend[Future] =
-    apply(client, closeFactory = false)
+  def usingClient(client: WebClient, closeFactory: Boolean = false): Backend[Future] =
+    apply(client, closeFactory = closeFactory)
 
-  def usingDefaultClient(): Backend[Future] =
-    apply(newClient(), closeFactory = false)
+  def usingDefaultClient(closeFactory: Boolean = false): Backend[Future] =
+    apply(newClient(), closeFactory = closeFactory)
 
   private def apply(client: WebClient, closeFactory: Boolean): Backend[Future] =
     FollowRedirectsBackend(new ArmeriaFutureBackend(client, closeFactory))

--- a/armeria-backend/zio/src/main/scala/sttp/client4/armeria/zio/ArmeriaZioBackend.scala
+++ b/armeria-backend/zio/src/main/scala/sttp/client4/armeria/zio/ArmeriaZioBackend.scala
@@ -77,18 +77,18 @@ object ArmeriaZioBackend {
   def layer(options: BackendOptions = BackendOptions.Default): Layer[Throwable, SttpClient] =
     ZLayer.scoped(scoped(options))
 
-  def usingClient(client: WebClient): Task[StreamBackend[Task, ZioStreams]] =
+  def usingClient(client: WebClient, closeFactory: Boolean = false): Task[StreamBackend[Task, ZioStreams]] =
     ZIO
       .runtime[Any]
-      .map(runtime => apply(runtime, client, closeFactory = false))
+      .map(runtime => apply(runtime, client, closeFactory = closeFactory))
 
-  def usingClient[R](runtime: Runtime[R], client: WebClient): StreamBackend[Task, ZioStreams] =
-    apply(runtime, client, closeFactory = false)
+  def usingClient[R](runtime: Runtime[R], client: WebClient, closeFactory: Boolean = false): StreamBackend[Task, ZioStreams] =
+    apply(runtime, client, closeFactory = closeFactory)
 
-  def usingDefaultClient(): Task[StreamBackend[Task, ZioStreams]] =
+  def usingDefaultClient(closeFactory: Boolean = false): Task[StreamBackend[Task, ZioStreams]] =
     ZIO
       .runtime[Any]
-      .map(runtime => apply(runtime, newClient(), closeFactory = false))
+      .map(runtime => apply(runtime, newClient(), closeFactory = closeFactory))
 
   private def apply[R](runtime: Runtime[R], client: WebClient, closeFactory: Boolean): StreamBackend[Task, ZioStreams] =
     wrappers.FollowRedirectsBackend(new ArmeriaZioBackend(runtime, client, closeFactory))

--- a/armeria-backend/zio1/src/main/scala/sttp/client4/armeria/zio/ArmeriaZioBackend.scala
+++ b/armeria-backend/zio1/src/main/scala/sttp/client4/armeria/zio/ArmeriaZioBackend.scala
@@ -61,18 +61,18 @@ object ArmeriaZioBackend {
   def layer(options: BackendOptions = BackendOptions.Default): Layer[Throwable, SttpClient] =
     ZLayer.fromManaged(managed(options))
 
-  def usingClient(client: WebClient): Task[StreamBackend[Task, ZioStreams]] =
+  def usingClient(client: WebClient, closeFactory: Boolean = false): Task[StreamBackend[Task, ZioStreams]] =
     ZIO
       .runtime[Any]
-      .map(runtime => apply(runtime, client, closeFactory = false))
+      .map(runtime => apply(runtime, client, closeFactory = closeFactory))
 
-  def usingClient[R](runtime: Runtime[R], client: WebClient): StreamBackend[Task, ZioStreams] =
-    apply(runtime, client, closeFactory = false)
+  def usingClient[R](runtime: Runtime[R], client: WebClient, closeFactory: Boolean = false): StreamBackend[Task, ZioStreams] =
+    apply(runtime, client, closeFactory = closeFactory)
 
-  def usingDefaultClient(): Task[StreamBackend[Task, ZioStreams]] =
+  def usingDefaultClient(closeFactory: Boolean = false): Task[StreamBackend[Task, ZioStreams]] =
     ZIO
       .runtime[Any]
-      .map(runtime => apply(runtime, newClient(), closeFactory = false))
+      .map(runtime => apply(runtime, newClient(), closeFactory = closeFactory))
 
   private def apply[R](runtime: Runtime[R], client: WebClient, closeFactory: Boolean): StreamBackend[Task, ZioStreams] =
     wrappers.FollowRedirectsBackend(new ArmeriaZioBackend(runtime, client, closeFactory))

--- a/okhttp-backend/src/main/scala/sttp/client4/okhttp/OkHttpFutureBackend.scala
+++ b/okhttp-backend/src/main/scala/sttp/client4/okhttp/OkHttpFutureBackend.scala
@@ -80,9 +80,10 @@ object OkHttpFutureBackend {
   def usingClient(
       client: OkHttpClient,
       compressionHandlers: CompressionHandlers[Any, InputStream] = DefaultCompressionHandlers,
-      webSocketBufferCapacity: Option[Int] = OkHttpBackend.DefaultWebSocketBufferCapacity
+      webSocketBufferCapacity: Option[Int] = OkHttpBackend.DefaultWebSocketBufferCapacity,
+      closeClient: Boolean = false
   )(implicit ec: ExecutionContext = ExecutionContext.global): WebSocketBackend[Future] =
-    OkHttpFutureBackend(client, closeClient = false, compressionHandlers, webSocketBufferCapacity)
+    OkHttpFutureBackend(client, closeClient = closeClient, compressionHandlers, webSocketBufferCapacity)
 
   /** Create a stub backend for testing, which uses the [[Future]] response wrapper, and doesn't support streaming.
     *

--- a/okhttp-backend/src/main/scala/sttp/client4/okhttp/OkHttpSyncBackend.scala
+++ b/okhttp-backend/src/main/scala/sttp/client4/okhttp/OkHttpSyncBackend.scala
@@ -128,9 +128,10 @@ object OkHttpSyncBackend {
   def usingClient(
       client: OkHttpClient,
       compressionHandlers: CompressionHandlers[Any, InputStream] = DefaultCompressionHandlers,
-      webSocketBufferCapacity: Option[Int] = OkHttpBackend.DefaultWebSocketBufferCapacity
+      webSocketBufferCapacity: Option[Int] = OkHttpBackend.DefaultWebSocketBufferCapacity,
+      closeClient: Boolean = false
   ): WebSocketSyncBackend =
-    OkHttpSyncBackend(client, closeClient = false, compressionHandlers, webSocketBufferCapacity)
+    OkHttpSyncBackend(client, closeClient = closeClient, compressionHandlers, webSocketBufferCapacity)
 
   /** Create a stub backend for testing, which uses the [[Identity]] response wrapper, and doesn't support streaming.
     *


### PR DESCRIPTION
## Summary

Adds an optional `closeFactory`/`closeClient: Boolean = false` parameter to all public `usingClient` and `usingDefaultClient` factory methods across Armeria (9 backends) and OkHttp (2 backends).

## Motivation

The `usingClient` and `usingDefaultClient` methods hardcoded `closeFactory` to `false`, giving users no way to have the backend close a user-provided client on `backend.close()`. This was reported in [#2628](https://github.com/softwaremill/sttp/issues/2628).

## Changes

**Armeria backends (9 files):**
- `ArmeriaCatsBackend` (CE3 + CE2): added `closeFactory: Boolean = false` to `usingClient`, `usingDefaultClient`
- `ArmeriaFutureBackend`: same
- `ArmeriaFs2Backend` (CE3 + CE2): same
- `ArmeriaZioBackend` (ZIO 2 + ZIO 1): same (including `usingClient` with runtime overload)
- `ArmeriaMonixBackend`: same
- `ArmeriaScalazBackend`: same

**OkHttp backends (2 files):**
- `OkHttpSyncBackend`: added `closeClient: Boolean = false` to `usingClient`
- `OkHttpFutureBackend`: same

## Backward Compatibility

All changes use default parameter values (`false`), so existing code continues to work without modification. MiMa is currently disabled for these subprojects.

## Testing

- Existing tests pass (default behavior unchanged)
- New parameter allows users to control client lifecycle

Closes #2628
